### PR TITLE
fix: заполняет способ входа для magic link

### DIFF
--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -201,6 +201,21 @@ describe('signIn callback', () => {
     }))
   })
 
+  it('для magic link обновляет пользователя по email, если id ещё не пришёл из callback', async () => {
+    const updateChain = mockDbUpdate()
+
+    await signInCallback()({
+      user: { email: 'magic@test.com' },
+      account: { provider: 'resend' },
+    })
+
+    expect(updateChain.set).toHaveBeenCalledWith(expect.objectContaining({
+      authProvider: 'email',
+      lastSignInAt: expect.any(Date),
+    }))
+    expect(updateChain.where).toHaveBeenCalled()
+  })
+
   it('не перетирает telegram_username пустым значением', async () => {
     const updateChain = mockDbUpdate()
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -150,13 +150,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   callbacks: {
     async signIn({ user, account }) {
       const userId = user.id
-      if (userId && account?.provider) {
+      if ((userId || user.email) && account?.provider) {
         const provider = normalizeAuthProvider(account.provider)
         await db.update(users).set({
           authProvider: provider,
           lastSignInAt: new Date(),
           ...(user.telegramUsername ? { telegramUsername: user.telegramUsername } : {}),
-        }).where(eq(users.id, userId))
+        }).where(userId ? eq(users.id, userId) : eq(users.email, user.email!))
       }
       return true
     },


### PR DESCRIPTION
## Что исправлено
- `signIn` callback теперь обновляет `auth_provider` по email, если NextAuth email/magic-link callback ещё не передал `user.id`.
- Добавлен unit-тест на этот сценарий.
- В прод-БД бэкфиллил 1 пользователя с `auth_provider IS NULL` в `email`; пустых значений не осталось.

## Проверки
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- npm run test:e2e -- e2e/signup.spec.ts e2e/admin-users.spec.ts

E2E: нужен — изменена auth chain для magic-link/email входа и админское отображение пользователя.