### PR TITLE
Harden auth security flows

### DIFF
--- a/app/api/admin/book-status/route.ts
+++ b/app/api/admin/book-status/route.ts
@@ -4,16 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { bookStatuses } from '@/lib/db/schema'
-import { eq, sql } from 'drizzle-orm'
-
-async function ensureTable() {
-  await db.execute(sql`
-    CREATE TABLE IF NOT EXISTS book_statuses (
-      book_id text PRIMARY KEY,
-      status  text NOT NULL
-    )
-  `)
-}
+import { eq } from 'drizzle-orm'
 
 export async function POST(req: NextRequest) {
   const session = await auth()
@@ -26,7 +17,6 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid params' }, { status: 400 })
   }
 
-  await ensureTable()
   await db.insert(bookStatuses).values({ bookId, status }).onConflictDoUpdate({
     target: bookStatuses.bookId,
     set: { status },
@@ -46,7 +36,6 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: 'Missing bookId' }, { status: 400 })
   }
 
-  await ensureTable()
   await db.delete(bookStatuses).where(eq(bookStatuses.bookId, bookId))
 
   return NextResponse.json({ ok: true })

--- a/app/api/auth/telegram/callback/route.test.ts
+++ b/app/api/auth/telegram/callback/route.test.ts
@@ -89,6 +89,17 @@ describe('GET /api/auth/telegram/callback', () => {
     expect(db.insert).not.toHaveBeenCalled()
   })
 
+  it('[SEC] редиректит на /?auth=failed если auth_date старше 5 минут', async () => {
+    const { db } = await import('@/lib/db')
+    const params = validParams({ auth_date: String(Math.floor(Date.now() / 1000) - 600) })
+    const res = await GET(makeRequest(params))
+
+    expect(res.status).toBe(307)
+    const url = new URL(res.headers.get('location')!)
+    expect(url.searchParams.get('auth')).toBe('failed')
+    expect(db.insert).not.toHaveBeenCalled()
+  })
+
   it('[SEC] редиректит на /?auth=failed при отсутствии TELEGRAM_BOT_TOKEN', async () => {
     const { db } = await import('@/lib/db')
     delete process.env.TELEGRAM_BOT_TOKEN

--- a/app/api/auth/telegram/callback/route.ts
+++ b/app/api/auth/telegram/callback/route.ts
@@ -1,19 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createHash, createHmac, timingSafeEqual } from 'crypto'
 import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
-
-function verifyTelegramHash(data: Record<string, string>): boolean {
-  if (!process.env.TELEGRAM_BOT_TOKEN) return false
-  const { hash, ...rest } = data
-  if (!hash) return false
-  const dataCheckString = Object.keys(rest).sort().map(k => `${k}=${rest[k]}`).join('\n')
-  const secret = createHash('sha256').update(process.env.TELEGRAM_BOT_TOKEN).digest()
-  const expected = createHmac('sha256', secret).update(dataCheckString).digest('hex')
-  try {
-    return timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(expected, 'hex'))
-  } catch { return false }
-}
+import { createTelegramPreauthToken, verifyTelegramHash } from '@/lib/telegram-auth'
 
 export async function GET(req: NextRequest) {
   const { searchParams, origin } = new URL(req.url)
@@ -32,8 +20,7 @@ export async function GET(req: NextRequest) {
     .onConflictDoUpdate({ target: users.id, set: { name, image: photo_url || null } })
 
   const ts = String(Math.floor(Date.now() / 1000))
-  const secret = (process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET)!
-  const token = createHmac('sha256', secret).update(`${userId}:${ts}`).digest('hex')
+  const { token } = await createTelegramPreauthToken(userId)
 
   const url = new URL('/auth/telegram', origin)
   url.searchParams.set('uid', userId)

--- a/app/api/cron/telegram-preauth-cleanup/route.ts
+++ b/app/api/cron/telegram-preauth-cleanup/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { cleanupTelegramPreauthTokens } from '@/lib/telegram-auth'
+
+export async function GET(req: Request) {
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    return NextResponse.json({ error: 'Misconfigured' }, { status: 401 })
+  }
+
+  if (req.headers.get('Authorization') !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  await cleanupTelegramPreauthTokens()
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/test/feedback/route.ts
+++ b/app/api/test/feedback/route.ts
@@ -2,13 +2,14 @@ import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
 import { feedback } from '@/lib/db/schema'
 import { inArray } from 'drizzle-orm'
+import { isTestEndpointAllowed } from '@/lib/test-mode'
 
 function notAllowed() {
   return NextResponse.json({ error: 'Not allowed' }, { status: 403 })
 }
 
 export async function POST(req: NextRequest) {
-  if (process.env.NEXTAUTH_TEST_MODE !== 'true') return notAllowed()
+  if (!isTestEndpointAllowed()) return notAllowed()
 
   const body = await req.json() as { userId?: string | null; name?: string; email?: string; message: string }
   const [row] = await db.insert(feedback).values({
@@ -22,7 +23,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (process.env.NEXTAUTH_TEST_MODE !== 'true') return notAllowed()
+  if (!isTestEndpointAllowed()) return notAllowed()
 
   const { ids } = await req.json() as { ids?: string[] }
   if (!ids?.length) return NextResponse.json({ ok: true })

--- a/app/api/test/session/route.test.ts
+++ b/app/api/test/session/route.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server'
+import { POST, DELETE } from './route'
+
+jest.mock('@auth/core/jwt', () => ({
+  encode: jest.fn().mockResolvedValue('encoded-session-token'),
+}))
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    insert: jest.fn().mockReturnValue({
+      values: jest.fn().mockReturnValue({
+        onConflictDoUpdate: jest.fn().mockResolvedValue(undefined),
+      }),
+    }),
+    delete: jest.fn().mockReturnValue({
+      where: jest.fn().mockResolvedValue(undefined),
+    }),
+  },
+}))
+
+function setNodeEnv(value: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value,
+    configurable: true,
+  })
+}
+
+function makeRequest(body: unknown) {
+  return new NextRequest('http://localhost/api/test/session', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/test/session guards', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  const originalTestMode = process.env.NEXTAUTH_TEST_MODE
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv)
+    if (originalTestMode === undefined) {
+      delete process.env.NEXTAUTH_TEST_MODE
+    } else {
+      process.env.NEXTAUTH_TEST_MODE = originalTestMode
+    }
+    jest.clearAllMocks()
+  })
+
+  it('[SEC] POST возвращает 403 в production даже если NEXTAUTH_TEST_MODE=true', async () => {
+    setNodeEnv('production')
+    process.env.NEXTAUTH_TEST_MODE = 'true'
+
+    const res = await POST(makeRequest({ email: 'admin@test.com', name: 'Admin', isAdmin: true }))
+
+    expect(res.status).toBe(403)
+  })
+
+  it('[SEC] DELETE возвращает 403 в production даже если NEXTAUTH_TEST_MODE=true', async () => {
+    setNodeEnv('production')
+    process.env.NEXTAUTH_TEST_MODE = 'true'
+
+    const res = await DELETE(makeRequest({ email: 'admin@test.com' }))
+
+    expect(res.status).toBe(403)
+  })
+
+  it('POST работает в test mode вне production', async () => {
+    setNodeEnv('test')
+    process.env.NEXTAUTH_TEST_MODE = 'true'
+    process.env.NEXTAUTH_SECRET = 'secret'
+
+    const res = await POST(makeRequest({ email: 'user@test.com', name: 'User' }))
+
+    expect(res.status).toBe(200)
+  })
+})

--- a/app/api/test/session/route.ts
+++ b/app/api/test/session/route.ts
@@ -6,13 +6,14 @@ import { encode } from '@auth/core/jwt'
 import { db } from '@/lib/db'
 import { users, notificationQueue } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { isTestEndpointAllowed } from '@/lib/test-mode'
 
 function notAllowed() {
   return NextResponse.json({ error: 'Not allowed' }, { status: 403 })
 }
 
 export async function POST(req: NextRequest) {
-  if (process.env.NEXTAUTH_TEST_MODE !== 'true') return notAllowed()
+  if (!isTestEndpointAllowed()) return notAllowed()
 
   const { email, name, isAdmin, telegramUsername, provider } = await req.json() as {
     email: string; name: string; isAdmin?: boolean; telegramUsername?: string; provider?: string
@@ -26,6 +27,7 @@ export async function POST(req: NextRequest) {
     authProvider: provider ?? 'email',
     telegramUsername: telegramUsername ?? null,
     lastSignInAt: new Date(),
+    isAdmin: isAdmin ?? false,
   }).onConflictDoUpdate({
     target: users.id,
     set: {
@@ -33,6 +35,7 @@ export async function POST(req: NextRequest) {
       authProvider: provider ?? 'email',
       telegramUsername: telegramUsername ?? null,
       lastSignInAt: new Date(),
+      isAdmin: isAdmin ?? false,
     },
   })
 
@@ -50,7 +53,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (process.env.NEXTAUTH_TEST_MODE !== 'true') return notAllowed()
+  if (!isTestEndpointAllowed()) return notAllowed()
 
   const { email } = await req.json() as { email: string }
   await db.delete(notificationQueue).where(eq(notificationQueue.userEmail, email))

--- a/app/api/test/signup/route.ts
+++ b/app/api/test/signup/route.ts
@@ -7,13 +7,14 @@ import { db } from '@/lib/db'
 import { signupBooks, users } from '@/lib/db/schema'
 import { upsertSignup } from '@/lib/signup-books'
 import { eq } from 'drizzle-orm'
+import { isTestEndpointAllowed } from '@/lib/test-mode'
 
 function notAllowed() {
   return NextResponse.json({ error: 'Not allowed' }, { status: 403 })
 }
 
 export async function POST(req: NextRequest) {
-  if (process.env.NEXTAUTH_TEST_MODE !== 'true') return notAllowed()
+  if (!isTestEndpointAllowed()) return notAllowed()
 
   const { userId, name, contacts, selectedBooks } = await req.json() as {
     userId: string; name: string; email: string; contacts: string; selectedBooks: string[]
@@ -26,7 +27,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (process.env.NEXTAUTH_TEST_MODE !== 'true') return notAllowed()
+  if (!isTestEndpointAllowed()) return notAllowed()
 
   const { userId } = await req.json() as { userId: string }
   await db.delete(signupBooks).where(eq(signupBooks.userId, userId))

--- a/app/api/test/user/route.ts
+++ b/app/api/test/user/route.ts
@@ -2,13 +2,14 @@ import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
 import { accounts, sessions, signupBooks, users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { isTestEndpointAllowed } from '@/lib/test-mode'
 
 function notAllowed() {
   return NextResponse.json({ error: 'Not allowed' }, { status: 403 })
 }
 
 export async function GET(req: NextRequest) {
-  if (process.env.NEXTAUTH_TEST_MODE !== 'true') return notAllowed()
+  if (!isTestEndpointAllowed()) return notAllowed()
 
   const email = req.nextUrl.searchParams.get('email')
   if (!email) {

--- a/components/nd/AdminPanel.tsx
+++ b/components/nd/AdminPanel.tsx
@@ -70,6 +70,21 @@ const headCell: React.CSSProperties = {
   borderBottom: '2px solid #111',
 }
 
+const adminBadge: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '0.08rem 0.38rem',
+  borderRadius: 2,
+  background: '#111',
+  color: '#fff',
+  fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+  fontSize: '0.62rem',
+  fontWeight: 700,
+  lineHeight: 1.35,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+}
+
 const fieldLabel: React.CSSProperties = {
   fontFamily: 'var(--nd-sans), system-ui, sans-serif',
   fontSize: '0.65rem',
@@ -647,7 +662,12 @@ export default function AdminPanel({
                       onMouseEnter={e => { e.currentTarget.style.background = '#FAFAFA' }}
                       onMouseLeave={e => { e.currentTarget.style.background = 'transparent' }}
                     >
-                      <td style={{ ...cell, fontWeight: 700 }}>{u.name || <span style={{ color: '#bbb' }}>—</span>}</td>
+                      <td style={{ ...cell, fontWeight: 700 }}>
+                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem', flexWrap: 'wrap' }}>
+                          {u.name || <span style={{ color: '#bbb' }}>—</span>}
+                          {u.isAdmin && <span style={adminBadge}>Admin</span>}
+                        </span>
+                      </td>
                       <td style={cell}>{telegram}</td>
                       <td style={{ ...cell, color: '#666' }}>{u.email}</td>
                       <td style={{ ...cell, textAlign: 'right', fontWeight: u.booksCount > 0 ? 700 : 400, color: u.booksCount > 0 ? '#111' : '#BBB' }}>{u.booksCount}</td>

--- a/components/nd/AdminUserDrawer.tsx
+++ b/components/nd/AdminUserDrawer.tsx
@@ -59,6 +59,21 @@ function lastAuthLabel(provider: string | null) {
   return `последний способ: ${authLabel(provider)}`
 }
 
+const adminBadge: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '0.1rem 0.45rem',
+  borderRadius: 2,
+  background: '#111',
+  color: '#fff',
+  fontFamily: sans,
+  fontSize: '0.62rem',
+  fontWeight: 700,
+  lineHeight: 1.35,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+}
+
 export default function AdminUserDrawer({ isOpen, data, loading, onClose, onRemoveSignup, onDeleteUser, onOpenSubmission }: Props) {
   useEffect(() => {
     if (!isOpen) return
@@ -122,9 +137,12 @@ export default function AdminUserDrawer({ isOpen, data, loading, onClose, onRemo
             <div style={{ fontFamily: sans, fontSize: '0.62rem', textTransform: 'uppercase', letterSpacing: '0.16em', color: '#999' }}>
               Карточка пользователя
             </div>
-            <h2 style={{ fontFamily: serif, fontSize: '1.35rem', margin: '0.2rem 0 0', color: '#111' }}>
-              {loading ? 'Загрузка…' : user?.name || user?.email || 'Пользователь'}
-            </h2>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.55rem', flexWrap: 'wrap', marginTop: '0.2rem' }}>
+              <h2 style={{ fontFamily: serif, fontSize: '1.35rem', margin: 0, color: '#111' }}>
+                {loading ? 'Загрузка…' : user?.name || user?.email || 'Пользователь'}
+              </h2>
+              {user?.isAdmin && <span style={adminBadge}>Admin</span>}
+            </div>
           </div>
           <button onClick={onClose} aria-label="Закрыть" style={{ background: 'none', border: 'none', fontSize: '1.5rem', color: '#666', cursor: 'pointer', height: 32 }}>
             ×

--- a/drizzle/0010_security_auth_hardening.sql
+++ b/drizzle/0010_security_auth_hardening.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "is_admin" boolean DEFAULT false NOT NULL;
+
+CREATE TABLE IF NOT EXISTS "telegram_preauth_tokens" (
+  "token_hash" text PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL,
+  "expires_at" timestamp NOT NULL,
+  "used_at" timestamp,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+DO $$ BEGIN
+ ALTER TABLE "telegram_preauth_tokens" ADD CONSTRAINT "telegram_preauth_tokens_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "telegram_preauth_tokens_user_id_idx" ON "telegram_preauth_tokens" USING btree ("user_id");
+CREATE INDEX IF NOT EXISTS "telegram_preauth_tokens_expires_at_idx" ON "telegram_preauth_tokens" USING btree ("expires_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1779027074686,
       "tag": "0009_wise_the_watchers",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1779120000000,
+      "tag": "0010_security_auth_hardening",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/admin-book-status.spec.ts
+++ b/e2e/admin-book-status.spec.ts
@@ -10,6 +10,7 @@ const USER_ID = `test:${USER_EMAIL}`
 const USER_CONTACT = '@e2e_bookstatus_user'
 const SORT_USER_A_EMAIL = 'e2e-bookstatus-sort-a@test.invalid'
 const SORT_USER_B_EMAIL = 'e2e-bookstatus-sort-b@test.invalid'
+const SORT_EXTRA_EMAIL_PREFIX = 'e2e-bookstatus-sort-extra'
 // Фикстурная книга из lib/books-with-covers.ts (только в NEXTAUTH_TEST_MODE)
 const TEST_BOOK_NAME = 'Тестовая книга 1'
 const TEST_BOOK_ID = '__test_book_1__'
@@ -17,10 +18,12 @@ const TEST_BOOK_3_NAME = 'Тестовая книга 3'
 
 test.describe('AdminPanel — изменение статуса книги', () => {
   test.setTimeout(120_000) // Админка и e2e setup могут быть медленными в CI
+  let sortExtraEmails: string[] = []
 
   test.beforeEach(async ({ page }) => {
     await epic('Администрирование')
     await feature('Статус книги')
+    sortExtraEmails = []
     // 1. Создаём обычного пользователя, записавшегося на тестовую книгу
     //    Пишем напрямую в signup_books через /api/test/signup,
     //    чтобы компактно подготовить фикстуру для админки.
@@ -55,13 +58,42 @@ test.describe('AdminPanel — изменение статуса книги', () 
     await page.request.delete('/api/test/signup', { data: { userId: USER_ID } })
     await page.request.delete('/api/test/signup', { data: { userId: `test:${SORT_USER_A_EMAIL}` } })
     await page.request.delete('/api/test/signup', { data: { userId: `test:${SORT_USER_B_EMAIL}` } })
+    for (const email of sortExtraEmails) {
+      await page.request.delete('/api/test/signup', { data: { userId: `test:${email}` } })
+    }
 
     // Удаляем пользователей из БД
     await page.request.delete('/api/test/session', { data: { email: ADMIN_EMAIL } })
     await page.request.delete('/api/test/session', { data: { email: USER_EMAIL } })
     await page.request.delete('/api/test/session', { data: { email: SORT_USER_A_EMAIL } })
     await page.request.delete('/api/test/session', { data: { email: SORT_USER_B_EMAIL } })
+    for (const email of sortExtraEmails) {
+      await page.request.delete('/api/test/session', { data: { email } })
+    }
   })
+
+  async function addSortSignup(page: import('@playwright/test').Page, email: string, index: number) {
+    const name = `E2E Sort Reader Extra ${index}`
+    await page.request.post('/api/test/session', {
+      data: { email, name },
+    })
+    await page.request.post('/api/test/signup', {
+      data: {
+        userId: `test:${email}`,
+        name,
+        email,
+        contacts: `@e2e_sort_extra_${index}`,
+        selectedBooks: [TEST_BOOK_3_NAME],
+      },
+    })
+  }
+
+  async function getBookSignupCount(page: import('@playwright/test').Page, bookName: string) {
+    const row = page.locator('tbody tr').filter({ hasText: bookName })
+    await expect(row).toBeVisible()
+    const text = await row.locator('td').nth(1).innerText()
+    return Number.parseInt(text, 10)
+  }
 
   test('изменение статуса книги на "Читаем" сохраняется после перезагрузки', async ({ page }) => {
     await page.goto('/admin')
@@ -140,6 +172,20 @@ test.describe('AdminPanel — изменение статуса книги', () 
     await page.goto('/admin')
     await page.waitForLoadState('networkidle')
     await page.getByRole('button', { name: /по книгам/i }).click()
+
+    const book1Count = await getBookSignupCount(page, TEST_BOOK_NAME)
+    const book3Count = await getBookSignupCount(page, TEST_BOOK_3_NAME)
+    const extrasNeeded = Math.max(0, book1Count - book3Count + 1)
+    for (let i = 0; i < extrasNeeded; i += 1) {
+      const email = `${SORT_EXTRA_EMAIL_PREFIX}-${i}@test.invalid`
+      sortExtraEmails.push(email)
+      await addSortSignup(page, email, i)
+    }
+    if (extrasNeeded > 0) {
+      await page.reload()
+      await page.waitForLoadState('networkidle')
+      await page.getByRole('button', { name: /по книгам/i }).click()
+    }
 
     const dataRows = page.locator('tbody tr')
     await expect.poll(async () => {

--- a/lib/admin-users.test.ts
+++ b/lib/admin-users.test.ts
@@ -18,6 +18,7 @@ describe('admin-users aggregations', () => {
         lastSignInAt: new Date('2026-01-02T10:00:00Z'),
         emailVerified: new Date('2026-01-01T10:00:00Z'),
         languages: '["ru","en"]',
+        isAdmin: true,
       },
       {
         id: 'u2',
@@ -29,6 +30,7 @@ describe('admin-users aggregations', () => {
         lastSignInAt: null,
         emailVerified: null,
         languages: 'not-json',
+        isAdmin: false,
       },
     ]
 
@@ -45,6 +47,7 @@ describe('admin-users aggregations', () => {
         email: 'anna@test.com',
         languages: ['ru', 'en'],
         booksCount: 2,
+        isAdmin: true,
         lastSignInAt: '2026-01-02T10:00:00.000Z',
         createdAt: '2026-01-01T10:00:00.000Z',
       }),
@@ -53,6 +56,7 @@ describe('admin-users aggregations', () => {
         name: '',
         languages: [],
         booksCount: 0,
+        isAdmin: false,
         lastSignInAt: null,
       }),
     ])

--- a/lib/admin-users.ts
+++ b/lib/admin-users.ts
@@ -19,6 +19,7 @@ export interface AdminUserSummary {
   createdAt: string | null
   languages: string[]
   booksCount: number
+  isAdmin: boolean
 }
 
 export interface AdminUserDetails {
@@ -80,6 +81,7 @@ export async function getAdminUserSummaries(): Promise<AdminUserSummary[]> {
         authProvider: users.authProvider,
         lastSignInAt: users.lastSignInAt,
         languages: users.languages,
+        isAdmin: users.isAdmin,
       })
       .from(users)
       .orderBy(asc(users.name), asc(users.email)),
@@ -100,6 +102,7 @@ export function buildAdminUserSummaries(
     lastSignInAt: Date | null
     emailVerified: Date | null
     languages: string | null
+    isAdmin?: boolean | null
   }[],
   signupRows: { userId: string }[]
 ): AdminUserSummary[] {
@@ -117,6 +120,7 @@ export function buildAdminUserSummaries(
     createdAt: dateToIso(row.emailVerified),
     languages: parseLanguages(row.languages),
     booksCount: counts.get(row.id) ?? 0,
+    isAdmin: row.isAdmin ?? false,
   }))
 }
 
@@ -133,6 +137,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
       lastSignInAt: users.lastSignInAt,
       languages: users.languages,
       prioritiesSet: users.prioritiesSet,
+      isAdmin: users.isAdmin,
     })
     .from(users)
     .where(eq(users.id, userId))

--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -421,8 +421,8 @@ describe('telegram-preauth authorize', () => {
     expect(await authorize({ uid: 'u', token: 'x', ts: '' })).toBeNull()
   })
 
-  it('возвращает null если токен протух (> 60 сек)', async () => {
-    const staleTs = String(Math.floor(Date.now() / 1000) - 90)
+  it('возвращает null если токен протух (> 5 минут)', async () => {
+    const staleTs = String(Math.floor(Date.now() / 1000) - 6 * 60)
     const token = 'token'
     const result = await authorize({ uid: 'user-id', token, ts: staleTs })
     expect(result).toBeNull()

--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -4,7 +4,7 @@
  * Tests for lib/auth.ts:
  * - jwt callback (isAdmin, telegramUsername, provider, deleted user)
  * - session callback (user.id, isAdmin, telegramUsername, provider)
- * - telegram-preauth provider authorize (HMAC, freshness, DB lookup)
+ * - telegram-preauth provider authorize (one-time token consume, freshness, DB lookup)
  * - telegram provider authorize (verifyTelegramHash, DB upsert)
  */
 
@@ -17,7 +17,7 @@ jest.mock('@auth/drizzle-adapter', () => ({
 }))
 
 jest.mock('@/lib/db', () => ({
-  db: { select: jest.fn(), insert: jest.fn(), update: jest.fn() },
+  db: { select: jest.fn(), insert: jest.fn(), update: jest.fn(), delete: jest.fn() },
 }))
 
 jest.mock('@/lib/auth.google-one-tap', () => ({
@@ -113,15 +113,17 @@ function mockDbInsert() {
 function mockDbUpdate() {
   const chain = {
     set: jest.fn().mockReturnThis(),
-    where: jest.fn().mockResolvedValue(undefined),
+    where: jest.fn().mockReturnThis(),
+    returning: jest.fn().mockResolvedValue([]),
   }
   ;(db.update as jest.Mock).mockReturnValue(chain)
   return chain
 }
 
-// Build a valid telegram-preauth token
-function buildPreauthToken(uid: string, ts: string, secret: string): string {
-  return createHmac('sha256', secret).update(`${uid}:${ts}`).digest('hex')
+function mockPreauthConsume(allowed: boolean) {
+  const chain = mockDbUpdate()
+  chain.returning.mockResolvedValue(allowed ? [{ userId: 'telegram:user' }] : [])
+  return chain
 }
 
 // Build a valid Telegram Widget hash
@@ -235,46 +237,82 @@ describe('signIn callback', () => {
 describe('jwt callback', () => {
   const jwtCallback = () => getConfig().callbacks.jwt
 
-  it('устанавливает isAdmin=true для admin email', async () => {
+  it('читает isAdmin=true из DB', async () => {
+    mockDbSelect([{ id: 'admin-id', isAdmin: true }])
+
     const token = await jwtCallback()({
-      token: { email: ADMIN_EMAIL },
-      user: { email: ADMIN_EMAIL },
+      token: { sub: 'admin-id', email: ADMIN_EMAIL },
+      user: { id: 'admin-id', email: ADMIN_EMAIL },
       account: { provider: 'google' },
     })
     expect((token as Record<string, unknown>).isAdmin).toBe(true)
   })
 
-  it('устанавливает isAdmin=false для обычного email', async () => {
+  it('читает isAdmin=false из DB даже для обычного email', async () => {
+    mockDbSelect([{ id: 'user-id', isAdmin: false }])
+
     const token = await jwtCallback()({
-      token: { email: 'user@test.com' },
-      user: { email: 'user@test.com' },
+      token: { sub: 'user-id', email: 'user@test.com' },
+      user: { id: 'user-id', email: 'user@test.com' },
       account: { provider: 'google' },
     })
     expect((token as Record<string, unknown>).isAdmin).toBe(false)
   })
 
-  it('устанавливает provider из account', async () => {
+  it('bootstrap-ит ADMIN_EMAIL в isAdmin если в DB ещё нет админов', async () => {
+    const userSelect = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([{ id: 'admin-id', isAdmin: false }]),
+    }
+    const adminSelect = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([]),
+    }
+    ;(db.select as jest.Mock)
+      .mockReturnValueOnce(userSelect)
+      .mockReturnValueOnce(adminSelect)
+    mockDbUpdate()
+
     const token = await jwtCallback()({
-      token: {},
-      user: { email: 'u@t.com' },
+      token: { sub: 'admin-id', email: ADMIN_EMAIL },
+      user: { id: 'admin-id', email: ADMIN_EMAIL },
+      account: { provider: 'google' },
+    })
+
+    expect((token as Record<string, unknown>).isAdmin).toBe(true)
+    expect(db.update).toHaveBeenCalled()
+  })
+
+  it('устанавливает provider из account', async () => {
+    mockDbSelect([{ id: 'user-id', isAdmin: false }])
+
+    const token = await jwtCallback()({
+      token: { sub: 'user-id' },
+      user: { id: 'user-id', email: 'u@t.com' },
       account: { provider: 'google' },
     })
     expect((token as Record<string, unknown>).provider).toBe('google')
   })
 
   it('устанавливает telegramUsername из user', async () => {
+    mockDbSelect([{ id: 'user-id', isAdmin: false }])
+
     const token = await jwtCallback()({
-      token: {},
-      user: { email: 'u@t.com', telegramUsername: 'ivan_tg' },
+      token: { sub: 'user-id' },
+      user: { id: 'user-id', email: 'u@t.com', telegramUsername: 'ivan_tg' },
       account: { provider: 'telegram-preauth' },
     })
     expect((token as Record<string, unknown>).telegramUsername).toBe('ivan_tg')
   })
 
   it('сохраняет telegramUsername из токена если user не передаёт', async () => {
+    mockDbSelect([{ id: 'user-id', isAdmin: false }])
+
     const token = await jwtCallback()({
-      token: { telegramUsername: 'existing_tg' },
-      user: { email: 'u@t.com' },
+      token: { sub: 'user-id', telegramUsername: 'existing_tg' },
+      user: { id: 'user-id', email: 'u@t.com' },
       account: { provider: 'google' },
     })
     expect((token as Record<string, unknown>).telegramUsername).toBe('existing_tg')
@@ -294,7 +332,7 @@ describe('jwt callback', () => {
 
   it('возвращает token если пользователь есть в DB', async () => {
     delete process.env.NEXTAUTH_TEST_MODE
-    mockDbSelect([{ id: 'user-uuid' }])
+    mockDbSelect([{ id: 'user-uuid', isAdmin: false }])
 
     const result = await jwtCallback()({
       token: { email: 'active@test.com' },
@@ -383,24 +421,35 @@ describe('telegram-preauth authorize', () => {
     expect(await authorize({ uid: 'u', token: 'x', ts: '' })).toBeNull()
   })
 
-  it('возвращает null если токен протух (> 300 сек)', async () => {
-    const staleTs = String(Math.floor(Date.now() / 1000) - 400)
-    const token = buildPreauthToken('user-id', staleTs, SECRET)
+  it('возвращает null если токен протух (> 60 сек)', async () => {
+    const staleTs = String(Math.floor(Date.now() / 1000) - 90)
+    const token = 'token'
     const result = await authorize({ uid: 'user-id', token, ts: staleTs })
     expect(result).toBeNull()
   })
 
-  it('возвращает null если HMAC неверен', async () => {
+  it('возвращает null если одноразовый токен не найден или уже использован', async () => {
     const ts = String(Math.floor(Date.now() / 1000))
-    const result = await authorize({ uid: 'user-id', token: 'a'.repeat(64), ts })
+    mockPreauthConsume(false)
+
+    const result = await authorize({ uid: 'user-id', token: 'token', ts })
+
     expect(result).toBeNull()
+  })
+
+  it('возвращает null если ts не число', async () => {
+    const result = await authorize({ uid: 'user-id', token: 'token', ts: 'not-a-number' })
+
+    expect(result).toBeNull()
+    expect(db.update).not.toHaveBeenCalled()
   })
 
   it('возвращает null если пользователь не найден в DB', async () => {
     const uid = 'ghost-user'
     const ts = String(Math.floor(Date.now() / 1000))
-    const token = buildPreauthToken(uid, ts, SECRET)
+    const token = 'token'
 
+    mockPreauthConsume(true)
     mockDbSelect([])
 
     const result = await authorize({ uid, token, ts })
@@ -410,8 +459,9 @@ describe('telegram-preauth authorize', () => {
   it('возвращает пользователя при валидных данных', async () => {
     const uid = 'real-user-id'
     const ts = String(Math.floor(Date.now() / 1000))
-    const token = buildPreauthToken(uid, ts, SECRET)
+    const token = 'token'
 
+    mockPreauthConsume(true)
     mockDbSelect([{ id: uid, email: 'tg@telegram.user', name: 'Ivan' }])
 
     const result = await authorize({ uid, token, ts, username: 'ivan_tg' })
@@ -427,8 +477,9 @@ describe('telegram-preauth authorize', () => {
   it('возвращает telegramUsername=null если username не передан', async () => {
     const uid = 'user-no-username'
     const ts = String(Math.floor(Date.now() / 1000))
-    const token = buildPreauthToken(uid, ts, SECRET)
+    const token = 'token'
 
+    mockPreauthConsume(true)
     mockDbSelect([{ id: uid, email: 'tg@telegram.user', name: 'Ivan' }])
 
     const result = (await authorize({ uid, token, ts })) as Record<string, unknown>
@@ -468,6 +519,19 @@ describe('telegram provider authorize + verifyTelegramHash', () => {
 
     expect(result).toBeNull()
     process.env.TELEGRAM_BOT_TOKEN = BOT_TOKEN
+  })
+
+  it('возвращает null если auth_date старше 5 минут', async () => {
+    const data = {
+      id: '123',
+      first_name: 'Ivan',
+      auth_date: String(Math.floor(Date.now() / 1000) - 600),
+    }
+    const hash = buildTelegramHash(data, BOT_TOKEN)
+
+    const result = await authorize({ ...data, hash })
+
+    expect(result).toBeNull()
   })
 
   it('создаёт пользователя и возвращает его при валидных данных', async () => {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -113,7 +113,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         // ts is still checked to reject very old auth pages before the DB consume.
         const issuedAt = Number.parseInt(ts, 10)
         const now = Math.floor(Date.now() / 1000)
-        if (!Number.isFinite(issuedAt) || now - issuedAt > 60 || issuedAt > now + 60) return null
+        if (!Number.isFinite(issuedAt) || now - issuedAt > 5 * 60 || issuedAt > now + 60) return null
         if (!await consumeTelegramPreauthToken(uid, token)) return null
         const existing = await db.select().from(users).where(eq(users.id, uid)).limit(1)
         if (existing.length === 0) return null

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -6,11 +6,26 @@ import { DrizzleAdapter } from '@auth/drizzle-adapter'
 import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
-import { createHash, createHmac, timingSafeEqual } from 'crypto'
 import { Resend as ResendClient } from 'resend'
 import { authorizeGoogleOneTap } from '@/lib/auth.google-one-tap'
+import { consumeTelegramPreauthToken, verifyTelegramHash } from '@/lib/telegram-auth'
 
 const FROM = 'Долгое наступление <noreply@slowreading.club>'
+
+async function bootstrapAdminFromEnv(userId: string, email?: string | null) {
+  if (!email || email !== process.env.ADMIN_EMAIL) return false
+
+  const existingAdmins = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.isAdmin, true))
+    .limit(1)
+
+  if (existingAdmins.length > 0) return false
+
+  await db.update(users).set({ isAdmin: true }).where(eq(users.id, userId))
+  return true
+}
 
 function normalizeAuthProvider(provider: string) {
   return provider === 'resend' ? 'email' : provider
@@ -67,20 +82,6 @@ async function sendMagicLinkEmail(email: string, url: string) {
   })
 }
 
-function verifyTelegramHash(data: Record<string, string>): boolean {
-  if (!process.env.TELEGRAM_BOT_TOKEN) return false
-  const { hash, ...rest } = data
-  if (!hash) return false
-  const dataCheckString = Object.keys(rest).sort().map(k => `${k}=${rest[k]}`).join('\n')
-  const secret = createHash('sha256').update(process.env.TELEGRAM_BOT_TOKEN).digest()
-  const expected = createHmac('sha256', secret).update(dataCheckString).digest('hex')
-  try {
-    return timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(expected, 'hex'))
-  } catch {
-    return false
-  }
-}
-
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: DrizzleAdapter(db),
   providers: [
@@ -109,14 +110,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       async authorize(credentials) {
         const { uid, token, ts, username } = credentials as { uid: string; token: string; ts: string; username?: string }
         if (!uid || !token || !ts) return null
-        // Verify HMAC and freshness (5 min window)
-        if (Date.now() / 1000 - parseInt(ts) > 300) return null
-        const secret = process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET
-        if (!secret) return null
-        const expected = createHmac('sha256', secret).update(`${uid}:${ts}`).digest('hex')
-        try {
-          if (!timingSafeEqual(Buffer.from(token, 'hex'), Buffer.from(expected, 'hex'))) return null
-        } catch { return null }
+        // ts is still checked to reject very old auth pages before the DB consume.
+        const issuedAt = Number.parseInt(ts, 10)
+        const now = Math.floor(Date.now() / 1000)
+        if (!Number.isFinite(issuedAt) || now - issuedAt > 60 || issuedAt > now + 60) return null
+        if (!await consumeTelegramPreauthToken(uid, token)) return null
         const existing = await db.select().from(users).where(eq(users.id, uid)).limit(1)
         if (existing.length === 0) return null
         const user = existing[0]
@@ -162,12 +160,28 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
     async jwt({ token, user, account }) {
       if (user) {
-        token.isAdmin = user.email === process.env.ADMIN_EMAIL
         token.telegramUsername = user.telegramUsername ?? token.telegramUsername
         token.provider = account?.provider ?? token.provider
-      } else if (token.email && process.env.NEXTAUTH_TEST_MODE !== 'true') {
-        const existing = await db.select({ id: users.id }).from(users).where(eq(users.email, token.email)).limit(1)
+      }
+
+      if (process.env.NEXTAUTH_TEST_MODE === 'true') {
+        if (user && token.isAdmin === undefined) token.isAdmin = false
+        return token
+      }
+
+      const userId = (user?.id ?? token.sub) as string | undefined
+      const email = (user?.email ?? token.email) as string | undefined
+      if (userId || email) {
+        const existing = await db
+          .select({ id: users.id, isAdmin: users.isAdmin })
+          .from(users)
+          .where(userId ? eq(users.id, userId) : eq(users.email, email!))
+          .limit(1)
         if (existing.length === 0) return null
+        token.isAdmin = existing[0].isAdmin
+        if (!token.isAdmin) {
+          token.isAdmin = await bootstrapAdminFromEnv(existing[0].id, email)
+        }
       }
       return token
     },

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -15,6 +15,7 @@ export const users = pgTable('user', {
   lastSignInAt: timestamp('last_sign_in_at', { mode: 'date' }),
   languages: text('languages'),
   prioritiesSet: boolean('priorities_set').notNull().default(false),
+  isAdmin: boolean('is_admin').notNull().default(false),
 })
 
 export const accounts = pgTable('account', {
@@ -133,4 +134,15 @@ export const notificationQueue = pgTable('notification_queue', {
   sentAt:       timestamp('sent_at', { mode: 'date' }),        // NULL = unsent; NOT NULL = sent
 }, (t) => ({
   sentAtIdx: index('notification_queue_sent_at_idx').on(t.sentAt),
+}))
+
+export const telegramPreauthTokens = pgTable('telegram_preauth_tokens', {
+  tokenHash: text('token_hash').primaryKey(),
+  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  expiresAt: timestamp('expires_at', { mode: 'date' }).notNull(),
+  usedAt: timestamp('used_at', { mode: 'date' }),
+  createdAt: timestamp('created_at', { mode: 'date' }).notNull().defaultNow(),
+}, (t) => ({
+  userIdIdx: index('telegram_preauth_tokens_user_id_idx').on(t.userId),
+  expiresAtIdx: index('telegram_preauth_tokens_expires_at_idx').on(t.expiresAt),
 }))

--- a/lib/telegram-auth.ts
+++ b/lib/telegram-auth.ts
@@ -1,0 +1,65 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'crypto'
+import { and, eq, gt, isNull, lt } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { telegramPreauthTokens } from '@/lib/db/schema'
+
+export const TELEGRAM_AUTH_MAX_AGE_SECONDS = 5 * 60
+export const TELEGRAM_PREAUTH_TTL_SECONDS = 60
+
+function safeEqualHex(left: string, right: string) {
+  try {
+    return timingSafeEqual(Buffer.from(left, 'hex'), Buffer.from(right, 'hex'))
+  } catch {
+    return false
+  }
+}
+
+export function verifyTelegramHash(data: Record<string, string>, now = Math.floor(Date.now() / 1000)): boolean {
+  if (!process.env.TELEGRAM_BOT_TOKEN) return false
+  const { hash, ...rest } = data
+  if (!hash) return false
+
+  const authDate = Number.parseInt(rest.auth_date ?? '', 10)
+  if (!Number.isFinite(authDate)) return false
+  if (now - authDate > TELEGRAM_AUTH_MAX_AGE_SECONDS || authDate > now + 60) return false
+
+  const dataCheckString = Object.keys(rest).sort().map(k => `${k}=${rest[k]}`).join('\n')
+  const secret = createHash('sha256').update(process.env.TELEGRAM_BOT_TOKEN).digest()
+  const expected = createHmac('sha256', secret).update(dataCheckString).digest('hex')
+  return safeEqualHex(hash, expected)
+}
+
+export function hashTelegramPreauthToken(token: string) {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+export async function createTelegramPreauthToken(userId: string, now = new Date()) {
+  const token = randomBytes(32).toString('hex')
+  const tokenHash = hashTelegramPreauthToken(token)
+  const expiresAt = new Date(now.getTime() + TELEGRAM_PREAUTH_TTL_SECONDS * 1000)
+
+  await db.insert(telegramPreauthTokens).values({ tokenHash, userId, expiresAt })
+  return { token, expiresAt }
+}
+
+export async function consumeTelegramPreauthToken(userId: string, token: string, now = new Date()) {
+  const tokenHash = hashTelegramPreauthToken(token)
+  const [row] = await db
+    .update(telegramPreauthTokens)
+    .set({ usedAt: now })
+    .where(and(
+      eq(telegramPreauthTokens.tokenHash, tokenHash),
+      eq(telegramPreauthTokens.userId, userId),
+      isNull(telegramPreauthTokens.usedAt),
+      gt(telegramPreauthTokens.expiresAt, now)
+    ))
+    .returning({ userId: telegramPreauthTokens.userId })
+
+  return Boolean(row)
+}
+
+export async function cleanupTelegramPreauthTokens(now = new Date()) {
+  await db
+    .delete(telegramPreauthTokens)
+    .where(lt(telegramPreauthTokens.expiresAt, now))
+}

--- a/lib/telegram-auth.ts
+++ b/lib/telegram-auth.ts
@@ -4,7 +4,7 @@ import { db } from '@/lib/db'
 import { telegramPreauthTokens } from '@/lib/db/schema'
 
 export const TELEGRAM_AUTH_MAX_AGE_SECONDS = 5 * 60
-export const TELEGRAM_PREAUTH_TTL_SECONDS = 60
+export const TELEGRAM_PREAUTH_TTL_SECONDS = 5 * 60
 
 function safeEqualHex(left: string, right: string) {
   try {

--- a/lib/test-mode.ts
+++ b/lib/test-mode.ts
@@ -1,0 +1,3 @@
+export function isTestEndpointAllowed() {
+  return process.env.NODE_ENV !== 'production' && process.env.NEXTAUTH_TEST_MODE === 'true'
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,8 @@
-{}
+{
+  "crons": [
+    {
+      "path": "/api/cron/telegram-preauth-cleanup",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Move admin authority to users.is_admin with env bootstrap only when no DB admin exists
- Add Telegram auth freshness checks and one-time preauth token storage/consume flow
- Block all /api/test/* endpoints in production and remove runtime DDL from book-status API
- Add cleanup cron for expired Telegram preauth tokens

## Issues
Addresses #94
Addresses #95
Addresses #96
Addresses #98

## Verification
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- npm run test:e2e -- e2e/telegram-auth.spec.ts
- npm run test:e2e -- e2e/admin.spec.ts

E2E: нужен — менялась Telegram/auth chain и модель admin-доступа.