### PR TITLE
feat: добавить карточку пользователя в админке

### DIFF
--- a/app/api/admin/feedback/route.ts
+++ b/app/api/admin/feedback/route.ts
@@ -1,0 +1,15 @@
+export const dynamic = 'force-dynamic'
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { getAdminFeedback } from '@/lib/admin-users'
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const feedback = await getAdminFeedback()
+  return NextResponse.json({ success: true, data: feedback })
+}

--- a/app/api/admin/signup-books/route.ts
+++ b/app/api/admin/signup-books/route.ts
@@ -1,0 +1,41 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { bookPriorities } from '@/lib/db/schema'
+import { removeBookFromSignup } from '@/lib/signup-books'
+import { and, eq, gt, sql } from 'drizzle-orm'
+
+export async function DELETE(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { userId, bookName } = await req.json() as { userId?: string; bookName?: string }
+  if (!userId || !bookName) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+  }
+
+  const [existing] = await db
+    .select({ rank: bookPriorities.rank })
+    .from(bookPriorities)
+    .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookName, bookName)))
+    .limit(1)
+
+  await removeBookFromSignup(userId, bookName)
+
+  if (existing) {
+    await db
+      .delete(bookPriorities)
+      .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookName, bookName)))
+
+    await db
+      .update(bookPriorities)
+      .set({ rank: sql`${bookPriorities.rank} - 1` })
+      .where(and(eq(bookPriorities.userId, userId), gt(bookPriorities.rank, existing.rank)))
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,19 @@
+export const dynamic = 'force-dynamic'
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { getAdminUserDetails } from '@/lib/admin-users'
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const data = await getAdminUserDetails(decodeURIComponent(params.id))
+  if (!data) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json({ success: true, data })
+}

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,15 @@
+export const dynamic = 'force-dynamic'
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { getAdminUserSummaries } from '@/lib/admin-users'
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const users = await getAdminUserSummaries()
+  return NextResponse.json({ success: true, data: users })
+}

--- a/app/api/test/feedback/route.ts
+++ b/app/api/test/feedback/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { db } from '@/lib/db'
+import { feedback } from '@/lib/db/schema'
+import { inArray } from 'drizzle-orm'
+
+function notAllowed() {
+  return NextResponse.json({ error: 'Not allowed' }, { status: 403 })
+}
+
+export async function POST(req: NextRequest) {
+  if (process.env.NEXTAUTH_TEST_MODE !== 'true') return notAllowed()
+
+  const body = await req.json() as { userId?: string | null; name?: string; email?: string; message: string }
+  const [row] = await db.insert(feedback).values({
+    userId: body.userId ?? null,
+    name: body.name ?? null,
+    email: body.email ?? null,
+    message: body.message,
+  }).returning({ id: feedback.id })
+
+  return NextResponse.json({ ok: true, id: row.id })
+}
+
+export async function DELETE(req: NextRequest) {
+  if (process.env.NEXTAUTH_TEST_MODE !== 'true') return notAllowed()
+
+  const { ids } = await req.json() as { ids?: string[] }
+  if (!ids?.length) return NextResponse.json({ ok: true })
+  await db.delete(feedback).where(inArray(feedback.id, ids))
+  return NextResponse.json({ ok: true })
+}

--- a/components/nd/AdminPanel.tsx
+++ b/components/nd/AdminPanel.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect, Fragment } from 'react'
 import { useRouter } from 'next/navigation'
 import type { UserSignup } from '@/lib/signup-books'
 import type { BookWithCover } from '@/lib/books-with-covers'
+import type { AdminFeedbackItem, AdminUserDetails, AdminUserSummary } from '@/lib/admin-users'
 import Header from './Header'
 import IntroEditor from './IntroEditor'
+import AdminUserDrawer from './AdminUserDrawer'
 
 interface Submission {
   id: string
@@ -43,8 +45,10 @@ interface Props {
   prioritiesSetMap: Record<string, boolean>
 }
 
-type View = 'users' | 'books' | 'tags' | 'submissions' | 'intro'
+type View = 'users' | 'books' | 'tags' | 'submissions' | 'feedback' | 'intro'
 type SubmissionFilter = 'all' | 'pending' | 'approved' | 'rejected'
+type FeedbackFilter = 'all' | 'registered' | 'anonymous'
+type UserSortKey = 'name' | 'telegram' | 'email' | 'books' | 'languages'
 
 const cell: React.CSSProperties = {
   fontFamily: 'var(--nd-sans), system-ui, sans-serif',
@@ -97,13 +101,16 @@ export default function AdminPanel({
   allTags,
   tagDescriptions: initialTagDescriptions,
   newFlags: initialNewFlags,
-  userLanguages = {},
   bookPrioritiesMap,
-  prioritiesSetMap,
 }: Props) {
   const router = useRouter()
-  const [localUsers, setLocalUsers] = useState<UserSignup[]>(users)
-  const [localPrioritiesMap, setLocalPrioritiesMap] = useState<Record<string, { bookName: string; rank: number }[]>>(bookPrioritiesMap)
+  const [adminUsers, setAdminUsers] = useState<AdminUserSummary[]>([])
+  const [adminUsersLoaded, setAdminUsersLoaded] = useState(false)
+  const [userSearch, setUserSearch] = useState('')
+  const [userSort, setUserSort] = useState<{ key: UserSortKey; dir: 'asc' | 'desc' }>({ key: 'name', dir: 'asc' })
+  const [selectedAdminUserId, setSelectedAdminUserId] = useState<string | null>(null)
+  const [selectedAdminUser, setSelectedAdminUser] = useState<AdminUserDetails | null>(null)
+  const [userDrawerLoading, setUserDrawerLoading] = useState(false)
   const [view, setView] = useState<View>('users')
   const [syncing, setSyncing] = useState(false)
   const [syncMsg, setSyncMsg] = useState('')
@@ -127,14 +134,54 @@ export default function AdminPanel({
   const [submissionEdits, setSubmissionEdits] = useState<Record<string, Partial<Submission>>>({})
   const [submissionActionLoading, setSubmissionActionLoading] = useState<string | null>(null)
   const [submissionDeleteConfirm, setSubmissionDeleteConfirm] = useState<string | null>(null)
+  const [feedbackItems, setFeedbackItems] = useState<AdminFeedbackItem[]>([])
+  const [feedbackLoaded, setFeedbackLoaded] = useState(false)
+  const [feedbackFilter, setFeedbackFilter] = useState<FeedbackFilter>('all')
+  const [feedbackSearch, setFeedbackSearch] = useState('')
 
   useEffect(() => {
     fetch('/api/admin/submissions')
       .then(r => r.json())
-      .then(d => { if (d.success) setSubmissions(d.data) })
+      .then(d => { if (d.success && Array.isArray(d.data)) setSubmissions(d.data) })
       .catch(() => {})
       .finally(() => setSubmissionsLoaded(true))
   }, [])
+
+  useEffect(() => {
+    fetch('/api/admin/users')
+      .then(r => r.json())
+      .then(d => { if (d.success && Array.isArray(d.data)) setAdminUsers(d.data) })
+      .catch(() => {})
+      .finally(() => setAdminUsersLoaded(true))
+  }, [])
+
+  useEffect(() => {
+    if (view !== 'feedback' || feedbackLoaded) return
+    fetch('/api/admin/feedback')
+      .then(r => r.json())
+      .then(d => { if (d.success && Array.isArray(d.data)) setFeedbackItems(d.data) })
+      .catch(() => {})
+      .finally(() => setFeedbackLoaded(true))
+  }, [view, feedbackLoaded])
+
+  async function openUserDrawer(userId: string) {
+    setSelectedAdminUserId(userId)
+    setSelectedAdminUser(null)
+    setUserDrawerLoading(true)
+    try {
+      const res = await fetch(`/api/admin/users/${encodeURIComponent(userId)}`)
+      if (!res.ok) return
+      const d = await res.json()
+      if (d.success) setSelectedAdminUser(d.data)
+    } finally {
+      setUserDrawerLoading(false)
+    }
+  }
+
+  function closeUserDrawer() {
+    setSelectedAdminUserId(null)
+    setSelectedAdminUser(null)
+  }
 
   async function handleDeleteUser(userId: string, userName: string) {
     if (!window.confirm(`Удалить пользователя ${userName}? Это действие необратимо.`)) return
@@ -145,7 +192,8 @@ export default function AdminPanel({
         body: JSON.stringify({ userId }),
       })
       if (!res.ok) return
-      setLocalUsers(prev => prev.filter(u => u.userId !== userId))
+      setAdminUsers(prev => prev.filter(u => u.id !== userId))
+      if (selectedAdminUserId === userId) closeUserDrawer()
     } catch {
       // silently ignore
     }
@@ -154,23 +202,21 @@ export default function AdminPanel({
   async function handleRemoveBook(userId: string, bookName: string, userName: string) {
     if (!window.confirm(`Снять ${userName} с книги «${bookName}»?`)) return
     try {
-      const res = await fetch('/api/admin/remove-book', {
+      const res = await fetch('/api/admin/signup-books', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userId, bookName }),
       })
       if (!res.ok) return
-      setLocalUsers(prev =>
-        prev.map(u => u.userId === userId ? { ...u, selectedBooks: u.selectedBooks.filter(b => b !== bookName) } : u)
-      )
-      setLocalPrioritiesMap(prev => {
-        const books = prev[userId] ?? []
-        const removed = books.find(b => b.bookName === bookName)
-        if (!removed) return prev
-        const updated = books
-          .filter(b => b.bookName !== bookName)
-          .map(b => b.rank > removed.rank ? { ...b, rank: b.rank - 1 } : b)
-        return { ...prev, [userId]: updated }
+      setAdminUsers(prev => prev.map(u => u.id === userId ? { ...u, booksCount: Math.max(0, u.booksCount - 1) } : u))
+      setSelectedAdminUser(prev => {
+        if (!prev || prev.user.id !== userId) return prev
+        return {
+          ...prev,
+          user: { ...prev.user, booksCount: Math.max(0, prev.user.booksCount - 1) },
+          signupBooks: prev.signupBooks.filter(b => b.bookName !== bookName),
+          priorities: prev.priorities.filter(p => p.bookName !== bookName),
+        }
       })
     } catch {
       // silently ignore
@@ -360,6 +406,43 @@ export default function AdminPanel({
     ? submissions
     : submissions.filter(s => s.status === submissionFilter)
 
+  const filteredAdminUsers = adminUsers
+    .filter(u => {
+      const q = userSearch.trim().toLowerCase()
+      if (!q) return true
+      return `${u.name} ${u.email}`.toLowerCase().includes(q)
+    })
+    .sort((a, b) => {
+      const dir = userSort.dir === 'asc' ? 1 : -1
+      const value = (u: AdminUserSummary) => {
+        if (userSort.key === 'books') return u.booksCount
+        if (userSort.key === 'languages') return u.languages.join(', ')
+        if (userSort.key === 'telegram') return u.telegramUsername ?? u.contacts ?? ''
+        return u[userSort.key] ?? ''
+      }
+      const av = value(a)
+      const bv = value(b)
+      if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * dir
+      return String(av).localeCompare(String(bv), 'ru') * dir
+    })
+
+  const feedbackCounts = {
+    all: feedbackItems.length,
+    registered: feedbackItems.filter(f => f.userId).length,
+    anonymous: feedbackItems.filter(f => !f.userId).length,
+  }
+  const filteredFeedback = feedbackItems.filter(item => {
+    if (feedbackFilter === 'registered' && !item.userId) return false
+    if (feedbackFilter === 'anonymous' && item.userId) return false
+    const q = feedbackSearch.trim().toLowerCase()
+    if (!q) return true
+    return `${item.message} ${item.userName ?? item.name ?? ''} ${item.userEmail ?? item.email ?? ''}`.toLowerCase().includes(q)
+  })
+
+  function setSort(key: UserSortKey) {
+    setUserSort(prev => prev.key === key ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' })
+  }
+
   const submissionStatusLabel: Record<string, string> = { pending: 'На рассмотрении', approved: 'Одобрена', rejected: 'Отклонена' }
   const submissionStatusColor: Record<string, string> = { pending: '#C0603A', approved: '#2E7D32', rejected: '#999' }
 
@@ -404,7 +487,7 @@ export default function AdminPanel({
         {/* Tabs */}
         <div style={{ borderBottom: '1px solid #E5E5E5', marginBottom: '1.5rem' }}>
           <button style={tabStyle(view === 'users')} onClick={() => setView('users')}>
-            Участники ({localUsers.length})
+            Участники ({adminUsersLoaded ? adminUsers.length : users.length})
           </button>
           <button style={tabStyle(view === 'books')} onClick={() => setView('books')}>
             По книгам ({byBook.length})
@@ -414,6 +497,9 @@ export default function AdminPanel({
           </button>
           <button style={tabStyle(view === 'submissions')} onClick={() => setView('submissions')}>
             Заявки ({submissions.length})
+          </button>
+          <button style={tabStyle(view === 'feedback')} onClick={() => setView('feedback')}>
+            Фидбеки ({feedbackItems.length})
           </button>
           <button style={tabStyle(view === 'intro')} onClick={() => setView('intro')}>
             Интро
@@ -425,75 +511,55 @@ export default function AdminPanel({
         {/* Users table */}
         {view === 'users' && (
           <div>
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.9rem' }}>
+              <input
+                value={userSearch}
+                onChange={e => setUserSearch(e.target.value)}
+                placeholder="Поиск по имени или email"
+                aria-label="Поиск пользователей"
+                style={{ ...fieldInput, maxWidth: 420, borderBottomColor: '#111' }}
+              />
+              <span style={{ fontFamily: 'var(--nd-sans), system-ui, sans-serif', fontSize: '0.75rem', color: '#999' }}>
+                {adminUsersLoaded ? `${filteredAdminUsers.length} из ${adminUsers.length}` : 'Загрузка…'}
+              </span>
+            </div>
+            <table style={{ width: '100%', borderCollapse: 'collapse', background: '#fff', border: '1px solid #E5E5E5' }}>
               <thead>
                 <tr>
-                  <th style={headCell}>Имя</th>
-                  <th style={headCell}>Telegram</th>
-                  <th style={headCell}>Email</th>
-                  <th style={headCell}>Языки</th>
-                  <th style={headCell}>Книги</th>
-                  <th style={headCell}></th>
+                  <th style={{ ...headCell, cursor: 'pointer' }} onClick={() => setSort('name')}>Имя{userSort.key === 'name' ? (userSort.dir === 'asc' ? ' ↑' : ' ↓') : ''}</th>
+                  <th style={{ ...headCell, cursor: 'pointer' }} onClick={() => setSort('telegram')}>Telegram{userSort.key === 'telegram' ? (userSort.dir === 'asc' ? ' ↑' : ' ↓') : ''}</th>
+                  <th style={{ ...headCell, cursor: 'pointer' }} onClick={() => setSort('email')}>Email{userSort.key === 'email' ? (userSort.dir === 'asc' ? ' ↑' : ' ↓') : ''}</th>
+                  <th style={{ ...headCell, cursor: 'pointer', textAlign: 'right' }} onClick={() => setSort('books')}>Книг{userSort.key === 'books' ? (userSort.dir === 'asc' ? ' ↑' : ' ↓') : ''}</th>
+                  <th style={{ ...headCell, cursor: 'pointer' }} onClick={() => setSort('languages')}>Языки{userSort.key === 'languages' ? (userSort.dir === 'asc' ? ' ↑' : ' ↓') : ''}</th>
                 </tr>
               </thead>
               <tbody>
-                {localUsers.map(u => {
-                  const priSet = prioritiesSetMap[u.userId] ?? false
-                  const userPriorities = localPrioritiesMap[u.userId] ?? []
-                  const rankMap = new Map(userPriorities.map(p => [p.bookName, p.rank]))
-                  const ranked = u.selectedBooks
-                    .filter(b => rankMap.has(b))
-                    .sort((a, b) => rankMap.get(a)! - rankMap.get(b)!)
-                  const unranked = u.selectedBooks.filter(b => !rankMap.has(b))
-                  const sortedBooks = priSet ? [...ranked, ...unranked] : u.selectedBooks
+                {!adminUsersLoaded && (
+                  <tr><td colSpan={5} style={{ ...cell, color: '#999' }}>Загрузка пользователей…</td></tr>
+                )}
+                {adminUsersLoaded && filteredAdminUsers.length === 0 && (
+                  <tr><td colSpan={5} style={{ ...cell, color: '#999' }}>Никого не найдено</td></tr>
+                )}
+                {filteredAdminUsers.map(u => {
+                  const telegram = u.telegramUsername ? `@${u.telegramUsername}` : (u.contacts?.startsWith('@') ? u.contacts : '—')
                   return (
-                    <tr key={u.userId}>
-                      <td style={cell}>{u.name}</td>
-                      <td style={cell}>{u.contacts}</td>
+                    <tr
+                      key={u.id}
+                      onClick={() => openUserDrawer(u.id)}
+                      style={{ cursor: 'pointer', transition: 'background 0.1s' }}
+                      onMouseEnter={e => { e.currentTarget.style.background = '#FAFAFA' }}
+                      onMouseLeave={e => { e.currentTarget.style.background = 'transparent' }}
+                    >
+                      <td style={{ ...cell, fontWeight: 700 }}>{u.name || <span style={{ color: '#bbb' }}>—</span>}</td>
+                      <td style={cell}>{telegram}</td>
                       <td style={{ ...cell, color: '#666' }}>{u.email}</td>
+                      <td style={{ ...cell, textAlign: 'right', fontWeight: u.booksCount > 0 ? 700 : 400, color: u.booksCount > 0 ? '#111' : '#BBB' }}>{u.booksCount}</td>
                       <td style={{ ...cell, color: '#666' }}>
-                        {(userLanguages[u.userId] ?? []).join(', ') || <span style={{ color: '#ccc' }}>—</span>}
-                      </td>
-                      <td style={cell}>
-                        {!priSet && (
-                          <div style={{ fontSize: '0.65rem', color: '#aaa', fontStyle: 'italic', marginBottom: '0.25rem' }}>
-                            Приоритеты не расставлены
-                          </div>
-                        )}
-                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
-                          {sortedBooks.map(book => {
-                            const rank = rankMap.get(book)
-                            const numLabel = !priSet ? '?' : rank !== undefined ? String(rank) : '+'
-                            const numBg = !priSet || rank === undefined ? '#E5E5E5' : '#111'
-                            const numColor = !priSet || rank === undefined ? '#aaa' : '#fff'
-                            return (
-                              <span key={book} style={{ display: 'inline-flex', alignItems: 'center', background: '#F5F5F5', fontSize: '0.75rem', overflow: 'hidden' }}>
-                                <span style={{ background: numBg, color: numColor, padding: '0.15rem 0.35rem', fontWeight: 700, fontSize: '0.7rem', flexShrink: 0 }}>
-                                  {numLabel}
-                                </span>
-                                <span style={{ padding: '0.15rem 0.4rem' }}>{book}</span>
-                                <button
-                                  onClick={() => handleRemoveBook(u.userId, book, u.name)}
-                                  title="Снять с книги"
-                                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#999', fontSize: '0.85rem', lineHeight: 1, padding: '0 0.2rem' }}
-                                >
-                                  ×
-                                </button>
-                              </span>
-                            )
-                          })}
-                        </div>
-                      </td>
-                      <td style={{ ...cell, textAlign: 'right' }}>
-                        <button
-                          onClick={() => {
-                            handleDeleteUser(u.userId, u.name)
-                          }}
-                          title="Удалить пользователя"
-                          style={{ background: 'none', border: '1px solid #E5E5E5', cursor: 'pointer', color: '#999', fontSize: '0.65rem', padding: '0.2rem 0.5rem', fontFamily: 'var(--nd-sans), system-ui, sans-serif', textTransform: 'uppercase', letterSpacing: '0.06em' }}
-                        >
-                          Удалить
-                        </button>
+                        {u.languages.length === 0 ? <span style={{ color: '#ccc' }}>—</span> : u.languages.map(lang => (
+                          <span key={lang} style={{ display: 'inline-block', padding: '0.08rem 0.38rem', marginRight: '0.25rem', background: '#F0F0F0', color: '#555', fontSize: '0.68rem', borderRadius: 2, textTransform: 'uppercase' }}>
+                            {lang}
+                          </span>
+                        ))}
                       </td>
                     </tr>
                   )
@@ -906,7 +972,80 @@ export default function AdminPanel({
             )}
           </div>
         )}
+
+        {view === 'feedback' && (
+          <div>
+            <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap', marginBottom: '1rem' }}>
+              <input
+                value={feedbackSearch}
+                onChange={e => setFeedbackSearch(e.target.value)}
+                placeholder="Поиск по тексту, имени или email"
+                aria-label="Поиск фидбеков"
+                style={{ ...fieldInput, maxWidth: 420 }}
+              />
+              {(['all', 'registered', 'anonymous'] as const).map(f => {
+                const labels = { all: 'Все', registered: 'Зарегистрированные', anonymous: 'Анонимные' }
+                return (
+                  <button key={f} onClick={() => setFeedbackFilter(f)} style={filterBtnStyle(feedbackFilter === f)}>
+                    {labels[f]} ({feedbackCounts[f]})
+                  </button>
+                )
+              })}
+            </div>
+            {!feedbackLoaded && <p style={{ fontFamily: 'var(--nd-sans), system-ui, sans-serif', color: '#666' }}>Загрузка…</p>}
+            {feedbackLoaded && filteredFeedback.length === 0 && <p style={{ fontFamily: 'var(--nd-sans), system-ui, sans-serif', color: '#999' }}>Нет фидбеков</p>}
+            {feedbackLoaded && filteredFeedback.length > 0 && (
+              <div style={{ display: 'grid', gap: '0.6rem' }}>
+                {filteredFeedback.map(item => {
+                  const displayName = item.userName ?? item.name ?? 'Аноним'
+                  const displayEmail = item.userEmail ?? item.email
+                  return (
+                    <article key={item.id} style={{ border: '1px solid #E5E5E5', background: '#fff', padding: '0.8rem 0.9rem' }}>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', marginBottom: '0.45rem', alignItems: 'baseline' }}>
+                        <div>
+                          {item.userId ? (
+                            <button onClick={() => openUserDrawer(item.userId!)} style={{ background: 'none', border: 'none', padding: 0, color: '#111', fontWeight: 700, cursor: 'pointer', fontFamily: 'var(--nd-sans), system-ui, sans-serif' }}>
+                              {displayName}
+                            </button>
+                          ) : (
+                            <span style={{ fontWeight: 700 }}>{displayName}</span>
+                          )}
+                          {displayEmail && <span style={{ color: '#999', marginLeft: '0.5rem', fontSize: '0.78rem' }}>{displayEmail}</span>}
+                          {!item.userId && <span style={{ marginLeft: '0.5rem', background: '#F0F0F0', color: '#777', borderRadius: 2, padding: '0.08rem 0.4rem', fontSize: '0.68rem' }}>Аноним</span>}
+                        </div>
+                        <time style={{ color: '#999', fontSize: '0.72rem' }}>{new Date(item.createdAt).toLocaleString('ru-RU')}</time>
+                      </div>
+                      <div style={{ whiteSpace: 'pre-wrap', color: '#333', fontFamily: 'var(--nd-sans), system-ui, sans-serif', fontSize: '0.86rem', lineHeight: 1.55 }}>
+                        {item.message}
+                      </div>
+                    </article>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
       </main>
+      <AdminUserDrawer
+        isOpen={selectedAdminUserId !== null}
+        data={selectedAdminUser}
+        loading={userDrawerLoading}
+        onClose={closeUserDrawer}
+        onRemoveSignup={(bookName) => {
+          if (!selectedAdminUser) return
+          handleRemoveBook(selectedAdminUser.user.id, bookName, selectedAdminUser.user.name || selectedAdminUser.user.email)
+        }}
+        onDeleteUser={() => {
+          if (!selectedAdminUser) return
+          handleDeleteUser(selectedAdminUser.user.id, selectedAdminUser.user.name || selectedAdminUser.user.email)
+        }}
+        onOpenSubmission={(submissionId) => {
+          closeUserDrawer()
+          setView('submissions')
+          setSubmissionFilter('all')
+          setSelectedSubmissionId(submissionId)
+        }}
+      />
     </>
   )
 }

--- a/components/nd/AdminUserDrawer.tsx
+++ b/components/nd/AdminUserDrawer.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useEffect } from 'react'
+import type { AdminUserDetails } from '@/lib/admin-users'
+
+interface Props {
+  isOpen: boolean
+  data: AdminUserDetails | null
+  loading: boolean
+  onClose: () => void
+  onRemoveSignup: (bookName: string) => void
+  onDeleteUser: () => void
+  onOpenSubmission: (submissionId: string) => void
+}
+
+const sans = 'var(--nd-sans), system-ui, sans-serif'
+const serif = 'var(--nd-serif), Georgia, serif'
+
+const sectionTitle: React.CSSProperties = {
+  fontFamily: sans,
+  fontSize: '0.68rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.12em',
+  color: '#666',
+  margin: 0,
+}
+
+const pill = (bg: string, color: string): React.CSSProperties => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '0.12rem 0.45rem',
+  borderRadius: 10,
+  background: bg,
+  color,
+  fontFamily: sans,
+  fontSize: '0.68rem',
+  lineHeight: 1.4,
+})
+
+function formatDate(value: string | null) {
+  if (!value) return '—'
+  return new Date(value).toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function authLabel(provider: string | null) {
+  if (!provider) return '—'
+  if (provider === 'telegram-preauth') return 'telegram'
+  if (provider === 'google-one-tap') return 'google one tap'
+  return provider
+}
+
+export default function AdminUserDrawer({ isOpen, data, loading, onClose, onRemoveSignup, onDeleteUser, onOpenSubmission }: Props) {
+  useEffect(() => {
+    if (!isOpen) return
+    const original = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = original
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [isOpen, onClose])
+
+  const user = data?.user
+  const priorityMap = new Map((data?.priorities ?? []).map(row => [row.bookName, row.rank]))
+  const ranked = (data?.signupBooks ?? [])
+    .filter(row => priorityMap.has(row.bookName))
+    .sort((a, b) => priorityMap.get(a.bookName)! - priorityMap.get(b.bookName)!)
+  const unranked = (data?.signupBooks ?? []).filter(row => !priorityMap.has(row.bookName))
+  const sortedBooks = user?.prioritiesSet ? [...ranked, ...unranked] : (data?.signupBooks ?? [])
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.35)',
+          zIndex: 200,
+          opacity: isOpen ? 1 : 0,
+          pointerEvents: isOpen ? 'auto' : 'none',
+          transition: 'opacity 0.25s ease',
+        }}
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label={user ? `Карточка пользователя ${user.name || user.email}` : 'Карточка пользователя'}
+        style={{
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          width: 640,
+          maxWidth: '100vw',
+          height: '100dvh',
+          background: '#fff',
+          borderLeft: '2px solid #111',
+          zIndex: 300,
+          transform: isOpen ? 'translateX(0)' : 'translateX(100%)',
+          visibility: isOpen ? 'visible' : 'hidden',
+          transition: 'transform 0.28s cubic-bezier(0.4, 0, 0.2, 1)',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <header style={{ padding: '1rem 1.25rem', borderBottom: '1px solid #E5E5E5', display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
+          <div>
+            <div style={{ fontFamily: sans, fontSize: '0.62rem', textTransform: 'uppercase', letterSpacing: '0.16em', color: '#999' }}>
+              Карточка пользователя
+            </div>
+            <h2 style={{ fontFamily: serif, fontSize: '1.35rem', margin: '0.2rem 0 0', color: '#111' }}>
+              {loading ? 'Загрузка…' : user?.name || user?.email || 'Пользователь'}
+            </h2>
+          </div>
+          <button onClick={onClose} aria-label="Закрыть" style={{ background: 'none', border: 'none', fontSize: '1.5rem', color: '#666', cursor: 'pointer', height: 32 }}>
+            ×
+          </button>
+        </header>
+
+        <div style={{ flex: 1, overflowY: 'auto', padding: '1.25rem', fontFamily: sans }}>
+          {loading && <p style={{ color: '#666' }}>Загрузка данных…</p>}
+          {!loading && !data && <p style={{ color: '#999' }}>Не удалось загрузить пользователя.</p>}
+          {data && user && (
+            <>
+              <section style={{ marginBottom: '1.6rem' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', marginBottom: '0.7rem' }}>
+                  <h3 style={sectionTitle}>Профиль</h3>
+                  <span style={pill('#F0F0F0', '#555')}>{authLabel(user.authProvider)}</span>
+                </div>
+                <dl style={{ display: 'grid', gridTemplateColumns: '130px 1fr', gap: '0.45rem 0.9rem', margin: 0, fontSize: '0.82rem' }}>
+                  <dt style={{ color: '#999' }}>Имя</dt><dd style={{ margin: 0 }}>{user.name || '—'}</dd>
+                  <dt style={{ color: '#999' }}>Telegram</dt><dd style={{ margin: 0 }}>{user.telegramUsername ? `@${user.telegramUsername}` : user.contacts || '—'}</dd>
+                  <dt style={{ color: '#999' }}>Email</dt><dd style={{ margin: 0 }}>{user.email}</dd>
+                  <dt style={{ color: '#999' }}>Языки</dt><dd style={{ margin: 0 }}>{user.languages.length ? user.languages.join(', ') : '—'}</dd>
+                  <dt style={{ color: '#999' }}>Последний вход</dt><dd style={{ margin: 0 }}>{formatDate(user.lastSignInAt)}</dd>
+                  <dt style={{ color: '#999' }}>Создан</dt><dd style={{ margin: 0 }}>{formatDate(user.createdAt)}</dd>
+                </dl>
+                <button onClick={onDeleteUser} style={{ marginTop: '0.9rem', background: 'transparent', border: '1px solid #E5E5E5', color: '#999', padding: '0.35rem 0.75rem', cursor: 'pointer', fontFamily: sans, fontSize: '0.68rem', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                  Удалить пользователя
+                </button>
+              </section>
+
+              <section style={{ marginBottom: '1.6rem' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', marginBottom: '0.45rem' }}>
+                  <h3 style={sectionTitle}>Записи на книги</h3>
+                  <span style={user.prioritiesSet ? pill('#E2F0EA', '#2D6A4F') : pill('#F0F0F0', '#777')}>
+                    {user.prioritiesSet ? 'приоритеты расставлены' : 'без приоритетов'}
+                  </span>
+                </div>
+                {!user.prioritiesSet && sortedBooks.length > 0 && <div style={{ color: '#AAA', fontStyle: 'italic', fontSize: '0.76rem', marginBottom: '0.5rem' }}>приоритеты ещё не расставлены</div>}
+                {user.prioritiesSet && unranked.length > 0 && <div style={{ color: '#AAA', fontStyle: 'italic', fontSize: '0.76rem', marginBottom: '0.5rem' }}>добавил книги после расстановки</div>}
+                {sortedBooks.length === 0 ? <p style={{ color: '#BBB', fontStyle: 'italic', fontSize: '0.82rem' }}>Нет записей</p> : (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem' }}>
+                    {sortedBooks.map(row => {
+                      const rank = priorityMap.get(row.bookName)
+                      const label = !user.prioritiesSet ? '?' : rank ?? '+'
+                      const isRanked = user.prioritiesSet && rank !== undefined
+                      return (
+                        <span key={row.bookName} style={{ display: 'inline-flex', alignItems: 'center', background: '#F5F5F5', borderRadius: 2, overflow: 'hidden', fontSize: '0.78rem' }}>
+                          <span style={{ background: isRanked ? '#111' : '#E5E5E5', color: isRanked ? '#fff' : '#AAA', padding: '0.22rem 0.45rem', fontWeight: 700 }}>{label}</span>
+                          <span style={{ padding: '0.22rem 0.5rem' }}>{row.bookName}</span>
+                          <button onClick={() => onRemoveSignup(row.bookName)} title="Снять запись" style={{ background: 'none', border: 'none', color: '#999', cursor: 'pointer', padding: '0 0.4rem' }}>×</button>
+                        </span>
+                      )
+                    })}
+                  </div>
+                )}
+              </section>
+
+              <section style={{ marginBottom: '1.6rem' }}>
+                <h3 style={{ ...sectionTitle, marginBottom: '0.5rem' }}>Предложения книг</h3>
+                {data.submissions.length === 0 ? <p style={{ color: '#BBB', fontStyle: 'italic', fontSize: '0.82rem' }}>Нет предложений</p> : (
+                  <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                    {data.submissions.map(sub => (
+                      <li key={sub.id} style={{ padding: '0.55rem 0', borderBottom: '1px solid #F0F0F0', display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'center' }}>
+                        <div><div>{sub.title}</div><div style={{ color: '#999', fontSize: '0.7rem' }}>{sub.author} · {formatDate(sub.createdAt)}</div></div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                          <span style={pill(sub.status === 'approved' ? '#E2F0EA' : sub.status === 'rejected' ? '#FAE0E0' : '#FFF3DC', '#555')}>{sub.status}</span>
+                          <button onClick={() => onOpenSubmission(sub.id)} style={{ background: 'none', border: 'none', color: '#666', cursor: 'pointer', fontFamily: sans, fontSize: '0.72rem', padding: 0 }}>
+                            открыть заявку →
+                          </button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <section>
+                <h3 style={{ ...sectionTitle, marginBottom: '0.5rem' }}>Фидбеки</h3>
+                {data.feedback.length === 0 ? <p style={{ color: '#BBB', fontStyle: 'italic', fontSize: '0.82rem' }}>Нет фидбеков</p> : (
+                  <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                    {data.feedback.map(item => (
+                      <li key={item.id} style={{ padding: '0.65rem 0', borderBottom: '1px solid #F0F0F0' }}>
+                        <div style={{ color: '#999', fontSize: '0.72rem', marginBottom: '0.25rem' }}>{formatDate(item.createdAt)}</div>
+                        <div style={{ whiteSpace: 'pre-wrap', color: '#333', fontSize: '0.84rem' }}>{item.message}</div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </>
+          )}
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/e2e/admin-delete-user.spec.ts
+++ b/e2e/admin-delete-user.spec.ts
@@ -59,12 +59,14 @@ test.describe('Удаление пользователя в админке', () 
     // Принимаем confirm-диалог перед кликом
     page.on('dialog', dialog => dialog.accept())
 
-    // Находим строку жертвы и кликаем "Удалить"
+    // Находим строку жертвы, открываем карточку и удаляем из drawer
     const victimRow = page.locator('tr').filter({ hasText: VICTIM_NAME })
-    await victimRow.getByTitle('Удалить пользователя').click()
+    await victimRow.click()
+    await expect(page.getByRole('dialog')).toContainText(VICTIM_NAME)
+    await page.getByRole('dialog').getByRole('button', { name: /удалить пользователя/i }).click()
 
     // Жертва исчезла из таблицы (локальный стейт)
-    await expect(page.getByText(VICTIM_NAME)).not.toBeVisible()
+    await expect(page.locator('tr').filter({ hasText: VICTIM_NAME })).toHaveCount(0)
 
     const afterDelete = await page.request.get(`/api/test/user?email=${encodeURIComponent(VICTIM_EMAIL)}`)
     const afterDeleteData = await afterDelete.json()
@@ -78,6 +80,6 @@ test.describe('Удаление пользователя в админке', () 
     await page.waitForLoadState('networkidle')
 
     // Жертва не должна появиться снова
-    await expect(page.getByText(VICTIM_NAME)).not.toBeVisible()
+    await expect(page.locator('tr').filter({ hasText: VICTIM_NAME })).toHaveCount(0)
   })
 })

--- a/e2e/admin-users.spec.ts
+++ b/e2e/admin-users.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test'
+import { epic, feature } from 'allure-js-commons'
+
+const ADMIN_EMAIL = 'e2e-admin-users-admin@test.invalid'
+const ADMIN_NAME = 'E2E Admin Users Admin'
+const USER_EMAIL = 'e2e-admin-users-user@test.invalid'
+const USER_NAME = 'E2E Admin Users Reader'
+const USER_ID = `test:${USER_EMAIL}`
+const USER_CONTACT = '@e2e_admin_users'
+const BOOK_A = 'Тестовая книга 1'
+const BOOK_B = 'Тестовая книга 2'
+const REGISTERED_FEEDBACK = 'E2E registered feedback for admin users'
+const ANON_FEEDBACK = 'E2E anonymous feedback for admin users'
+
+test.describe('админка — пользователи и фидбеки', () => {
+  test.setTimeout(120_000)
+
+  let feedbackIds: string[] = []
+
+  test.beforeEach(async ({ page }) => {
+    await epic('Администрирование')
+    await feature('Карточка пользователя')
+    feedbackIds = []
+
+    await page.request.post('/api/test/session', {
+      data: { email: USER_EMAIL, name: USER_NAME },
+    })
+    await page.request.post('/api/test/signup', {
+      data: { userId: USER_ID, name: USER_NAME, email: USER_EMAIL, contacts: USER_CONTACT, selectedBooks: [BOOK_A, BOOK_B] },
+    })
+    const registered = await page.request.post('/api/test/feedback', {
+      data: { userId: USER_ID, name: USER_NAME, email: USER_EMAIL, message: REGISTERED_FEEDBACK },
+    })
+    const anonymous = await page.request.post('/api/test/feedback', {
+      data: { userId: null, name: 'Anon E2E', email: 'anon-admin-users@test.invalid', message: ANON_FEEDBACK },
+    })
+    feedbackIds.push((await registered.json()).id, (await anonymous.json()).id)
+
+    await page.request.post('/api/test/session', {
+      data: { email: ADMIN_EMAIL, name: ADMIN_NAME, isAdmin: true },
+    })
+  })
+
+  test.afterEach(async ({ page }) => {
+    await page.request.delete('/api/test/feedback', { data: { ids: feedbackIds } })
+    await page.request.delete('/api/test/signup', { data: { userId: USER_ID } })
+    await page.request.delete('/api/test/session', { data: { email: ADMIN_EMAIL } })
+    await page.request.delete('/api/test/session', { data: { email: USER_EMAIL } })
+  })
+
+  async function openUserDrawer(page: import('@playwright/test').Page) {
+    await page.goto('/admin')
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Поиск пользователей').fill(USER_EMAIL)
+    await page.locator('tr').filter({ hasText: USER_EMAIL }).click()
+    await expect(page.getByRole('dialog', { name: /карточка пользователя/i })).toBeVisible()
+  }
+
+  test('поиск открывает drawer со всеми секциями пользователя', async ({ page }) => {
+    await openUserDrawer(page)
+
+    await expect(page.getByRole('dialog')).toContainText(USER_NAME)
+    await expect(page.getByRole('dialog')).toContainText(USER_CONTACT)
+    await expect(page.getByRole('dialog')).toContainText('Профиль')
+    await expect(page.getByRole('dialog')).toContainText('Записи на книги')
+    await expect(page.getByRole('dialog')).toContainText('Предложения книг')
+    await expect(page.getByRole('dialog')).toContainText('Фидбеки')
+    await expect(page.getByRole('dialog')).toContainText(BOOK_A)
+    await expect(page.getByRole('dialog')).toContainText(REGISTERED_FEEDBACK)
+  })
+
+  test('снятие записи на книгу сохраняется после reload', async ({ page }) => {
+    await openUserDrawer(page)
+
+    page.on('dialog', dialog => dialog.accept())
+    const bookPill = page.getByRole('dialog').locator('span').filter({ hasText: BOOK_B }).first()
+    await bookPill.getByTitle('Снять запись').click()
+
+    await expect.poll(async () => {
+      const state = await (await page.request.get(`/api/test/user?email=${encodeURIComponent(USER_EMAIL)}`)).json()
+      return state.signupBooks.sort()
+    }).toEqual([BOOK_A])
+
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Поиск пользователей').fill(USER_EMAIL)
+    await expect(page.locator('tr').filter({ hasText: USER_EMAIL })).toContainText('1')
+  })
+
+  test('удаление пользователя закрывает drawer и убирает строку', async ({ page }) => {
+    await openUserDrawer(page)
+
+    page.on('dialog', dialog => dialog.accept())
+    await page.getByRole('dialog').getByRole('button', { name: /удалить пользователя/i }).click()
+
+    await expect(page.getByRole('dialog')).not.toBeVisible()
+    await expect(page.locator('tr').filter({ hasText: USER_EMAIL })).toHaveCount(0)
+  })
+
+  test('вкладка фидбеков показывает фильтры, поиск и открывает пользователя', async ({ page }) => {
+    await page.goto('/admin')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('button', { name: /фидбеки/i }).click()
+
+    await expect(page.getByText(REGISTERED_FEEDBACK)).toBeVisible()
+    await expect(page.getByText(ANON_FEEDBACK)).toBeVisible()
+
+    await page.getByRole('button', { name: /анонимные/i }).click()
+    await expect(page.getByText(ANON_FEEDBACK)).toBeVisible()
+    await expect(page.getByText(REGISTERED_FEEDBACK)).not.toBeVisible()
+
+    await page.getByRole('button', { name: /все/i }).click()
+    await page.getByLabel('Поиск фидбеков').fill('registered feedback')
+    await expect(page.getByText(REGISTERED_FEEDBACK)).toBeVisible()
+    await expect(page.getByText(ANON_FEEDBACK)).not.toBeVisible()
+
+    await page.getByRole('button', { name: USER_NAME }).click()
+    await expect(page.getByRole('dialog')).toContainText(USER_EMAIL)
+  })
+})

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -52,3 +52,37 @@ test.describe('Header: hide on scroll down', () => {
     expect(await isFullyVisible(page, 'header')).toBe(true)
   })
 })
+
+test.describe('Admin user drawer layout', () => {
+  const ADMIN_EMAIL = 'e2e-ui-admin@test.invalid'
+  const USER_EMAIL = 'e2e-ui-drawer-user@test.invalid'
+  const USER_ID = `test:${USER_EMAIL}`
+  const USER_NAME = 'E2E UI Drawer User'
+
+  test.afterEach(async ({ page }) => {
+    await page.request.delete('/api/test/signup', { data: { userId: USER_ID } })
+    await page.request.delete('/api/test/session', { data: { email: ADMIN_EMAIL } })
+    await page.request.delete('/api/test/session', { data: { email: USER_EMAIL } })
+  })
+
+  test('drawer slides in from the right within viewport bounds', async ({ page }) => {
+    await page.request.post('/api/test/session', { data: { email: USER_EMAIL, name: USER_NAME } })
+    await page.request.post('/api/test/signup', {
+      data: { userId: USER_ID, name: USER_NAME, email: USER_EMAIL, contacts: '@ui_drawer', selectedBooks: ['Тестовая книга 1'] },
+    })
+    await page.request.post('/api/test/session', { data: { email: ADMIN_EMAIL, name: 'E2E UI Admin', isAdmin: true } })
+
+    await page.goto('/admin')
+    await page.waitForLoadState('networkidle')
+    await page.getByLabel('Поиск пользователей').fill(USER_EMAIL)
+    await page.locator('tr').filter({ hasText: USER_EMAIL }).click()
+    await page.waitForTimeout(350)
+
+    const box = await page.getByRole('dialog').boundingBox()
+    const viewport = page.viewportSize()!
+    expect(box).not.toBeNull()
+    expect(box!.width).toBeLessThanOrEqual(640)
+    expect(box!.x + box!.width).toBeLessThanOrEqual(viewport.width + 1)
+    expect(box!.x).toBeGreaterThanOrEqual(Math.max(0, viewport.width - 641))
+  })
+})

--- a/lib/admin-users.test.ts
+++ b/lib/admin-users.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@/lib/db', () => ({ db: {} }))
+
+import { buildAdminUserSummaries, getTelegramDisplay } from './admin-users'
+
+describe('admin-users aggregations', () => {
+  it('считает signup_books по пользователям и парсит языки', () => {
+    const users = [
+      {
+        id: 'u1',
+        name: 'Анна',
+        email: 'anna@test.com',
+        contacts: '@anna_contact',
+        telegramUsername: 'anna',
+        authProvider: 'telegram-preauth',
+        lastSignInAt: new Date('2026-01-02T10:00:00Z'),
+        emailVerified: new Date('2026-01-01T10:00:00Z'),
+        languages: '["ru","en"]',
+      },
+      {
+        id: 'u2',
+        name: null,
+        email: 'b@test.com',
+        contacts: null,
+        telegramUsername: null,
+        authProvider: 'google',
+        lastSignInAt: null,
+        emailVerified: null,
+        languages: 'not-json',
+      },
+    ]
+
+    const result = buildAdminUserSummaries(users, [
+      { userId: 'u1' },
+      { userId: 'u1' },
+      { userId: 'missing' },
+    ])
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'u1',
+        name: 'Анна',
+        email: 'anna@test.com',
+        languages: ['ru', 'en'],
+        booksCount: 2,
+        lastSignInAt: '2026-01-02T10:00:00.000Z',
+        createdAt: '2026-01-01T10:00:00.000Z',
+      }),
+      expect.objectContaining({
+        id: 'u2',
+        name: '',
+        languages: [],
+        booksCount: 0,
+        lastSignInAt: null,
+      }),
+    ])
+  })
+
+  it('показывает telegram_username раньше contacts', () => {
+    expect(getTelegramDisplay({ telegramUsername: 'reader', contacts: '@fallback' })).toBe('@reader')
+    expect(getTelegramDisplay({ contacts: '@fallback' })).toBe('@fallback')
+    expect(getTelegramDisplay({ contacts: 'email@test.com' })).toBe('email@test.com')
+  })
+})

--- a/lib/admin-users.ts
+++ b/lib/admin-users.ts
@@ -1,0 +1,234 @@
+import { db } from '@/lib/db'
+import {
+  bookPriorities,
+  bookSubmissions,
+  feedback,
+  signupBooks,
+  users,
+} from '@/lib/db/schema'
+import { asc, desc, eq } from 'drizzle-orm'
+
+export interface AdminUserSummary {
+  id: string
+  name: string
+  email: string
+  contacts: string | null
+  telegramUsername: string | null
+  authProvider: string | null
+  lastSignInAt: string | null
+  createdAt: string | null
+  languages: string[]
+  booksCount: number
+}
+
+export interface AdminUserDetails {
+  user: AdminUserSummary & { prioritiesSet: boolean }
+  signupBooks: { bookName: string; signedAt: string }[]
+  priorities: { bookName: string; rank: number }[]
+  submissions: {
+    id: string
+    title: string
+    author: string
+    status: string
+    createdAt: string
+  }[]
+  feedback: AdminFeedbackItem[]
+}
+
+export interface AdminFeedbackItem {
+  id: string
+  userId: string | null
+  name: string | null
+  email: string | null
+  message: string
+  createdAt: string
+  userName: string | null
+  userEmail: string | null
+}
+
+function parseLanguages(value: string | null): string[] {
+  if (!value) return []
+  try {
+    const parsed = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function dateToIso(value: Date | null | undefined): string | null {
+  return value ? value.toISOString() : null
+}
+
+export function getTelegramDisplay(user: { telegramUsername?: string | null; contacts?: string | null }) {
+  if (user.telegramUsername) return `@${user.telegramUsername.replace(/^@/, '')}`
+  const contacts = user.contacts?.trim()
+  if (contacts?.startsWith('@')) return contacts
+  return contacts ?? ''
+}
+
+export async function getAdminUserSummaries(): Promise<AdminUserSummary[]> {
+  const [userRows, signupRows] = await Promise.all([
+    db
+      .select({
+        id: users.id,
+        name: users.name,
+        email: users.email,
+        emailVerified: users.emailVerified,
+        contacts: users.contacts,
+        telegramUsername: users.telegramUsername,
+        authProvider: users.authProvider,
+        lastSignInAt: users.lastSignInAt,
+        languages: users.languages,
+      })
+      .from(users)
+      .orderBy(asc(users.name), asc(users.email)),
+    db.select({ userId: signupBooks.userId }).from(signupBooks),
+  ])
+
+  return buildAdminUserSummaries(userRows, signupRows)
+}
+
+export function buildAdminUserSummaries(
+  userRows: {
+    id: string
+    name: string | null
+    email: string
+    contacts: string | null
+    telegramUsername: string | null
+    authProvider: string | null
+    lastSignInAt: Date | null
+    emailVerified: Date | null
+    languages: string | null
+  }[],
+  signupRows: { userId: string }[]
+): AdminUserSummary[] {
+  const counts = new Map<string, number>()
+  for (const row of signupRows) counts.set(row.userId, (counts.get(row.userId) ?? 0) + 1)
+
+  return userRows.map(row => ({
+    id: row.id,
+    name: row.name ?? '',
+    email: row.email,
+    contacts: row.contacts,
+    telegramUsername: row.telegramUsername,
+    authProvider: row.authProvider,
+    lastSignInAt: dateToIso(row.lastSignInAt),
+    createdAt: dateToIso(row.emailVerified),
+    languages: parseLanguages(row.languages),
+    booksCount: counts.get(row.id) ?? 0,
+  }))
+}
+
+export async function getAdminUserDetails(userId: string): Promise<AdminUserDetails | null> {
+  const [userRow] = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      emailVerified: users.emailVerified,
+      contacts: users.contacts,
+      telegramUsername: users.telegramUsername,
+      authProvider: users.authProvider,
+      lastSignInAt: users.lastSignInAt,
+      languages: users.languages,
+      prioritiesSet: users.prioritiesSet,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
+
+  if (!userRow) return null
+
+  const [signupRows, priorityRows, submissionRows, feedbackRows] = await Promise.all([
+    db
+      .select({ bookName: signupBooks.bookName, signedAt: signupBooks.signedAt })
+      .from(signupBooks)
+      .where(eq(signupBooks.userId, userId))
+      .orderBy(asc(signupBooks.signedAt), asc(signupBooks.bookName)),
+    db
+      .select({ bookName: bookPriorities.bookName, rank: bookPriorities.rank })
+      .from(bookPriorities)
+      .where(eq(bookPriorities.userId, userId))
+      .orderBy(asc(bookPriorities.rank)),
+    db
+      .select({
+        id: bookSubmissions.id,
+        title: bookSubmissions.title,
+        author: bookSubmissions.author,
+        status: bookSubmissions.status,
+        createdAt: bookSubmissions.createdAt,
+      })
+      .from(bookSubmissions)
+      .where(eq(bookSubmissions.userId, userId))
+      .orderBy(desc(bookSubmissions.createdAt)),
+    db
+      .select({
+        id: feedback.id,
+        userId: feedback.userId,
+        name: feedback.name,
+        email: feedback.email,
+        message: feedback.message,
+        createdAt: feedback.createdAt,
+        userName: users.name,
+        userEmail: users.email,
+      })
+      .from(feedback)
+      .leftJoin(users, eq(feedback.userId, users.id))
+      .where(eq(feedback.userId, userId))
+      .orderBy(desc(feedback.createdAt)),
+  ])
+
+  const summary = buildAdminUserSummaries([userRow], signupRows.map(() => ({ userId })))[0]
+
+  return {
+    user: { ...summary, prioritiesSet: userRow.prioritiesSet ?? false },
+    signupBooks: signupRows.map(row => ({ bookName: row.bookName, signedAt: row.signedAt.toISOString() })),
+    priorities: priorityRows,
+    submissions: submissionRows.map(row => ({
+      id: row.id,
+      title: row.title,
+      author: row.author,
+      status: row.status,
+      createdAt: row.createdAt.toISOString(),
+    })),
+    feedback: feedbackRows.map(row => ({
+      id: row.id,
+      userId: row.userId,
+      name: row.name,
+      email: row.email,
+      message: row.message,
+      createdAt: row.createdAt.toISOString(),
+      userName: row.userName,
+      userEmail: row.userEmail,
+    })),
+  }
+}
+
+export async function getAdminFeedback(): Promise<AdminFeedbackItem[]> {
+  const rows = await db
+    .select({
+      id: feedback.id,
+      userId: feedback.userId,
+      name: feedback.name,
+      email: feedback.email,
+      message: feedback.message,
+      createdAt: feedback.createdAt,
+      userName: users.name,
+      userEmail: users.email,
+    })
+    .from(feedback)
+    .leftJoin(users, eq(feedback.userId, users.id))
+    .orderBy(desc(feedback.createdAt))
+
+  return rows.map(row => ({
+    id: row.id,
+    userId: row.userId,
+    name: row.name,
+    email: row.email,
+    message: row.message,
+    createdAt: row.createdAt.toISOString(),
+    userName: row.userName,
+    userEmail: row.userEmail,
+  }))
+}


### PR DESCRIPTION
## Что сделано
- новая вкладка пользователей с поиском, сортировкой и колонками по принятому решению
- drawer карточки пользователя: профиль, книги с приоритетами, заявки, фидбеки
- новая вкладка «Фидбеки» с фильтрами, поиском и открытием карточки зарегистрированного автора
- новые admin API: users, user details, feedback, signup-books delete

## Проверки
- `npm run lint`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run test:e2e -- e2e/admin-book-status.spec.ts e2e/admin-users.spec.ts e2e/admin-delete-user.spec.ts e2e/admin.spec.ts e2e/ui-states.spec.ts`

E2E: нужен — новый admin UI/drawer/feedback tab, destructive flows и CSS drawer-позиционирование; релевантный набор прошёл 15/15.

Closes #100