### PR TITLE
feat: exclude owner from PostHog analytics

### DIFF
--- a/components/PostHogProvider.tsx
+++ b/components/PostHogProvider.tsx
@@ -23,12 +23,13 @@ function PageviewTracker() {
 function IdentityTracker() {
   const { data: session, status } = useSession()
   const userId = session?.user?.id
+  const isExcluded = session?.user?.isExcludedFromAnalytics
 
   useEffect(() => {
     if (status === 'loading') return
-    if (userId) identifyUser(userId)
+    if (userId) identifyUser(userId, isExcluded)
     else resetIdentity()
-  }, [userId, status])
+  }, [userId, isExcluded, status])
 
   return null
 }

--- a/components/nd/AdminFooter.tsx
+++ b/components/nd/AdminFooter.tsx
@@ -6,6 +6,7 @@ import AdminStatusBar from './AdminStatusBar'
 import DigestStatusWidget from './DigestStatusWidget'
 import AllureWidget from './AllureWidget'
 import PostHogUsageWidget from './PostHogUsageWidget'
+import AnalyticsOptOutWidget from './AnalyticsOptOutWidget'
 
 interface AdminFooterProps {
   buildTime: string | null
@@ -95,6 +96,7 @@ export default function AdminFooter({
       <DigestStatusWidget refreshSignal={refreshSignal} />
       <AllureWidget refreshSignal={refreshSignal} />
       <PostHogUsageWidget refreshSignal={refreshSignal} />
+      <AnalyticsOptOutWidget />
     </footer>
   )
 }

--- a/components/nd/AnalyticsOptOutWidget.tsx
+++ b/components/nd/AnalyticsOptOutWidget.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+
+type Status = 'loading' | 'opted_out' | 'tracking'
+
+export default function AnalyticsOptOutWidget() {
+  const [status, setStatus] = useState<Status>('loading')
+
+  useEffect(() => {
+    setStatus(posthog.has_opted_out_capturing() ? 'opted_out' : 'tracking')
+  }, [])
+
+  function optOut() {
+    posthog.opt_out_capturing()
+    setStatus('opted_out')
+  }
+
+  function optIn() {
+    posthog.opt_in_capturing()
+    setStatus('tracking')
+  }
+
+  const containerStyle: React.CSSProperties = {
+    border: '1px solid #E5E5E5',
+    background: '#fff',
+    padding: '0.75rem 1rem',
+    fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+  }
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: '0.6rem',
+    textTransform: 'uppercase',
+    letterSpacing: '0.12em',
+    color: '#999',
+    marginBottom: '0.5rem',
+  }
+
+  const buttonStyle: React.CSSProperties = {
+    fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+    fontSize: '0.68rem',
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    cursor: 'pointer',
+    padding: '0.3rem 0.6rem',
+    border: '1px solid #111',
+    background: '#fff',
+    color: '#222',
+  }
+
+  return (
+    <div style={containerStyle}>
+      <div style={labelStyle}>PostHog · этот браузер</div>
+      {status === 'loading' && (
+        <div style={{ fontSize: '0.85rem', color: '#999' }}>Проверяем…</div>
+      )}
+      {status === 'opted_out' && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+          <span style={{ fontSize: '0.85rem', color: '#2D6A4F' }}>
+            ✓ Аналитика отключена — визиты с этого браузера не считаются
+          </span>
+          <button type="button" onClick={optIn} style={{ ...buttonStyle, color: '#999', borderColor: '#ccc' }}>
+            Включить обратно
+          </button>
+        </div>
+      )}
+      {status === 'tracking' && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+          <span style={{ fontSize: '0.85rem', color: '#C0603A' }}>
+            ✗ Аналитика включена — визиты с этого браузера попадают в статистику
+          </span>
+          <button type="button" onClick={optOut} style={buttonStyle}>
+            Отключить для этого браузера
+          </button>
+        </div>
+      )}
+      {status === 'tracking' && (
+        <div style={{ fontSize: '0.7rem', color: '#999', marginTop: '0.4rem' }}>
+          После отключения статус сохраняется навсегда в этом браузере — даже без логина и при смене аккаунта. При очистке кэша/куки нужно нажать снова.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/e2e/admin-book-status.spec.ts
+++ b/e2e/admin-book-status.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const ADMIN_EMAIL = 'e2e-bookstatus-admin@test.invalid'

--- a/e2e/admin-delete-user.spec.ts
+++ b/e2e/admin-delete-user.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const ADMIN_EMAIL = 'e2e-admin-delete-test@test.invalid'

--- a/e2e/admin-footer-widgets.spec.ts
+++ b/e2e/admin-footer-widgets.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const ADMIN_EMAIL = 'e2e-admin-footer@test.invalid'

--- a/e2e/admin-intro.spec.ts
+++ b/e2e/admin-intro.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const ADMIN_EMAIL = 'e2e-intro-admin@test.invalid'

--- a/e2e/admin-users.spec.ts
+++ b/e2e/admin-users.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const ADMIN_NAME = 'E2E Admin Users Admin'

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 // /admin перенаправляет на / если session.user.isAdmin !== true.

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const TEST_EMAIL = 'e2e-auth@test.invalid'

--- a/e2e/book-card.spec.ts
+++ b/e2e/book-card.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 // BookCard показывает кнопку «Читать далее» только когда description.length > 120.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,20 @@
+import { test as base, expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+const POSTHOG_PATTERNS = [
+  '**/eu.i.posthog.com/**',
+  '**/eu.posthog.com/**',
+  '**/app.posthog.com/**',
+]
+
+export const test = base.extend({
+  context: async ({ context }, use) => {
+    for (const pattern of POSTHOG_PATTERNS) {
+      await context.route(pattern, (route) => route.abort())
+    }
+    await use(context)
+  },
+})
+
+export { expect }
+export type { Page }

--- a/e2e/priority-hint.spec.ts
+++ b/e2e/priority-hint.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const TEST_NAME_BASE = 'E2E Priority Hint'

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const EMAIL = 'e2e-profile-test@test.invalid'

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 test.describe('поиск по книгам', () => {

--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const TEST_EMAIL = 'e2e-signup@test.invalid'

--- a/e2e/submit-book.spec.ts
+++ b/e2e/submit-book.spec.ts
@@ -1,4 +1,4 @@
-import { type Page, test, expect } from '@playwright/test'
+import { type Page, test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const TEST_EMAIL = 'e2e-submit@test.invalid'

--- a/e2e/tags-admin.spec.ts
+++ b/e2e/tags-admin.spec.ts
@@ -10,7 +10,7 @@
  *
  * После теста описание восстанавливается к исходному значению.
  */
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 
 const TEST_EMAIL = 'e2e-tags-admin@test.invalid'
 const TEST_NAME = 'E2E Tags Admin'

--- a/e2e/telegram-auth.spec.ts
+++ b/e2e/telegram-auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 const TG_EMAIL = 'e2e-telegram-test@test.invalid'

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 // Тема переключения в текущей версии не реализована в UI.

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 async function isFullyAboveViewport(page: import('@playwright/test').Page, selector: string) {

--- a/e2e/view-mode.spec.ts
+++ b/e2e/view-mode.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
 // localStorage key: 'book_view_mode', values: 'grid' | 'list'

--- a/env.ts
+++ b/env.ts
@@ -16,6 +16,7 @@ export const env = createEnv({
     GH_TOKEN: z.string().min(1).optional(),
     VERCEL_TOKEN: z.string().min(1).optional(),
     NEXTAUTH_TEST_MODE: z.string().optional(),
+    POSTHOG_OWNER_EMAILS: z.string().optional(),
   },
   client: {
     NEXT_PUBLIC_GOOGLE_CLIENT_ID: z.string().min(1),
@@ -35,6 +36,7 @@ export const env = createEnv({
     GH_TOKEN: process.env.GH_TOKEN,
     VERCEL_TOKEN: process.env.VERCEL_TOKEN,
     NEXTAUTH_TEST_MODE: process.env.NEXTAUTH_TEST_MODE,
+    POSTHOG_OWNER_EMAILS: process.env.POSTHOG_OWNER_EMAILS,
     NEXT_PUBLIC_GOOGLE_CLIENT_ID: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
     NEXT_PUBLIC_TELEGRAM_BOT_NAME: process.env.NEXT_PUBLIC_TELEGRAM_BOT_NAME,
   },

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -1,0 +1,124 @@
+// Override the global analytics mock from jest.setup.ts so we can test the real implementation
+jest.unmock('@/lib/analytics')
+
+import posthog from 'posthog-js'
+import {
+  initPostHog,
+  identifyUser,
+  resetIdentity,
+  __resetForTesting,
+} from './analytics'
+
+jest.mock('posthog-js', () => ({
+  init: jest.fn(),
+  capture: jest.fn(),
+  identify: jest.fn(),
+  reset: jest.fn(),
+  opt_out_capturing: jest.fn(),
+  opt_in_capturing: jest.fn(),
+  has_opted_out_capturing: jest.fn(() => false),
+}))
+
+beforeEach(() => {
+  __resetForTesting()
+  jest.clearAllMocks()
+})
+
+describe('initPostHog', () => {
+  it('does not initialise when NEXT_PUBLIC_DISABLE_ANALYTICS is set', () => {
+    process.env.NEXT_PUBLIC_DISABLE_ANALYTICS = 'true'
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = 'phc_test'
+    initPostHog()
+    expect(posthog.init).not.toHaveBeenCalled()
+    delete process.env.NEXT_PUBLIC_DISABLE_ANALYTICS
+  })
+
+  it('does not initialise when token is missing', () => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+    initPostHog()
+    expect(posthog.init).not.toHaveBeenCalled()
+  })
+})
+
+describe('identifyUser — opt-out for excluded IDs', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = 'phc_test'
+    process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS = 'owner-uuid-1,owner-uuid-2'
+    initPostHog()
+  })
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS
+  })
+
+  it('calls opt_out_capturing when userId is in excluded list', () => {
+    identifyUser('owner-uuid-1')
+    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
+    expect(posthog.identify).not.toHaveBeenCalled()
+  })
+
+  it('calls opt_out_capturing for the second excluded ID', () => {
+    identifyUser('owner-uuid-2')
+    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call opt_out_capturing twice when identifyUser called twice with same excluded ID', () => {
+    identifyUser('owner-uuid-1')
+    identifyUser('owner-uuid-1')
+    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call opt_out_capturing for a regular user', () => {
+    identifyUser('regular-user-uuid')
+    expect(posthog.opt_out_capturing).not.toHaveBeenCalled()
+    expect(posthog.identify).toHaveBeenCalledWith('regular-user-uuid')
+  })
+
+  it('does NOT call opt_out_capturing when env var is not set', () => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS
+    identifyUser('owner-uuid-1')
+    expect(posthog.opt_out_capturing).not.toHaveBeenCalled()
+  })
+
+  it('handles empty EXCLUDED_USER_IDS env var without matching anything', () => {
+    process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS = ''
+    identifyUser('owner-uuid-1')
+    expect(posthog.opt_out_capturing).not.toHaveBeenCalled()
+  })
+
+  it('handles env var with spaces around commas', () => {
+    process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS = ' owner-uuid-1 , owner-uuid-2 '
+    identifyUser('owner-uuid-1')
+    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('identifyUser — lazy initPostHog (race condition fix)', () => {
+  it('initialises PostHog internally so opt-out works even if initPostHog was not called before', () => {
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = 'phc_test'
+    process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS = 'owner-uuid-1'
+    // Do NOT call initPostHog() — simulate the race where child effect fires first
+    identifyUser('owner-uuid-1')
+    expect(posthog.init).toHaveBeenCalledTimes(1)
+    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
+    delete process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS
+  })
+})
+
+describe('resetIdentity — never re-enables capturing', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = 'phc_test'
+    initPostHog()
+    identifyUser('some-user')
+  })
+
+  it('does not call opt_in_capturing on reset', () => {
+    resetIdentity()
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled()
+  })
+
+  it('calls posthog.reset on reset', () => {
+    resetIdentity()
+    expect(posthog.reset).toHaveBeenCalled()
+  })
+})

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -40,68 +40,44 @@ describe('initPostHog', () => {
   })
 })
 
-describe('identifyUser — opt-out for excluded IDs', () => {
+describe('identifyUser — opt-out via isExcluded flag', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = 'phc_test'
-    process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS = 'owner-uuid-1,owner-uuid-2'
     initPostHog()
   })
 
-  afterEach(() => {
-    delete process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS
-  })
-
-  it('calls opt_out_capturing when userId is in excluded list', () => {
-    identifyUser('owner-uuid-1')
+  it('calls opt_out_capturing when isExcluded is true', () => {
+    identifyUser('owner-uuid-1', true)
     expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
     expect(posthog.identify).not.toHaveBeenCalled()
   })
 
-  it('calls opt_out_capturing for the second excluded ID', () => {
-    identifyUser('owner-uuid-2')
+  it('does not call opt_out_capturing twice when identifyUser called twice with same userId and isExcluded', () => {
+    identifyUser('owner-uuid-1', true)
+    identifyUser('owner-uuid-1', true)
     expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
   })
 
-  it('does not call opt_out_capturing twice when identifyUser called twice with same excluded ID', () => {
-    identifyUser('owner-uuid-1')
-    identifyUser('owner-uuid-1')
-    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
-  })
-
-  it('does NOT call opt_out_capturing for a regular user', () => {
-    identifyUser('regular-user-uuid')
+  it('does NOT call opt_out_capturing when isExcluded is false', () => {
+    identifyUser('regular-user-uuid', false)
     expect(posthog.opt_out_capturing).not.toHaveBeenCalled()
     expect(posthog.identify).toHaveBeenCalledWith('regular-user-uuid')
   })
 
-  it('does NOT call opt_out_capturing when env var is not set', () => {
-    delete process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS
-    identifyUser('owner-uuid-1')
+  it('does NOT call opt_out_capturing when isExcluded is undefined', () => {
+    identifyUser('regular-user-uuid')
     expect(posthog.opt_out_capturing).not.toHaveBeenCalled()
-  })
-
-  it('handles empty EXCLUDED_USER_IDS env var without matching anything', () => {
-    process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS = ''
-    identifyUser('owner-uuid-1')
-    expect(posthog.opt_out_capturing).not.toHaveBeenCalled()
-  })
-
-  it('handles env var with spaces around commas', () => {
-    process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS = ' owner-uuid-1 , owner-uuid-2 '
-    identifyUser('owner-uuid-1')
-    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
+    expect(posthog.identify).toHaveBeenCalledWith('regular-user-uuid')
   })
 })
 
 describe('identifyUser — lazy initPostHog (race condition fix)', () => {
   it('initialises PostHog internally so opt-out works even if initPostHog was not called before', () => {
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = 'phc_test'
-    process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS = 'owner-uuid-1'
     // Do NOT call initPostHog() — simulate the race where child effect fires first
-    identifyUser('owner-uuid-1')
+    identifyUser('owner-uuid-1', true)
     expect(posthog.init).toHaveBeenCalledTimes(1)
     expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1)
-    delete process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS
   })
 })
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -5,8 +5,14 @@ type EventProps = Record<string, string | number | boolean | undefined | null>
 let initialized = false
 let currentIdentity: string | null = null
 
+function getExcludedIds(): Set<string> {
+  const raw = process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS ?? ''
+  return new Set(raw.split(',').map((s) => s.trim()).filter(Boolean))
+}
+
 export function initPostHog(): void {
   if (initialized || typeof window === 'undefined') return
+  if (process.env.NEXT_PUBLIC_DISABLE_ANALYTICS === 'true') return
   const key = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
   if (!key) return
   posthog.init(key, {
@@ -34,8 +40,15 @@ export function capturePageview(url: string): void {
 }
 
 export function identifyUser(userId: string): void {
-  if (typeof window === 'undefined' || !initialized) return
+  if (typeof window === 'undefined') return
+  initPostHog() // ensure init before identify, even if parent useEffect hasn't fired yet
+  if (!initialized) return
   if (currentIdentity === userId) return
+  if (getExcludedIds().has(userId)) {
+    posthog.opt_out_capturing()
+    currentIdentity = userId // prevent duplicate calls on re-render
+    return
+  }
   posthog.identify(userId)
   currentIdentity = userId
 }
@@ -44,5 +57,13 @@ export function resetIdentity(): void {
   if (typeof window === 'undefined' || !initialized) return
   if (currentIdentity === null) return
   posthog.reset()
+  currentIdentity = null
+  // Intentionally NOT calling opt_in_capturing() here.
+  // Once a browser is opted out (owner's browser), it stays opted out
+  // permanently regardless of which account is used next.
+}
+
+export function __resetForTesting(): void {
+  initialized = false
   currentIdentity = null
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -5,11 +5,6 @@ type EventProps = Record<string, string | number | boolean | undefined | null>
 let initialized = false
 let currentIdentity: string | null = null
 
-function getExcludedIds(): Set<string> {
-  const raw = process.env.NEXT_PUBLIC_POSTHOG_EXCLUDED_USER_IDS ?? ''
-  return new Set(raw.split(',').map((s) => s.trim()).filter(Boolean))
-}
-
 export function initPostHog(): void {
   if (initialized || typeof window === 'undefined') return
   if (process.env.NEXT_PUBLIC_DISABLE_ANALYTICS === 'true') return
@@ -39,12 +34,12 @@ export function capturePageview(url: string): void {
   posthog.capture('$pageview', { $current_url: url })
 }
 
-export function identifyUser(userId: string): void {
+export function identifyUser(userId: string, isExcluded?: boolean): void {
   if (typeof window === 'undefined') return
   initPostHog() // ensure init before identify, even if parent useEffect hasn't fired yet
   if (!initialized) return
   if (currentIdentity === userId) return
-  if (getExcludedIds().has(userId)) {
+  if (isExcluded) {
     posthog.opt_out_capturing()
     currentIdentity = userId // prevent duplicate calls on re-render
     return

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -183,6 +183,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         if (!token.isAdmin) {
           token.isAdmin = await bootstrapAdminFromEnv(existing[0].id, email)
         }
+        const ownerEmails = (process.env.POSTHOG_OWNER_EMAILS ?? '').split(',').map(s => s.trim()).filter(Boolean)
+        token.isExcludedFromAnalytics = ownerEmails.length > 0 && ownerEmails.includes(email ?? '')
       }
       return token
     },
@@ -190,6 +192,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (session.user) {
         if (token.sub) session.user.id = token.sub
         session.user.isAdmin = token.isAdmin as boolean | undefined
+        session.user.isExcludedFromAnalytics = token.isExcludedFromAnalytics as boolean | undefined
         session.user.telegramUsername = token.telegramUsername
         session.user.provider = token.provider
       }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     timeout: 120_000,
     env: {
       NEXTAUTH_TEST_MODE: 'true',
+      NEXT_PUBLIC_DISABLE_ANALYTICS: 'true',
     },
   },
 })

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -5,6 +5,7 @@ declare module 'next-auth' {
     user: {
       id?: string
       isAdmin?: boolean
+      isExcludedFromAnalytics?: boolean
       telegramUsername?: string | null
       provider?: string | null
     } & DefaultSession['user']
@@ -17,6 +18,7 @@ declare module 'next-auth' {
 declare module '@auth/core/jwt' {
   interface JWT {
     isAdmin?: boolean
+    isExcludedFromAnalytics?: boolean
     telegramUsername?: string | null
     provider?: string | null
   }


### PR DESCRIPTION
## Summary

- Добавлена серверная переменная `POSTHOG_OWNER_EMAILS` — email владельца проверяется в JWT callback, флаг `isExcludedFromAnalytics` передаётся через сессию (не попадает в клиентский бандл)
- `identifyUser(userId, isExcluded?)` принимает булев флаг вместо проверки ID по `NEXT_PUBLIC_*` переменной
- Добавлен виджет **PostHog · этот браузер** в подвал админки — показывает статус opt-out для текущего браузера, кнопка отключает трекинг навсегда в localStorage (работает без логина, при смене аккаунта)
- Playwright: env `NEXT_PUBLIC_DISABLE_ANALYTICS=true` + блокировка PostHog-запросов на сетевом уровне через фикстуру

Closes #115

## Test plan

- [ ] Войти под `bon2362@gmail.com` → убедиться что PostHog не получает события
- [ ] Зайти на `/admin` → в подвале появился виджет со статусом браузера
- [ ] Нажать "Отключить для этого браузера" → статус меняется на зелёный
- [ ] Очистить кэш → статус снова красный, кнопка напоминает нажать

🤖 Generated with [Claude Code](https://claude.com/claude-code)