### PR TITLE
Add book cover collage to OG social preview

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,8 +1,30 @@
 import { ImageResponse } from 'next/og'
+import { fetchBooks } from '@/lib/sheets'
 
-export const runtime = 'edge'
+export const runtime = 'nodejs'
+
+const COVER_W = 168
+const COVER_H = 235
+const GAP = 10
+
+function pickRandom<T>(arr: T[], n: number): T[] {
+  const shuffled = [...arr].sort(() => Math.random() - 0.5)
+  return shuffled.slice(0, n)
+}
 
 export async function GET() {
+  let coverUrls: string[] = []
+
+  try {
+    const books = await fetchBooks()
+    const withCovers = books.filter(b => b.coverUrl)
+    coverUrls = pickRandom(withCovers, 6).map(b => b.coverUrl!)
+  } catch {
+    // fall through to text-only
+  }
+
+  const hasCovers = coverUrls.length >= 3
+
   return new ImageResponse(
     (
       <div
@@ -10,90 +32,153 @@ export async function GET() {
           width: '1200px',
           height: '630px',
           display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'flex-start',
+          flexDirection: 'row',
           background: '#F5F0E8',
-          padding: '80px 100px',
-          position: 'relative',
         }}
       >
-        {/* Decorative vertical line */}
+        {/* Left panel */}
         <div
           style={{
-            position: 'absolute',
-            left: '60px',
-            top: '80px',
-            bottom: '80px',
-            width: '3px',
-            background: '#C0603A',
-          }}
-        />
-
-        {/* Eyebrow */}
-        <div
-          style={{
-            fontFamily: 'serif',
-            fontSize: '18px',
-            letterSpacing: '0.18em',
-            textTransform: 'uppercase',
-            color: '#999',
-            marginBottom: '24px',
+            width: hasCovers ? '680px' : '1200px',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            padding: '72px 72px 60px 80px',
+            borderLeft: '3px solid #C0603A',
+            marginLeft: '48px',
           }}
         >
-          Читательские круги
+          {/* Top area: eyebrow + title + description */}
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div
+              style={{
+                fontFamily: 'serif',
+                fontSize: '17px',
+                letterSpacing: '0.18em',
+                textTransform: 'uppercase',
+                color: '#999',
+                marginBottom: '22px',
+                display: 'flex',
+              }}
+            >
+              Читательские круги
+            </div>
+
+            <div
+              style={{
+                fontFamily: 'serif',
+                fontWeight: 700,
+                fontSize: hasCovers ? '74px' : '88px',
+                lineHeight: 1.05,
+                color: '#111',
+                letterSpacing: '-0.02em',
+                marginBottom: '28px',
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              <span>Долгое</span>
+              <span>наступление</span>
+            </div>
+
+            <div
+              style={{
+                fontFamily: 'serif',
+                fontStyle: 'italic',
+                fontSize: '22px',
+                lineHeight: 1.5,
+                color: '#555',
+                display: 'flex',
+              }}
+            >
+              Записывайтесь на совместное чтение
+              {!hasCovers ? ' и обсуждение книг' : ''}
+            </div>
+          </div>
+
+          {/* Bottom: domain */}
+          <div
+            style={{
+              fontFamily: 'serif',
+              fontSize: '17px',
+              color: '#C0603A',
+              letterSpacing: '0.04em',
+              display: 'flex',
+            }}
+          >
+            slowreading.club
+          </div>
         </div>
 
-        {/* Title */}
-        <div
-          style={{
-            fontFamily: 'serif',
-            fontWeight: 700,
-            fontSize: '88px',
-            lineHeight: 1.1,
-            color: '#111',
-            letterSpacing: '-0.02em',
-            marginBottom: '32px',
-          }}
-        >
-          Долгое
-          <br />
-          наступление
-        </div>
-
-        {/* Description */}
-        <div
-          style={{
-            fontFamily: 'serif',
-            fontStyle: 'italic',
-            fontSize: '26px',
-            lineHeight: 1.5,
-            color: '#555',
-            maxWidth: '700px',
-          }}
-        >
-          Записывайтесь на совместное чтение и обсуждение книг
-        </div>
-
-        {/* Bottom domain */}
-        <div
-          style={{
-            position: 'absolute',
-            bottom: '56px',
-            right: '100px',
-            fontFamily: 'serif',
-            fontSize: '18px',
-            color: '#C0603A',
-            letterSpacing: '0.04em',
-          }}
-        >
-          slowreading.club
-        </div>
+        {/* Right panel: book covers */}
+        {hasCovers && (
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: '32px 32px 32px 24px',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                gap: `${GAP}px`,
+              }}
+            >
+              {/* Column 1: covers 0, 2, 4 */}
+              <div style={{ display: 'flex', flexDirection: 'column', gap: `${GAP}px` }}>
+                {[0, 2, 4].map(i =>
+                  coverUrls[i] ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      key={i}
+                      src={coverUrls[i]}
+                      alt=""
+                      width={COVER_W}
+                      height={COVER_H}
+                      style={{
+                        objectFit: 'cover',
+                        borderRadius: '3px',
+                        boxShadow: '0 3px 12px rgba(0,0,0,0.2)',
+                      }}
+                    />
+                  ) : null
+                )}
+              </div>
+              {/* Column 2: covers 1, 3, 5 */}
+              <div style={{ display: 'flex', flexDirection: 'column', gap: `${GAP}px` }}>
+                {[1, 3, 5].map(i =>
+                  coverUrls[i] ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      key={i}
+                      src={coverUrls[i]}
+                      alt=""
+                      width={COVER_W}
+                      height={COVER_H}
+                      style={{
+                        objectFit: 'cover',
+                        borderRadius: '3px',
+                        boxShadow: '0 3px 12px rgba(0,0,0,0.2)',
+                      }}
+                    />
+                  ) : null
+                )}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     ),
     {
       width: 1200,
       height: 630,
+      headers: {
+        'Cache-Control': 'public, max-age=21600, s-maxage=21600',
+      },
     }
   )
 }


### PR DESCRIPTION
## Summary
- Switches `/api/og` from edge to Node.js runtime to enable `fetchBooks()` calls
- Renders a 2×3 grid of random book covers (from Google Sheets `coverUrl`) on the right side of the OG image
- Graceful fallback to text-only layout if fewer than 3 covers available or Sheets unreachable
- Cache-Control: 6 hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)