### PR TITLE
Add identity-based auth resolution

### DIFF
--- a/app/api/auth/telegram/callback/route.test.ts
+++ b/app/api/auth/telegram/callback/route.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  *
  * Unit-тесты для GET /api/auth/telegram/callback — route handler.
- * Проверяет: создание пользователя в БД, генерацию pre-auth токена,
+ * Проверяет: создание/поиск пользователя через identity helper, генерацию pre-auth токена,
  * redirect на /auth/telegram, отклонение невалидного HMAC.
  */
 import { NextRequest } from 'next/server'
@@ -18,6 +18,12 @@ jest.mock('@/lib/db', () => ({
     }),
   },
 }))
+
+jest.mock('@/lib/user-identities', () => ({
+  resolveOrCreateUserFromIdentity: jest.fn(),
+}))
+
+import { resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 const BOT_TOKEN = 'test-telegram-bot-token'
 const SECRET = 'test-auth-secret-that-is-long-enough-32'
@@ -54,6 +60,12 @@ describe('GET /api/auth/telegram/callback', () => {
   beforeEach(() => {
     process.env.TELEGRAM_BOT_TOKEN = BOT_TOKEN
     process.env.NEXTAUTH_SECRET = SECRET
+    ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
+      id: 'canonical-uuid',
+      email: 'telegram:123456789@telegram.user',
+      name: 'Иван Петров',
+      telegramUsername: 'ivanp',
+    })
     jest.clearAllMocks()
   })
 
@@ -62,7 +74,7 @@ describe('GET /api/auth/telegram/callback', () => {
     delete process.env.NEXTAUTH_SECRET
   })
 
-  it('создаёт пользователя в БД и редиректит на /auth/telegram при валидном HMAC', async () => {
+  it('создаёт пользователя через identity helper и редиректит на /auth/telegram при валидном HMAC', async () => {
     const { db } = await import('@/lib/db')
     const res = await GET(makeRequest(validParams()))
 
@@ -70,10 +82,16 @@ describe('GET /api/auth/telegram/callback', () => {
     const location = res.headers.get('location')!
     const url = new URL(location)
     expect(url.pathname).toBe('/auth/telegram')
-    expect(url.searchParams.get('uid')).toBe('telegram:123456789')
+    expect(url.searchParams.get('uid')).toBe('canonical-uuid')
     expect(url.searchParams.get('token')).toBeTruthy()
     expect(url.searchParams.get('ts')).toBeTruthy()
     expect(url.searchParams.get('username')).toBe('ivanp')
+    expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledWith('telegram', '123456789', expect.objectContaining({
+      name: 'Иван Петров',
+      image: null,
+      telegramUsername: 'ivanp',
+      metadata: { source: 'telegram-callback' },
+    }))
     expect(db.insert).toHaveBeenCalled()
   })
 
@@ -87,6 +105,7 @@ describe('GET /api/auth/telegram/callback', () => {
     const url = new URL(res.headers.get('location')!)
     expect(url.searchParams.get('auth')).toBe('failed')
     expect(db.insert).not.toHaveBeenCalled()
+    expect(resolveOrCreateUserFromIdentity).not.toHaveBeenCalled()
   })
 
   it('[SEC] редиректит на /?auth=failed если auth_date старше 5 минут', async () => {
@@ -98,6 +117,7 @@ describe('GET /api/auth/telegram/callback', () => {
     const url = new URL(res.headers.get('location')!)
     expect(url.searchParams.get('auth')).toBe('failed')
     expect(db.insert).not.toHaveBeenCalled()
+    expect(resolveOrCreateUserFromIdentity).not.toHaveBeenCalled()
   })
 
   it('[SEC] редиректит на /?auth=failed при отсутствии TELEGRAM_BOT_TOKEN', async () => {
@@ -109,6 +129,7 @@ describe('GET /api/auth/telegram/callback', () => {
     const url = new URL(res.headers.get('location')!)
     expect(url.searchParams.get('auth')).toBe('failed')
     expect(db.insert).not.toHaveBeenCalled()
+    expect(resolveOrCreateUserFromIdentity).not.toHaveBeenCalled()
   })
 
   it('не добавляет username в redirect URL если он отсутствует', async () => {
@@ -125,27 +146,18 @@ describe('GET /api/auth/telegram/callback', () => {
     expect(url.searchParams.has('username')).toBe(false)
   })
 
-  it('использует first_name + last_name как имя пользователя в БД', async () => {
-    const { db } = await import('@/lib/db')
-    const mockValues = jest.fn().mockReturnValue({ onConflictDoUpdate: jest.fn().mockResolvedValue(undefined) })
-    ;(db.insert as jest.Mock).mockReturnValue({ values: mockValues })
-
+  it('использует first_name + last_name как имя пользователя в identity profile', async () => {
     await GET(makeRequest(validParams()))
 
-    const insertArg = mockValues.mock.calls[0][0]
-    expect(insertArg.name).toBe('Иван Петров')
-    expect(insertArg.email).toBe('telegram:123456789@telegram.user')
+    expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledWith('telegram', '123456789', expect.objectContaining({
+      name: 'Иван Петров',
+    }))
   })
 
-  it('повторный вход вызывает onConflictDoUpdate (не дублирует пользователя)', async () => {
-    const { db } = await import('@/lib/db')
-    const mockOnConflict = jest.fn().mockResolvedValue(undefined)
-    const mockValues = jest.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflict })
-    ;(db.insert as jest.Mock).mockReturnValue({ values: mockValues })
-
+  it('повторный вход делегирует идемпотентность identity helper', async () => {
     await GET(makeRequest(validParams()))
     await GET(makeRequest(validParams()))
 
-    expect(mockOnConflict).toHaveBeenCalledTimes(2)
+    expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledTimes(2)
   })
 })

--- a/app/api/auth/telegram/callback/route.ts
+++ b/app/api/auth/telegram/callback/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
 import { createTelegramPreauthToken, verifyTelegramHash } from '@/lib/telegram-auth'
+import { resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 export async function GET(req: NextRequest) {
   const { searchParams, origin } = new URL(req.url)
@@ -13,17 +12,19 @@ export async function GET(req: NextRequest) {
 
   const { id, first_name, last_name, username, photo_url } = params
   const name = [first_name, last_name].filter(Boolean).join(' ') || username || String(id)
-  const email = `telegram:${id}@telegram.user`
-  const userId = `telegram:${id}`
 
-  await db.insert(users).values({ id: userId, email, name, image: photo_url || null })
-    .onConflictDoUpdate({ target: users.id, set: { name, image: photo_url || null } })
+  const user = await resolveOrCreateUserFromIdentity('telegram', id, {
+    name,
+    image: photo_url || null,
+    telegramUsername: username || null,
+    metadata: { source: 'telegram-callback' },
+  })
 
   const ts = String(Math.floor(Date.now() / 1000))
-  const { token } = await createTelegramPreauthToken(userId)
+  const { token } = await createTelegramPreauthToken(user.id)
 
   const url = new URL('/auth/telegram', origin)
-  url.searchParams.set('uid', userId)
+  url.searchParams.set('uid', user.id)
   url.searchParams.set('token', token)
   url.searchParams.set('ts', ts)
   if (username) url.searchParams.set('username', username)

--- a/app/api/test/session/route.test.ts
+++ b/app/api/test/session/route.test.ts
@@ -11,9 +11,9 @@ jest.mock('@auth/core/jwt', () => ({
 
 jest.mock('@/lib/db', () => ({
   db: {
-    insert: jest.fn().mockReturnValue({
-      values: jest.fn().mockReturnValue({
-        onConflictDoUpdate: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockReturnValue({
+      set: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue(undefined),
       }),
     }),
     delete: jest.fn().mockReturnValue({
@@ -21,6 +21,14 @@ jest.mock('@/lib/db', () => ({
     }),
   },
 }))
+
+jest.mock('@/lib/user-identities', () => ({
+  normalizeIdentityProvider: jest.fn((provider: string) => provider === 'telegram-preauth' ? 'telegram' : provider),
+  resolveOrCreateUserFromIdentity: jest.fn(),
+}))
+
+import { encode } from '@auth/core/jwt'
+import { resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 function setNodeEnv(value: string) {
   Object.defineProperty(process.env, 'NODE_ENV', {
@@ -72,9 +80,49 @@ describe('/api/test/session guards', () => {
     setNodeEnv('test')
     process.env.NEXTAUTH_TEST_MODE = 'true'
     process.env.NEXTAUTH_SECRET = 'secret'
+    ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
+      id: 'canonical-test-uuid',
+      email: 'user@test.com',
+      name: 'User',
+    })
 
     const res = await POST(makeRequest({ email: 'user@test.com', name: 'User' }))
 
     expect(res.status).toBe(200)
+    expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledWith('email', 'user@test.com', expect.objectContaining({
+      email: 'user@test.com',
+      name: 'User',
+      metadata: { source: 'test-session' },
+    }))
+    expect(encode).toHaveBeenCalledWith(expect.objectContaining({
+      token: expect.objectContaining({ sub: 'canonical-test-uuid' }),
+    }))
+  })
+
+  it('POST для telegram-preauth создаёт session на canonical UUID, не на test:* id', async () => {
+    setNodeEnv('test')
+    process.env.NEXTAUTH_TEST_MODE = 'true'
+    process.env.NEXTAUTH_SECRET = 'secret'
+    ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
+      id: 'telegram-canonical-uuid',
+      email: 'tg@test.com',
+      name: 'Telegram User',
+    })
+
+    const res = await POST(makeRequest({
+      email: 'tg@test.com',
+      name: 'Telegram User',
+      telegramUsername: 'reader_tg',
+      provider: 'telegram-preauth',
+    }))
+
+    expect(res.status).toBe(200)
+    expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledWith('telegram', 'reader_tg', expect.objectContaining({
+      email: 'tg@test.com',
+      telegramUsername: 'reader_tg',
+    }))
+    expect(encode).toHaveBeenCalledWith(expect.objectContaining({
+      token: expect.objectContaining({ sub: 'telegram-canonical-uuid' }),
+    }))
   })
 })

--- a/app/api/test/session/route.ts
+++ b/app/api/test/session/route.ts
@@ -4,9 +4,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { encode } from '@auth/core/jwt'
 import { db } from '@/lib/db'
-import { users, notificationQueue } from '@/lib/db/schema'
+import { notificationQueue, users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { isTestEndpointAllowed } from '@/lib/test-mode'
+import { normalizeIdentityProvider, resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 function notAllowed() {
   return NextResponse.json({ error: 'Not allowed' }, { status: 403 })
@@ -15,37 +16,37 @@ function notAllowed() {
 export async function POST(req: NextRequest) {
   if (!isTestEndpointAllowed()) return notAllowed()
 
-  const { email, name, isAdmin, telegramUsername, provider } = await req.json() as {
-    email: string; name: string; isAdmin?: boolean; telegramUsername?: string; provider?: string
+  const { email, name, isAdmin, telegramUsername, provider, providerAccountId } = await req.json() as {
+    email: string; name: string; isAdmin?: boolean; telegramUsername?: string; provider?: string; providerAccountId?: string
   }
+  const identityProvider = normalizeIdentityProvider(provider ?? 'email')
+  const identityAccountId = providerAccountId ?? (identityProvider === 'telegram' ? telegramUsername ?? email : email)
 
-  await db.insert(users).values({
-    id: `test:${email}`,
+  const user = await resolveOrCreateUserFromIdentity(identityProvider, identityAccountId, {
     email,
     name,
-    emailVerified: new Date(),
+    emailVerified: identityProvider !== 'telegram',
+    telegramUsername: telegramUsername ?? null,
+    isAdmin: isAdmin ?? false,
+    metadata: { source: 'test-session' },
+  })
+
+  await db.update(users).set({
+    name,
     authProvider: provider ?? 'email',
     telegramUsername: telegramUsername ?? null,
     lastSignInAt: new Date(),
+    emailVerified: new Date(),
     isAdmin: isAdmin ?? false,
-  }).onConflictDoUpdate({
-    target: users.id,
-    set: {
-      name,
-      authProvider: provider ?? 'email',
-      telegramUsername: telegramUsername ?? null,
-      lastSignInAt: new Date(),
-      isAdmin: isAdmin ?? false,
-    },
-  })
+  }).where(eq(users.id, user.id))
 
   const token = await encode({
-    token: { sub: `test:${email}`, email, name, isAdmin: isAdmin ?? false, telegramUsername: telegramUsername ?? null, provider: provider ?? null },
+    token: { sub: user.id, email, name, isAdmin: isAdmin ?? false, telegramUsername: telegramUsername ?? null, provider: provider ?? null },
     secret: (process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET)!,
     salt: 'authjs.session-token',
   })
 
-  const res = NextResponse.json({ ok: true })
+  const res = NextResponse.json({ ok: true, userId: user.id })
   res.cookies.set('authjs.session-token', token, {
     httpOnly: true, sameSite: 'lax', path: '/', maxAge: 86400,
   })

--- a/app/api/test/signup/route.ts
+++ b/app/api/test/signup/route.ts
@@ -16,14 +16,20 @@ function notAllowed() {
 export async function POST(req: NextRequest) {
   if (!isTestEndpointAllowed()) return notAllowed()
 
-  const { userId, name, contacts, selectedBooks } = await req.json() as {
+  const { userId, name, email, contacts, selectedBooks } = await req.json() as {
     userId: string; name: string; email: string; contacts: string; selectedBooks: string[]
   }
+  const rows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1)
+  const canonicalUserId = rows[0]?.id ?? userId
 
-  await db.update(users).set({ name, contacts }).where(eq(users.id, userId))
-  await upsertSignup(userId, selectedBooks)
+  await db.update(users).set({ name, contacts }).where(eq(users.id, canonicalUserId))
+  await upsertSignup(canonicalUserId, selectedBooks)
 
-  return NextResponse.json({ ok: true })
+  return NextResponse.json({ ok: true, userId: canonicalUserId })
 }
 
 export async function DELETE(req: NextRequest) {

--- a/app/api/test/user/route.ts
+++ b/app/api/test/user/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-import { accounts, sessions, signupBooks, users } from '@/lib/db/schema'
+import { accounts, sessions, signupBooks, userIdentities, users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { isTestEndpointAllowed } from '@/lib/test-mode'
 
@@ -27,16 +27,26 @@ export async function GET(req: NextRequest) {
   }
 
   const userId = rows[0].id
-  const [accountRows, sessionRows, signupBookRows] = await Promise.all([
+  const [accountRows, sessionRows, signupBookRows, identityRows] = await Promise.all([
     db.select({ userId: accounts.userId }).from(accounts).where(eq(accounts.userId, userId)),
     db.select({ userId: sessions.userId }).from(sessions).where(eq(sessions.userId, userId)),
     db.select({ bookName: signupBooks.bookName }).from(signupBooks).where(eq(signupBooks.userId, userId)),
+    db
+      .select({
+        provider: userIdentities.provider,
+        providerAccountId: userIdentities.providerAccountId,
+        userId: userIdentities.userId,
+      })
+      .from(userIdentities)
+      .where(eq(userIdentities.userId, userId)),
   ])
 
   return NextResponse.json({
     exists: true,
     user: rows[0],
     accountCount: accountRows.length,
+    identityCount: identityRows.length,
+    identities: identityRows,
     sessionCount: sessionRows.length,
     signupBookCount: signupBookRows.length,
     signupBooks: signupBookRows.map(row => row.bookName),

--- a/docs/implementation-artifacts/tech-spec-user-identities-release-b.md
+++ b/docs/implementation-artifacts/tech-spec-user-identities-release-b.md
@@ -1,0 +1,46 @@
+---
+status: ready-for-dev
+source_plan: docs/planning-artifacts/user-identity-activity-refactor-plan.md
+issue: 122
+date: 2026-05-19
+---
+
+# User Identities Release B
+
+## Goal
+
+Ship identity-based auth for new users without physically migrating legacy primary keys.
+
+## Scope
+
+- Add `user_identities` as the domain source of truth for external provider ids.
+- Keep Auth.js `account` as the technical adapter table for Google OAuth compatibility.
+- Add a transaction-based helper for resolving or creating users from provider identities.
+- Switch Telegram callback/preauth to canonical user ids for newly-created Telegram users.
+- Switch Google One Tap to the same helper and sync both `account` and `user_identities`.
+- Update test-mode session creation so E2E exercises the same identity model.
+
+## Explicit Non-Goals
+
+- Do not migrate existing `telegram:*` primary keys to UUID.
+- Do not make `users.email` nullable in this release.
+- Do not remove or bypass Auth.js `account`.
+- Do not change unrelated user-facing UI.
+
+## Acceptance Criteria
+
+Given a new Telegram login, when `/api/auth/telegram/callback` receives a valid Telegram payload, then it creates a UUID `users.id`, stores Telegram numeric id in `user_identities`, creates a preauth token for the UUID, and redirects with `uid=<uuid>`.
+
+Given an existing legacy `telegram:*` user, when the Telegram identity is resolved, then login remains compatible and no physical primary-key migration is attempted.
+
+Given Google One Tap login, when a new Google user is created, then `users`, `account`, and `user_identities` are created consistently for the same canonical UUID.
+
+Given email/test-mode session creation, when the endpoint creates a user, then an `email` identity is present and `session.user.id` is the canonical `users.id`.
+
+Given duplicate provider identity requests, when the helper runs twice, then `(provider, provider_account_id)` remains unique and the existing user is returned.
+
+## Verification
+
+- Unit tests for identity helper idempotency, provider normalization, Telegram canonical id creation, legacy compatibility, Google One Tap sync, and test session identity creation.
+- Auth chain E2E is required because provider/session behavior changes.
+- Run `npm run lint`, `npm run typecheck`, `npm test`, and relevant Playwright auth/profile/admin flows before commit.

--- a/drizzle/0013_user_identities.sql
+++ b/drizzle/0013_user_identities.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "user_identities" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"provider" text NOT NULL,
+	"provider_account_id" text NOT NULL,
+	"email" text,
+	"telegram_username" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"last_seen_at" timestamp DEFAULT now() NOT NULL,
+	"metadata" text
+);
+--> statement-breakpoint
+ALTER TABLE "user_identities" ADD CONSTRAINT "user_identities_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "user_identities_provider_account_id_idx" ON "user_identities" USING btree ("provider","provider_account_id");--> statement-breakpoint
+CREATE INDEX "user_identities_user_id_idx" ON "user_identities" USING btree ("user_id");

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1196 @@
+{
+  "id": "69a97157-aaff-46f8-b516-46952b4c5b95",
+  "prevId": "39b70f81-b82d-4b09-afea-70574ab02f68",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_new_flags": {
+      "name": "book_new_flags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_priorities": {
+      "name": "book_priorities",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_name": {
+          "name": "book_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "book_priorities_user_id_user_id_fk": {
+          "name": "book_priorities_user_id_user_id_fk",
+          "tableFrom": "book_priorities",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_priorities_user_id_book_name_pk": {
+          "name": "book_priorities_user_id_book_name_pk",
+          "columns": [
+            "user_id",
+            "book_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_statuses": {
+      "name": "book_statuses",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_submissions": {
+      "name": "book_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_url": {
+          "name": "text_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "why_read": {
+          "name": "why_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_submissions_status_idx": {
+          "name": "book_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_submissions_user_id_user_id_fk": {
+          "name": "book_submissions_user_id_user_id_fk",
+          "tableFrom": "book_submissions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_user_id_fk": {
+          "name": "feedback_user_id_user_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.intro_sections": {
+      "name": "intro_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "intro_sections_kind_sort_idx": {
+          "name": "intro_sections_kind_sort_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_queue": {
+      "name": "notification_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_books": {
+          "name": "added_books",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processing_at": {
+          "name": "processing_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_queue_sent_at_idx": {
+          "name": "notification_queue_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signup_books": {
+      "name": "signup_books",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_name": {
+          "name": "book_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "signup_books_user_id_user_id_fk": {
+          "name": "signup_books_user_id_user_id_fk",
+          "tableFrom": "signup_books",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "signup_books_user_id_book_name_pk": {
+          "name": "signup_books_user_id_book_name_pk",
+          "columns": [
+            "user_id",
+            "book_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_descriptions": {
+      "name": "tag_descriptions",
+      "schema": "",
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_preauth_tokens": {
+      "name": "telegram_preauth_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "telegram_preauth_tokens_user_id_idx": {
+          "name": "telegram_preauth_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "telegram_preauth_tokens_expires_at_idx": {
+          "name": "telegram_preauth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_preauth_tokens_user_id_user_id_fk": {
+          "name": "telegram_preauth_tokens_user_id_user_id_fk",
+          "tableFrom": "telegram_preauth_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity_events": {
+      "name": "user_activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_activity_events_user_id_occurred_at_idx": {
+          "name": "user_activity_events_user_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_events_dedupe_key_idx": {
+          "name": "user_activity_events_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_activity_events_user_id_user_id_fk": {
+          "name": "user_activity_events_user_id_user_id_fk",
+          "tableFrom": "user_activity_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_identities": {
+      "name": "user_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_identities_provider_account_id_idx": {
+          "name": "user_identities_provider_account_id_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_user_id_idx": {
+          "name": "user_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_identities_user_id_user_id_fk": {
+          "name": "user_identities_user_id_user_id_fk",
+          "tableFrom": "user_identities",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sign_in_at": {
+          "name": "last_sign_in_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priorities_set": {
+          "name": "priorities_set",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1779209212687,
       "tag": "0012_user_activity_events",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1779226192891,
+      "tag": "0013_user_identities",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/admin-users.spec.ts
+++ b/e2e/admin-users.spec.ts
@@ -26,13 +26,13 @@ test.describe('админка — пользователи и фидбеки', (
     const runId = `${testInfo.workerIndex}-${testInfo.retry}-${Date.now()}`
     adminEmail = `e2e-admin-users-admin-${runId}@test.invalid`
     userEmail = `e2e-admin-users-user-${runId}@test.invalid`
-    userId = `test:${userEmail}`
     registeredFeedback = `${REGISTERED_FEEDBACK_BASE} ${runId}`
     anonFeedback = `${ANON_FEEDBACK_BASE} ${runId}`
 
-    await page.request.post('/api/test/session', {
+    const userSession = await page.request.post('/api/test/session', {
       data: { email: userEmail, name: USER_NAME },
     })
+    userId = (await userSession.json()).userId
     await page.request.post('/api/test/signup', {
       data: { userId, name: USER_NAME, email: userEmail, contacts: USER_CONTACT, selectedBooks: [BOOK_A, BOOK_B] },
     })

--- a/e2e/telegram-auth.spec.ts
+++ b/e2e/telegram-auth.spec.ts
@@ -4,13 +4,20 @@ import { epic, feature } from 'allure-js-commons'
 const TG_EMAIL = 'e2e-telegram-test@test.invalid'
 const TG_NAME = 'E2E Telegram User'
 const TG_USERNAME = 'e2e_tg_test'
+const TG_PROVIDER_ACCOUNT_ID = '900100200'
 
 test.describe('Авторизация через Telegram', () => {
   test.beforeEach(async ({ page }) => {
     await epic('Авторизация')
     await feature('Telegram')
     await page.request.post('/api/test/session', {
-      data: { email: TG_EMAIL, name: TG_NAME, telegramUsername: TG_USERNAME, provider: 'telegram-preauth' },
+      data: {
+        email: TG_EMAIL,
+        name: TG_NAME,
+        telegramUsername: TG_USERNAME,
+        provider: 'telegram-preauth',
+        providerAccountId: TG_PROVIDER_ACCOUNT_ID,
+      },
     })
   })
 

--- a/lib/auth.google-one-tap.test.ts
+++ b/lib/auth.google-one-tap.test.ts
@@ -11,12 +11,13 @@ jest.mock('google-auth-library', () => ({
   })),
 }))
 
-// Mock the DB
-jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn() } }))
+jest.mock('@/lib/user-identities', () => ({
+  resolveOrCreateUserFromIdentity: jest.fn(),
+}))
 
 import { OAuth2Client } from 'google-auth-library'
 import { authorizeGoogleOneTap } from './auth.google-one-tap'
-import { db } from '@/lib/db'
+import { resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 const mockVerifyIdToken = jest.fn()
 const mockGetPayload = jest.fn()
@@ -35,17 +36,6 @@ const VALID_PAYLOAD = {
   name: 'Ivan Petrov',
 }
 
-function mockDbSelect(rows: { id: string }[]) {
-  const chain = {
-    select: jest.fn().mockReturnThis(),
-    from: jest.fn().mockReturnThis(),
-    where: jest.fn().mockReturnThis(),
-    limit: jest.fn().mockResolvedValue(rows),
-  }
-  ;(db.select as jest.Mock).mockReturnValue(chain)
-  return chain
-}
-
 describe('authorizeGoogleOneTap', () => {
   it('returns null when credential is invalid (verifyIdToken throws)', async () => {
     mockVerifyIdToken.mockRejectedValue(new Error('Invalid token'))
@@ -57,19 +47,23 @@ describe('authorizeGoogleOneTap', () => {
     mockGetPayload.mockReturnValue(null)
     const result = await authorizeGoogleOneTap('credential')
     expect(result).toBeNull()
-    expect(db.select).not.toHaveBeenCalled()
+    expect(resolveOrCreateUserFromIdentity).not.toHaveBeenCalled()
   })
 
   it('returns null when payload has no email', async () => {
     mockGetPayload.mockReturnValue({ sub: 'abc', name: 'No Email' })
     const result = await authorizeGoogleOneTap('credential')
     expect(result).toBeNull()
-    expect(db.select).not.toHaveBeenCalled()
+    expect(resolveOrCreateUserFromIdentity).not.toHaveBeenCalled()
   })
 
-  it('returns existing user when found in DB by email', async () => {
+  it('returns user resolved through google identity helper', async () => {
     mockGetPayload.mockReturnValue(VALID_PAYLOAD)
-    mockDbSelect([{ id: 'existing-uuid' }])
+    ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
+      id: 'existing-uuid',
+      email: 'user@example.com',
+      name: 'Ivan Petrov',
+    })
 
     const result = await authorizeGoogleOneTap('credential')
 
@@ -78,33 +72,21 @@ describe('authorizeGoogleOneTap', () => {
       email: 'user@example.com',
       name: 'Ivan Petrov',
     })
-    // Should NOT insert anything for existing users
-    expect(db.insert).not.toHaveBeenCalled()
-  })
-
-  it('creates new user + accounts entry when user not found in DB', async () => {
-    mockGetPayload.mockReturnValue(VALID_PAYLOAD)
-    mockDbSelect([])
-    // Two inserts: users then accounts — use mockReturnValueOnce for correctness
-    const chain1 = { values: jest.fn().mockResolvedValue(undefined) }
-    const chain2 = { values: jest.fn().mockResolvedValue(undefined) }
-    ;(db.insert as jest.Mock).mockReturnValueOnce(chain1).mockReturnValueOnce(chain2)
-
-    const result = await authorizeGoogleOneTap('credential')
-
-    expect(result).not.toBeNull()
-    expect(result!.email).toBe('user@example.com')
-    expect(result!.name).toBe('Ivan Petrov')
-    expect(typeof result!.id).toBe('string')
-    // Should insert into both users and accounts
-    expect(db.insert).toHaveBeenCalledTimes(2)
-    expect(chain1.values).toHaveBeenCalledTimes(1)
-    expect(chain2.values).toHaveBeenCalledTimes(1)
+    expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledWith('google-one-tap', 'google-sub-123', expect.objectContaining({
+      email: 'user@example.com',
+      name: 'Ivan Petrov',
+      emailVerified: true,
+      metadata: { source: 'google-one-tap' },
+    }))
   })
 
   it('falls back to email as name when payload has no name', async () => {
     mockGetPayload.mockReturnValue({ sub: 'abc', email: 'user@example.com' })
-    mockDbSelect([{ id: 'existing-uuid' }])
+    ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
+      id: 'existing-uuid',
+      email: 'user@example.com',
+      name: 'user@example.com',
+    })
 
     const result = await authorizeGoogleOneTap('credential')
 

--- a/lib/auth.google-one-tap.ts
+++ b/lib/auth.google-one-tap.ts
@@ -1,7 +1,5 @@
 import { OAuth2Client } from 'google-auth-library'
-import { db } from '@/lib/db'
-import { users, accounts } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 export async function authorizeGoogleOneTap(
   credential: string
@@ -15,35 +13,15 @@ export async function authorizeGoogleOneTap(
     const payload = ticket.getPayload()
     if (!payload?.email) return null
 
-    const { sub, email, name } = payload
-
-    // Find existing user by email
-    const existing = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(eq(users.email, email))
-      .limit(1)
-
-    if (existing.length > 0) {
-      return { id: existing[0].id, email, name: name ?? email }
-    }
-
-    // New user: insert into users + accounts
-    // accounts entry prevents OAuthAccountNotLinked if user later signs in via Google OAuth button
-    const newId = crypto.randomUUID()
-    await db.insert(users).values({
-      id: newId,
+    const { sub, email, name, picture, email_verified } = payload
+    const user = await resolveOrCreateUserFromIdentity('google-one-tap', sub, {
       email,
       name: name ?? email,
-      emailVerified: new Date(),
+      image: picture ?? null,
+      emailVerified: email_verified !== false,
+      metadata: { source: 'google-one-tap' },
     })
-    await db.insert(accounts).values({
-      userId: newId,
-      type: 'oidc',
-      provider: 'google',
-      providerAccountId: sub,
-    })
-    return { id: newId, email, name: name ?? email }
+    return { id: user.id, email: user.email, name: user.name ?? email }
   } catch {
     return null
   }

--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -28,6 +28,11 @@ jest.mock('@/lib/user-activity', () => ({
   bestEffortRecordUserActivity: jest.fn(),
 }))
 
+jest.mock('@/lib/user-identities', () => ({
+  linkIdentityToUser: jest.fn(),
+  resolveOrCreateUserFromIdentity: jest.fn(),
+}))
+
 jest.mock('next-auth/providers/google', () => ({
   __esModule: true,
   default: jest.fn(() => ({ id: 'google', type: 'oauth' })),
@@ -71,6 +76,7 @@ jest.mock('next-auth', () => ({
 import NextAuth from 'next-auth'
 import { db } from '@/lib/db'
 import { bestEffortRecordUserActivity } from '@/lib/user-activity'
+import { linkIdentityToUser, resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require('@/lib/auth')
@@ -102,16 +108,6 @@ function mockDbSelect(rows: unknown[]) {
     limit: jest.fn().mockResolvedValue(rows),
   }
   ;(db.select as jest.Mock).mockReturnValue(chain)
-  return chain
-}
-
-// Mock db chain for insert with onConflictDoUpdate
-function mockDbInsert() {
-  const chain = {
-    values: jest.fn().mockReturnThis(),
-    onConflictDoUpdate: jest.fn().mockResolvedValue(undefined),
-  }
-  ;(db.insert as jest.Mock).mockReturnValue(chain)
   return chain
 }
 
@@ -158,6 +154,16 @@ beforeAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  ;(linkIdentityToUser as jest.Mock).mockResolvedValue({
+    id: 'identity-user',
+    email: 'identity@test.com',
+    name: 'Identity',
+  })
+  ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
+    id: 'identity-user',
+    email: 'identity@test.com',
+    name: 'Identity',
+  })
 })
 
 // ── signIn callback ──────────────────────────────────────────────────────────
@@ -184,6 +190,56 @@ describe('signIn callback', () => {
       sourceId: 'google',
       metadata: { provider: 'google' },
     }))
+    expect(linkIdentityToUser).not.toHaveBeenCalled()
+  })
+
+  it('синхронизирует Google OAuth account в user_identities для canonical users.id', async () => {
+    mockDbUpdate()
+
+    const result = await signInCallback()({
+      user: { id: 'user-uuid', email: 'user@test.com', name: 'User', image: 'https://avatar.test/u.png' },
+      account: { provider: 'google', providerAccountId: 'google-sub-123' },
+    })
+
+    expect(result).toBe(true)
+    expect(linkIdentityToUser).toHaveBeenCalledWith('user-uuid', 'google', 'google-sub-123', expect.objectContaining({
+      email: 'user@test.com',
+      emailVerified: true,
+      name: 'User',
+      image: 'https://avatar.test/u.png',
+      metadata: { source: 'auth-sign-in' },
+    }))
+  })
+
+  it('синхронизирует Resend/email sign-in в user_identities', async () => {
+    mockDbUpdate()
+
+    await signInCallback()({
+      user: { id: 'email-user-uuid', email: 'magic@test.com', name: 'Magic User' },
+      account: { provider: 'resend' },
+    })
+
+    expect(linkIdentityToUser).toHaveBeenCalledWith('email-user-uuid', 'email', 'magic@test.com', expect.objectContaining({
+      email: 'magic@test.com',
+      emailVerified: true,
+      name: 'Magic User',
+      metadata: { source: 'auth-sign-in' },
+    }))
+  })
+
+  it('не создаёт email identity на pre-send фазе magic link', async () => {
+    mockDbUpdate()
+
+    const result = await signInCallback()({
+      user: { email: 'not-yet-verified@test.com' },
+      account: { provider: 'resend' },
+      email: { verificationRequest: true },
+    })
+
+    expect(result).toBe(true)
+    expect(db.update).not.toHaveBeenCalled()
+    expect(linkIdentityToUser).not.toHaveBeenCalled()
+    expect(resolveOrCreateUserFromIdentity).not.toHaveBeenCalled()
   })
 
   it('пишет telegram_username если он пришёл из credentials user', async () => {
@@ -568,19 +624,29 @@ describe('telegram provider authorize + verifyTelegramHash', () => {
       auth_date: String(Math.floor(Date.now() / 1000)),
     }
     const hash = buildTelegramHash(data, BOT_TOKEN)
-    mockDbInsert()
+    ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
+      id: 'canonical-telegram-uuid',
+      email: 'telegram:987654321@telegram.user',
+      name: 'Ivan Petrov',
+    })
 
     const result = await authorize({ ...data, hash })
 
     expect(result).toMatchObject({
-      id: 'telegram:987654321',
+      id: 'canonical-telegram-uuid',
       email: 'telegram:987654321@telegram.user',
       name: 'Ivan Petrov',
       telegramUsername: 'ivan_p',
     })
+    expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledWith('telegram', '987654321', expect.objectContaining({
+      name: 'Ivan Petrov',
+      image: 'https://t.me/photo.jpg',
+      telegramUsername: 'ivan_p',
+      metadata: { source: 'telegram-credentials' },
+    }))
   })
 
-  it('устанавливает image из photo_url', async () => {
+  it('передаёт image из photo_url в identity helper', async () => {
     const data = {
       id: '111',
       first_name: 'Anna',
@@ -588,13 +654,12 @@ describe('telegram provider authorize + verifyTelegramHash', () => {
       auth_date: String(Math.floor(Date.now() / 1000)),
     }
     const hash = buildTelegramHash(data, BOT_TOKEN)
-    const insertChain = mockDbInsert()
 
     await authorize({ ...data, hash })
 
-    expect(insertChain.values).toHaveBeenCalledWith(
-      expect.objectContaining({ image: 'https://t.me/photo.jpg' })
-    )
+    expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledWith('telegram', '111', expect.objectContaining({
+      image: 'https://t.me/photo.jpg',
+    }))
   })
 
   it('использует username как имя если first_name и last_name пусты', async () => {
@@ -604,7 +669,11 @@ describe('telegram provider authorize + verifyTelegramHash', () => {
       auth_date: String(Math.floor(Date.now() / 1000)),
     }
     const hash = buildTelegramHash(data, BOT_TOKEN)
-    mockDbInsert()
+    ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
+      id: 'canonical-telegram-uuid',
+      email: 'telegram:222@telegram.user',
+      name: 'noname_user',
+    })
 
     const result = (await authorize({ ...data, hash })) as Record<string, unknown>
     expect(result.name).toBe('noname_user')
@@ -616,25 +685,28 @@ describe('telegram provider authorize + verifyTelegramHash', () => {
       auth_date: String(Math.floor(Date.now() / 1000)),
     }
     const hash = buildTelegramHash(data, BOT_TOKEN)
-    mockDbInsert()
+    ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
+      id: 'canonical-telegram-uuid',
+      email: 'telegram:333@telegram.user',
+      name: '333',
+    })
 
     const result = (await authorize({ ...data, hash })) as Record<string, unknown>
     expect(result.name).toBe('333')
   })
 
-  it('устанавливает image=null если photo_url отсутствует', async () => {
+  it('передаёт image=null если photo_url отсутствует', async () => {
     const data = {
       id: '444',
       first_name: 'No Photo',
       auth_date: String(Math.floor(Date.now() / 1000)),
     }
     const hash = buildTelegramHash(data, BOT_TOKEN)
-    const insertChain = mockDbInsert()
 
     await authorize({ ...data, hash })
 
-    expect(insertChain.values).toHaveBeenCalledWith(
-      expect.objectContaining({ image: null })
-    )
+    expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledWith('telegram', '444', expect.objectContaining({
+      image: null,
+    }))
   })
 })

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -10,6 +10,7 @@ import { Resend as ResendClient } from 'resend'
 import { authorizeGoogleOneTap } from '@/lib/auth.google-one-tap'
 import { consumeTelegramPreauthToken, verifyTelegramHash } from '@/lib/telegram-auth'
 import { bestEffortRecordUserActivity } from '@/lib/user-activity'
+import { linkIdentityToUser, resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 const FROM = 'Долгое наступление <noreply@slowreading.club>'
 
@@ -130,16 +131,16 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         if (!verifyTelegramHash(data)) return null
         const { id, first_name, last_name, username, photo_url } = data
         const name = [first_name, last_name].filter(Boolean).join(' ') || username || String(id)
-        const email = `telegram:${id}@telegram.user`
-        const userId = `telegram:${id}`
-        await db.insert(users).values({ id: userId, email, name, image: photo_url || null }).onConflictDoUpdate({
-          target: users.id,
-          set: { name, image: photo_url || null },
+        const user = await resolveOrCreateUserFromIdentity('telegram', id, {
+          name,
+          image: photo_url || null,
+          telegramUsername: username || null,
+          metadata: { source: 'telegram-credentials' },
         })
         return {
-          id: userId,
-          email,
-          name,
+          id: user.id,
+          email: user.email,
+          name: user.name ?? name,
           telegramUsername: username || null,
         }
       },
@@ -147,7 +148,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   ],
   session: { strategy: 'jwt' },
   callbacks: {
-    async signIn({ user, account }) {
+    async signIn({ user, account, email }) {
+      if (email?.verificationRequest) return true
       const userId = user.id
       if (userId || user.email) {
         // account is null for email magic link (Resend doesn't create an accounts row)
@@ -165,6 +167,36 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             sourceId: provider,
             metadata: { provider },
           })
+        }
+        if (account?.provider === 'google' && account.providerAccountId && userId) {
+          await linkIdentityToUser(userId, 'google', account.providerAccountId, {
+            email: user.email,
+            emailVerified: true,
+            name: user.name,
+            image: user.image,
+            now,
+            metadata: { source: 'auth-sign-in' },
+          })
+        } else if (provider === 'email' && user.email) {
+          if (userId) {
+            await linkIdentityToUser(userId, 'email', user.email, {
+              email: user.email,
+              emailVerified: true,
+              name: user.name,
+              image: user.image,
+              now,
+              metadata: { source: 'auth-sign-in' },
+            })
+          } else {
+            await resolveOrCreateUserFromIdentity('email', user.email, {
+              email: user.email,
+              emailVerified: true,
+              name: user.name,
+              image: user.image,
+              now,
+              metadata: { source: 'auth-sign-in' },
+            })
+          }
         }
       }
       return true

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -34,6 +34,21 @@ export const userActivityEvents = pgTable('user_activity_events', {
   dedupeKeyIdx: uniqueIndex('user_activity_events_dedupe_key_idx').on(t.dedupeKey),
 }))
 
+export const userIdentities = pgTable('user_identities', {
+  id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  provider: text('provider').notNull(),
+  providerAccountId: text('provider_account_id').notNull(),
+  email: text('email'),
+  telegramUsername: text('telegram_username'),
+  createdAt: timestamp('created_at', { mode: 'date' }).notNull().defaultNow(),
+  lastSeenAt: timestamp('last_seen_at', { mode: 'date' }).notNull().defaultNow(),
+  metadata: text('metadata'),
+}, (t) => ({
+  providerAccountUnique: uniqueIndex('user_identities_provider_account_id_idx').on(t.provider, t.providerAccountId),
+  userIdIdx: index('user_identities_user_id_idx').on(t.userId),
+}))
+
 export const accounts = pgTable('account', {
   userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
   type: text('type').notNull(),

--- a/lib/user-identities.test.ts
+++ b/lib/user-identities.test.ts
@@ -1,0 +1,285 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    select: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(),
+  },
+}))
+
+import { db } from '@/lib/db'
+import { accounts, userIdentities, users } from '@/lib/db/schema'
+import {
+  linkIdentityToUser,
+  normalizeIdentityProvider,
+  normalizeTelegramContact,
+  resolveOrCreateUserFromIdentity,
+} from './user-identities'
+
+type InsertChain = {
+  table: unknown
+  lastValues?: Record<string, unknown>
+  values: jest.Mock
+  onConflictDoUpdate: jest.Mock
+  onConflictDoNothing: jest.Mock
+  returning: jest.Mock
+}
+
+function queueSelects(...rows: unknown[][]) {
+  const queue = [...rows]
+  ;(db.select as jest.Mock).mockImplementation(() => ({
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue(queue.shift() ?? []),
+  }))
+}
+
+function mockInserts() {
+  const chains: InsertChain[] = []
+  ;(db.insert as jest.Mock).mockImplementation((table: unknown) => {
+    const chain: InsertChain = {
+      table,
+      values: jest.fn((values: Record<string, unknown>) => {
+        chain.lastValues = values
+        return chain
+      }),
+      onConflictDoUpdate: jest.fn(() => chain),
+      onConflictDoNothing: jest.fn(() => Promise.resolve(undefined)),
+      returning: jest.fn(() => Promise.resolve([{ userId: chain.lastValues?.userId }])),
+    }
+    chains.push(chain)
+    return chain
+  })
+  return chains
+}
+
+function mockUpdate() {
+  const chain = {
+    set: jest.fn().mockReturnThis(),
+    where: jest.fn().mockResolvedValue(undefined),
+  }
+  ;(db.update as jest.Mock).mockReturnValue(chain)
+  return chain
+}
+
+describe('user identity helpers', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+    delete (db as unknown as { transaction?: unknown }).transaction
+  })
+
+  it('нормализует provider aliases и Telegram contact', () => {
+    expect(normalizeIdentityProvider('google-one-tap')).toBe('google')
+    expect(normalizeIdentityProvider('resend')).toBe('email')
+    expect(normalizeIdentityProvider('telegram-preauth')).toBe('telegram')
+    expect(normalizeTelegramContact(' @reader ')).toBe('reader')
+    expect(normalizeTelegramContact('')).toBeNull()
+  })
+
+  it('использует transaction если DB client её поддерживает', async () => {
+    ;(db as unknown as { transaction: jest.Mock }).transaction = jest.fn(async (callback) => callback(db))
+    queueSelects(
+      [{ userId: 'user-uuid' }],
+      [{ id: 'user-uuid', email: 'u@test.com', name: 'User', image: null, telegramUsername: null }]
+    )
+    mockInserts()
+    mockUpdate()
+
+    await resolveOrCreateUserFromIdentity('email', 'u@test.com', { email: 'u@test.com' })
+
+    expect((db as unknown as { transaction: jest.Mock }).transaction).toHaveBeenCalled()
+  })
+
+  it('откатывается на обычные запросы если neon-http объявляет transaction, но не поддерживает её', async () => {
+    ;(db as unknown as { transaction: jest.Mock }).transaction = jest.fn(async () => {
+      throw new Error('No transactions support in neon-http driver')
+    })
+    queueSelects(
+      [{ userId: 'user-uuid' }],
+      [{ id: 'user-uuid', email: 'u@test.com', name: 'User', image: null, telegramUsername: null }]
+    )
+    mockInserts()
+    mockUpdate()
+
+    const result = await resolveOrCreateUserFromIdentity('email', 'u@test.com', { email: 'u@test.com' })
+
+    expect(result.id).toBe('user-uuid')
+    expect((db as unknown as { transaction: jest.Mock }).transaction).toHaveBeenCalled()
+  })
+
+  it('создаёт нового Telegram user с UUID и technical placeholder email', async () => {
+    queueSelects(
+      [],
+      [],
+      [{ id: 'generated-uuid', email: 'telegram:123@telegram.user', name: 'Ivan', image: null, telegramUsername: 'ivan' }]
+    )
+    const insertChains = mockInserts()
+    mockUpdate()
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue('generated-uuid')
+
+    const result = await resolveOrCreateUserFromIdentity('telegram-preauth', '123', {
+      name: 'Ivan',
+      telegramUsername: '@ivan',
+    })
+
+    expect(result.id).toBe('generated-uuid')
+    expect(insertChains[0].table).toBe(users)
+    expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
+      id: 'generated-uuid',
+      email: 'telegram:123@telegram.user',
+      telegramUsername: 'ivan',
+    }))
+    expect(insertChains[1].table).toBe(userIdentities)
+    expect(insertChains[1].lastValues).toEqual(expect.objectContaining({
+      userId: 'generated-uuid',
+      provider: 'telegram',
+      providerAccountId: '123',
+      email: null,
+      telegramUsername: 'ivan',
+    }))
+  })
+
+  it('линкует новую Telegram identity к legacy telegram:* user вместо физической миграции id', async () => {
+    queueSelects(
+      [],
+      [{ id: 'telegram:123' }],
+      [{ id: 'telegram:123', email: 'telegram:123@telegram.user', name: 'Legacy', image: null, telegramUsername: 'legacy' }]
+    )
+    const insertChains = mockInserts()
+    mockUpdate()
+
+    const result = await resolveOrCreateUserFromIdentity('telegram', '123', { telegramUsername: 'legacy' })
+
+    expect(result.id).toBe('telegram:123')
+    expect(insertChains.some(chain => chain.table === users)).toBe(false)
+    expect(insertChains[0].table).toBe(userIdentities)
+    expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
+      userId: 'telegram:123',
+      provider: 'telegram',
+      providerAccountId: '123',
+    }))
+  })
+
+  it('линкует trusted Google identity к существующему user by email и синхронизирует account', async () => {
+    queueSelects(
+      [],
+      [],
+      [{ id: 'user-uuid' }],
+      [],
+      [{ id: 'user-uuid', email: 'user@test.com', name: 'User', image: null, telegramUsername: null }]
+    )
+    const insertChains = mockInserts()
+    mockUpdate()
+
+    const result = await resolveOrCreateUserFromIdentity('google-one-tap', 'google-sub', {
+      email: 'User@Test.COM',
+      emailVerified: true,
+      name: 'User',
+    })
+
+    expect(result.id).toBe('user-uuid')
+    expect(insertChains.some(chain => chain.table === users)).toBe(false)
+    expect(insertChains[0].table).toBe(userIdentities)
+    expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
+      userId: 'user-uuid',
+      provider: 'google',
+      providerAccountId: 'google-sub',
+      email: 'user@test.com',
+    }))
+    expect(insertChains[1].table).toBe(accounts)
+    expect(insertChains[1].lastValues).toEqual(expect.objectContaining({
+      userId: 'user-uuid',
+      provider: 'google',
+      providerAccountId: 'google-sub',
+    }))
+  })
+
+  it('при существующем Google account выбирает владельца account, а не user по email', async () => {
+    queueSelects(
+      [],
+      [{ userId: 'account-owner' }],
+      [{ userId: 'account-owner' }],
+      [{ id: 'account-owner', email: 'owner@test.com', name: 'Owner', image: null, telegramUsername: null }]
+    )
+    const insertChains = mockInserts()
+    mockUpdate()
+
+    const result = await resolveOrCreateUserFromIdentity('google', 'google-sub', {
+      email: 'other@test.com',
+      emailVerified: true,
+      name: 'Other',
+    })
+
+    expect(result.id).toBe('account-owner')
+    expect(insertChains.some(chain => chain.table === users)).toBe(false)
+    expect(insertChains[0].table).toBe(userIdentities)
+    expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
+      userId: 'account-owner',
+      provider: 'google',
+      providerAccountId: 'google-sub',
+    }))
+  })
+
+  it('linkIdentityToUser upsert-ит Google identity для canonical Auth.js user id', async () => {
+    queueSelects(
+      [],
+      [],
+      [],
+      [{ id: 'canonical-uuid', email: 'oauth@test.com', name: 'OAuth', image: null, telegramUsername: null }]
+    )
+    const insertChains = mockInserts()
+    mockUpdate()
+
+    await linkIdentityToUser('canonical-uuid', 'google', 'oauth-sub', {
+      email: 'oauth@test.com',
+      emailVerified: true,
+    })
+
+    expect(insertChains[0].table).toBe(userIdentities)
+    expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
+      userId: 'canonical-uuid',
+      provider: 'google',
+      providerAccountId: 'oauth-sub',
+    }))
+    expect(insertChains[1].table).toBe(accounts)
+    expect(insertChains[1].onConflictDoNothing).toHaveBeenCalledWith({
+      target: [accounts.provider, accounts.providerAccountId],
+    })
+  })
+
+  it('linkIdentityToUser падает при попытке привязать identity другого пользователя', async () => {
+    queueSelects(
+      [],
+      [{ userId: 'other-user' }]
+    )
+    const insertChains = mockInserts()
+
+    await expect(linkIdentityToUser('canonical-uuid', 'google', 'oauth-sub', {
+      email: 'oauth@test.com',
+      emailVerified: true,
+    })).rejects.toThrow('already linked to another user')
+
+    expect(insertChains).toHaveLength(0)
+    expect(db.update).not.toHaveBeenCalled()
+  })
+
+  it('linkIdentityToUser не переносит существующий Google account на другого пользователя', async () => {
+    queueSelects(
+      [{ userId: 'other-user' }]
+    )
+    const insertChains = mockInserts()
+    mockUpdate()
+
+    await expect(linkIdentityToUser('canonical-uuid', 'google', 'oauth-sub', {
+      email: 'oauth@test.com',
+      emailVerified: true,
+    })).rejects.toThrow('already linked to another user')
+
+    expect(insertChains).toHaveLength(0)
+    expect(insertChains.some(chain => chain.table === accounts)).toBe(false)
+  })
+})

--- a/lib/user-identities.ts
+++ b/lib/user-identities.ts
@@ -1,0 +1,322 @@
+import { and, eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { accounts, userIdentities, users } from '@/lib/db/schema'
+
+export const IDENTITY_PROVIDERS = ['google', 'email', 'telegram'] as const
+
+export type IdentityProvider = typeof IDENTITY_PROVIDERS[number]
+export type RawIdentityProvider = IdentityProvider | 'resend' | 'google-one-tap' | 'telegram-preauth'
+export type IdentityMetadataValue =
+  | string
+  | number
+  | boolean
+  | null
+  | IdentityMetadataValue[]
+  | { [key: string]: IdentityMetadataValue }
+export type IdentityMetadata = Record<string, IdentityMetadataValue>
+
+export interface IdentityProfile {
+  userId?: string
+  email?: string | null
+  emailVerified?: boolean
+  name?: string | null
+  image?: string | null
+  telegramUsername?: string | null
+  isAdmin?: boolean
+  metadata?: IdentityMetadata
+  now?: Date
+}
+
+export interface ResolvedIdentityUser {
+  id: string
+  email: string
+  name: string | null
+  image: string | null
+  telegramUsername: string | null
+  isNew: boolean
+}
+
+type IdentityDb = Pick<typeof db, 'select' | 'insert' | 'update'>
+type TransactionalIdentityDb = IdentityDb & {
+  transaction?: <T>(callback: (tx: IdentityDb) => Promise<T>) => Promise<T>
+}
+
+function getIdentityDb(): TransactionalIdentityDb {
+  return db as unknown as TransactionalIdentityDb
+}
+
+async function withIdentityTransaction<T>(callback: (tx: IdentityDb) => Promise<T>): Promise<T> {
+  const client = getIdentityDb()
+  if (typeof client.transaction === 'function') {
+    try {
+      return await client.transaction(callback)
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes('No transactions support in neon-http driver')) {
+        throw error
+      }
+    }
+  }
+  return callback(client)
+}
+
+export function normalizeIdentityProvider(provider: RawIdentityProvider | string): IdentityProvider {
+  if (provider === 'google' || provider === 'google-one-tap') return 'google'
+  if (provider === 'email' || provider === 'resend') return 'email'
+  if (provider === 'telegram' || provider === 'telegram-preauth') return 'telegram'
+  throw new Error(`Unsupported identity provider: ${provider}`)
+}
+
+export function normalizeTelegramContact(rawContact?: string | null): string | null {
+  const trimmed = rawContact?.trim()
+  if (!trimmed) return null
+  return trimmed.replace(/^@+/, '')
+}
+
+function normalizeEmail(email?: string | null): string | null {
+  const normalized = email?.trim().toLowerCase()
+  return normalized || null
+}
+
+function normalizeProviderAccountId(provider: IdentityProvider, providerAccountId: string): string {
+  const trimmed = providerAccountId.trim()
+  if (!trimmed) throw new Error('providerAccountId is required')
+  return provider === 'email' ? trimmed.toLowerCase() : trimmed
+}
+
+function syntheticTelegramEmail(providerAccountId: string): string {
+  return `telegram:${providerAccountId}@telegram.user`
+}
+
+function userInsertEmail(provider: IdentityProvider, providerAccountId: string, email: string | null): string {
+  if (email) return email
+  if (provider === 'telegram') return syntheticTelegramEmail(providerAccountId)
+  throw new Error(`${provider} identity requires email`)
+}
+
+function metadataToText(metadata?: IdentityMetadata): string | null {
+  return metadata ? JSON.stringify(metadata) : null
+}
+
+function canLinkByEmail(provider: IdentityProvider, profile: IdentityProfile, email: string | null): email is string {
+  if (!email) return false
+  if (provider === 'email') return true
+  if (provider === 'google') return profile.emailVerified !== false
+  return false
+}
+
+async function findUserIdByEmail(tx: IdentityDb, email: string): Promise<string | null> {
+  const rows = await tx
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1)
+  return rows[0]?.id ?? null
+}
+
+async function findIdentityUserId(
+  tx: IdentityDb,
+  provider: IdentityProvider,
+  providerAccountId: string
+): Promise<string | null> {
+  const rows = await tx
+    .select({ userId: userIdentities.userId })
+    .from(userIdentities)
+    .where(and(
+      eq(userIdentities.provider, provider),
+      eq(userIdentities.providerAccountId, providerAccountId)
+    ))
+    .limit(1)
+  return rows[0]?.userId ?? null
+}
+
+async function findGoogleAccountUserId(tx: IdentityDb, provider: IdentityProvider, providerAccountId: string): Promise<string | null> {
+  if (provider !== 'google') return null
+  const rows = await tx
+    .select({ userId: accounts.userId })
+    .from(accounts)
+    .where(and(
+      eq(accounts.provider, 'google'),
+      eq(accounts.providerAccountId, providerAccountId)
+    ))
+    .limit(1)
+  return rows[0]?.userId ?? null
+}
+
+async function findLegacyTelegramUserId(tx: IdentityDb, provider: IdentityProvider, providerAccountId: string): Promise<string | null> {
+  if (provider !== 'telegram') return null
+  const legacyUserId = `telegram:${providerAccountId}`
+  const rows = await tx
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, legacyUserId))
+    .limit(1)
+  return rows[0]?.id ?? null
+}
+
+async function selectResolvedUser(tx: IdentityDb, userId: string, isNew: boolean): Promise<ResolvedIdentityUser> {
+  const rows = await tx
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      image: users.image,
+      telegramUsername: users.telegramUsername,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
+
+  const user = rows[0]
+  if (!user) throw new Error(`User not found for identity: ${userId}`)
+  return { ...user, isNew }
+}
+
+async function updateUserCache(
+  tx: IdentityDb,
+  userId: string,
+  provider: IdentityProvider,
+  profile: IdentityProfile,
+  now: Date
+): Promise<void> {
+  await tx
+    .update(users)
+    .set({
+      authProvider: provider,
+      lastSignInAt: now,
+      lastActivityAt: now,
+      ...(profile.name ? { name: profile.name } : {}),
+      ...(profile.image ? { image: profile.image } : {}),
+      ...(normalizeTelegramContact(profile.telegramUsername) ? { telegramUsername: normalizeTelegramContact(profile.telegramUsername) } : {}),
+      ...(profile.isAdmin !== undefined ? { isAdmin: profile.isAdmin } : {}),
+    })
+    .where(eq(users.id, userId))
+}
+
+async function upsertIdentity(
+  tx: IdentityDb,
+  userId: string,
+  provider: IdentityProvider,
+  providerAccountId: string,
+  profile: IdentityProfile,
+  now: Date
+): Promise<string> {
+  const rows = await tx
+    .insert(userIdentities)
+    .values({
+      userId,
+      provider,
+      providerAccountId,
+      email: normalizeEmail(profile.email),
+      telegramUsername: normalizeTelegramContact(profile.telegramUsername),
+      lastSeenAt: now,
+      metadata: metadataToText(profile.metadata),
+    })
+    .onConflictDoUpdate({
+      target: [userIdentities.provider, userIdentities.providerAccountId],
+      set: {
+        email: normalizeEmail(profile.email),
+        telegramUsername: normalizeTelegramContact(profile.telegramUsername),
+        lastSeenAt: now,
+        metadata: metadataToText(profile.metadata),
+      },
+    })
+    .returning({ userId: userIdentities.userId })
+  return rows[0]?.userId ?? userId
+}
+
+async function syncGoogleAccount(tx: IdentityDb, userId: string, provider: IdentityProvider, providerAccountId: string): Promise<void> {
+  if (provider !== 'google') return
+  const existingAccountUserId = await findGoogleAccountUserId(tx, provider, providerAccountId)
+  if (existingAccountUserId && existingAccountUserId !== userId) {
+    throw new Error(`Google account ${providerAccountId} is already linked to another user`)
+  }
+
+  await tx
+    .insert(accounts)
+    .values({
+      userId,
+      type: 'oidc',
+      provider: 'google',
+      providerAccountId,
+    })
+    .onConflictDoNothing({
+      target: [accounts.provider, accounts.providerAccountId],
+    })
+}
+
+export async function linkIdentityToUser(
+  userId: string,
+  provider: RawIdentityProvider | string,
+  providerAccountId: string,
+  profile: IdentityProfile = {}
+): Promise<ResolvedIdentityUser> {
+  return withIdentityTransaction(async (tx) => {
+    const normalizedProvider = normalizeIdentityProvider(provider)
+    const normalizedProviderAccountId = normalizeProviderAccountId(normalizedProvider, providerAccountId)
+    const now = profile.now ?? new Date()
+    const existingGoogleAccountUserId = await findGoogleAccountUserId(tx, normalizedProvider, normalizedProviderAccountId)
+    if (existingGoogleAccountUserId && existingGoogleAccountUserId !== userId) {
+      throw new Error(`Google account ${normalizedProviderAccountId} is already linked to another user`)
+    }
+    const existingIdentityUserId = await findIdentityUserId(tx, normalizedProvider, normalizedProviderAccountId)
+    if (existingIdentityUserId && existingIdentityUserId !== userId) {
+      throw new Error(`Identity ${normalizedProvider}:${normalizedProviderAccountId} is already linked to another user`)
+    }
+    const identityUserId = await upsertIdentity(tx, userId, normalizedProvider, normalizedProviderAccountId, profile, now)
+    await updateUserCache(tx, identityUserId, normalizedProvider, profile, now)
+    await syncGoogleAccount(tx, identityUserId, normalizedProvider, normalizedProviderAccountId)
+    return selectResolvedUser(tx, identityUserId, false)
+  })
+}
+
+export async function resolveOrCreateUserFromIdentity(
+  provider: RawIdentityProvider | string,
+  providerAccountId: string,
+  profile: IdentityProfile = {}
+): Promise<ResolvedIdentityUser> {
+  return withIdentityTransaction(async (tx) => {
+    const normalizedProvider = normalizeIdentityProvider(provider)
+    const normalizedProviderAccountId = normalizeProviderAccountId(normalizedProvider, providerAccountId)
+    const now = profile.now ?? new Date()
+    const email = normalizeEmail(profile.email)
+
+    const existingIdentityUserId = await findIdentityUserId(tx, normalizedProvider, normalizedProviderAccountId)
+
+    if (existingIdentityUserId) {
+      const userId = existingIdentityUserId
+      await upsertIdentity(tx, userId, normalizedProvider, normalizedProviderAccountId, profile, now)
+      await updateUserCache(tx, userId, normalizedProvider, profile, now)
+      await syncGoogleAccount(tx, userId, normalizedProvider, normalizedProviderAccountId)
+      return selectResolvedUser(tx, userId, false)
+    }
+
+    const linkedByAccountUserId = await findGoogleAccountUserId(tx, normalizedProvider, normalizedProviderAccountId)
+    const linkedByEmailUserId = !linkedByAccountUserId && canLinkByEmail(normalizedProvider, profile, email)
+      ? await findUserIdByEmail(tx, email)
+      : null
+    const legacyTelegramUserId = await findLegacyTelegramUserId(tx, normalizedProvider, normalizedProviderAccountId)
+    const userId = profile.userId ?? linkedByAccountUserId ?? linkedByEmailUserId ?? legacyTelegramUserId ?? crypto.randomUUID()
+    const isNew = !profile.userId && !linkedByAccountUserId && !linkedByEmailUserId && !legacyTelegramUserId
+
+    if (isNew) {
+      await tx.insert(users).values({
+        id: userId,
+        email: userInsertEmail(normalizedProvider, normalizedProviderAccountId, email),
+        name: profile.name ?? email ?? normalizeTelegramContact(profile.telegramUsername) ?? normalizedProviderAccountId,
+        emailVerified: email && normalizedProvider !== 'telegram' ? now : null,
+        image: profile.image ?? null,
+        telegramUsername: normalizeTelegramContact(profile.telegramUsername),
+        authProvider: normalizedProvider,
+        lastSignInAt: now,
+        lastActivityAt: now,
+        isAdmin: profile.isAdmin ?? false,
+      })
+    } else {
+      await updateUserCache(tx, userId, normalizedProvider, profile, now)
+    }
+
+    const identityUserId = await upsertIdentity(tx, userId, normalizedProvider, normalizedProviderAccountId, profile, now)
+    await syncGoogleAccount(tx, identityUserId, normalizedProvider, normalizedProviderAccountId)
+    return selectResolvedUser(tx, identityUserId, isNew && identityUserId === userId)
+  })
+}


### PR DESCRIPTION
## Summary
- Add `user_identities` schema/migration and identity helper for Google, email, and Telegram.
- Move new Telegram auth and Google One Tap flows to canonical `users.id` resolution while preserving legacy `telegram:*` compatibility.
- Sync Google OAuth and email magic-link sign-ins into identities without writing during magic-link verification-request pre-send.
- Update test-mode session/signup/user helpers and E2E fixtures to use canonical user ids.

## Safety notes
- Release B only: no physical legacy `telegram:*` primary-key migration and no nullable email migration.
- `users.email` remains NOT NULL; Telegram still uses a technical placeholder email until the nullable-email release.
- Google `account` ownership is checked before identity upserts; account conflicts do not reassign users.
- `drizzle/0013_user_identities.sql` was manually applied to the current Neon DB for E2E verification because the existing Drizzle migration journal is desynced.

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm test -- --runInBand` (57 suites / 484 tests)
- `npm run build`
- `npm run test:e2e -- e2e/telegram-auth.spec.ts` (2/2)
- `npm run test:e2e -- e2e/telegram-auth.spec.ts e2e/admin-users.spec.ts e2e/admin-delete-user.spec.ts e2e/admin-book-status.spec.ts e2e/ui-states.spec.ts e2e/signup.spec.ts e2e/profile.spec.ts e2e/submit-book.spec.ts` (35/35)

E2E: нужен — изменена auth chain, Telegram preauth, canonical session ids и test-session fixtures.
