### PR TITLE
fix: set authProvider for email magic link when account is null

### DIFF
--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -218,6 +218,20 @@ describe('signIn callback', () => {
     expect(updateChain.where).toHaveBeenCalled()
   })
 
+  it('пишет authProvider=email если account отсутствует (Resend magic link)', async () => {
+    const updateChain = mockDbUpdate()
+
+    await signInCallback()({
+      user: { id: 'user-uuid', email: 'magic@test.com' },
+      account: null,
+    })
+
+    expect(updateChain.set).toHaveBeenCalledWith(expect.objectContaining({
+      authProvider: 'email',
+      lastSignInAt: expect.any(Date),
+    }))
+  })
+
   it('не перетирает telegram_username пустым значением', async () => {
     const updateChain = mockDbUpdate()
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -148,8 +148,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   callbacks: {
     async signIn({ user, account }) {
       const userId = user.id
-      if ((userId || user.email) && account?.provider) {
-        const provider = normalizeAuthProvider(account.provider)
+      if (userId || user.email) {
+        // account is null for email magic link (Resend doesn't create an accounts row)
+        const provider = account?.provider ? normalizeAuthProvider(account.provider) : 'email'
         await db.update(users).set({
           authProvider: provider,
           lastSignInAt: new Date(),


### PR DESCRIPTION
## Summary
- `signIn` callback не выставлял `authProvider` и `lastSignInAt` для новых email-пользователей (Resend magic link), потому что Auth.js v5 передаёт `account = null` для email-провайдеров
- Убрал `account?.provider` из условия-гейта, добавил дефолт `'email'` когда account отсутствует
- Добавил тест на кейс `account: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)