### PR TITLE
Release C: physical PK migration + cleanup

### DIFF
--- a/docs/planning-artifacts/user-identity-release-c-migration.md
+++ b/docs/planning-artifacts/user-identity-release-c-migration.md
@@ -1,0 +1,57 @@
+# Release C: миграция legacy Telegram PK → UUID
+
+**Дата:** 2026-05-19
+**Issue:** [#122](https://github.com/bon2362/book-club/issues/122)
+**План:** [user-identity-activity-refactor-plan.md](./user-identity-activity-refactor-plan.md), Этап 8
+
+## Что сделано
+
+Завершён последний релиз из плана — физическая замена primary key у двух legacy пользователей с `users.id = "telegram:<numeric_id>"` на canonical UUID. После миграции `users.id` всегда UUID; provider id хранится только в `user_identities`.
+
+## Затронутые пользователи
+
+| telegram_username | старый id | новый UUID |
+|---|---|---|
+| MashaaKaaa | `telegram:63199968` | `68ed5db4-191e-4c80-a914-d4daf88e5e90` |
+| julia555x | `telegram:1793660681` | `1ce37975-e4ab-4aff-b409-6b93ce2f5c85` |
+
+Synthetic email `telegram:<id>@telegram.user` сохранён (display-forbidden, скрыт formatter'ом из Release A). Реальная очистка email — отдельная схемная задача.
+
+## FK-строки, переписанные на новые UUID
+
+| таблица | строк |
+|---|---|
+| book_priorities | 14 |
+| book_submissions | 5 |
+| signup_books | 16 |
+| user_activity_events | 37 |
+| user_identities | 2 |
+| **итого** | **74** |
+
+Таблицы `account`, `session`, `feedback`, `telegram_preauth_tokens` legacy-строк не содержали.
+
+## Инварианты после миграции
+
+- Остатков `telegram:%` ни в одной из 9 FK-таблиц: **0**
+- Orphan FK rows: **0**
+- Дубликатов `(provider, provider_account_id)` в `user_identities`: **0**
+- Total users: **10** (никого не потеряли)
+- Lookup по Telegram numeric id (`63199968`, `1793660681`) через `user_identities` корректно резолвит canonical UUID
+
+## Процесс
+
+1. Backfill `user_identities` для legacy юзеров (idempotent, перед PK-миграцией).
+2. На каждого юзера — одна транзакция:
+   - временно переименовать email старого юзера (UNIQUE constraint);
+   - INSERT нового user row с UUID, копируя все поля и оригинальный email;
+   - UPDATE всех FK-таблиц со старого id на новый;
+   - DELETE старой user row.
+
+## Сайд-эффекты
+
+- Оба пользователя будут разлогинены при следующем заходе (JWT в куках содержит `telegram:NNN`, такого id в БД больше нет). При повторном входе через Telegram `resolveOrCreateUserFromIdentity('telegram', numericId)` находит их по `user_identities.provider_account_id` и логинит в тот же аккаунт со всеми данными.
+- Удалён dead-код `findLegacyTelegramUserId` в `lib/user-identities.ts` и соответствующий unit-тест.
+
+## Скрипты
+
+Скрипты миграции (`check-telegram-ids.mjs`, `backfill-legacy-telegram-identities.mjs`, `migrate-legacy-telegram-pks.mjs`, `verify-pk-migration.mjs`) выполнены одноразово и не сохранены в репо. Миграция повторно не воспроизводится: `telegram:*` пользователей в `users` больше нет.

--- a/lib/user-identities.test.ts
+++ b/lib/user-identities.test.ts
@@ -143,27 +143,6 @@ describe('user identity helpers', () => {
     }))
   })
 
-  it('линкует новую Telegram identity к legacy telegram:* user вместо физической миграции id', async () => {
-    queueSelects(
-      [],
-      [{ id: 'telegram:123' }],
-      [{ id: 'telegram:123', email: 'telegram:123@telegram.user', name: 'Legacy', image: null, telegramUsername: 'legacy' }]
-    )
-    const insertChains = mockInserts()
-    mockUpdate()
-
-    const result = await resolveOrCreateUserFromIdentity('telegram', '123', { telegramUsername: 'legacy' })
-
-    expect(result.id).toBe('telegram:123')
-    expect(insertChains.some(chain => chain.table === users)).toBe(false)
-    expect(insertChains[0].table).toBe(userIdentities)
-    expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
-      userId: 'telegram:123',
-      provider: 'telegram',
-      providerAccountId: '123',
-    }))
-  })
-
   it('линкует trusted Google identity к существующему user by email и синхронизирует account', async () => {
     queueSelects(
       [],

--- a/lib/user-identities.ts
+++ b/lib/user-identities.ts
@@ -142,17 +142,6 @@ async function findGoogleAccountUserId(tx: IdentityDb, provider: IdentityProvide
   return rows[0]?.userId ?? null
 }
 
-async function findLegacyTelegramUserId(tx: IdentityDb, provider: IdentityProvider, providerAccountId: string): Promise<string | null> {
-  if (provider !== 'telegram') return null
-  const legacyUserId = `telegram:${providerAccountId}`
-  const rows = await tx
-    .select({ id: users.id })
-    .from(users)
-    .where(eq(users.id, legacyUserId))
-    .limit(1)
-  return rows[0]?.id ?? null
-}
-
 async function selectResolvedUser(tx: IdentityDb, userId: string, isNew: boolean): Promise<ResolvedIdentityUser> {
   const rows = await tx
     .select({
@@ -294,9 +283,8 @@ export async function resolveOrCreateUserFromIdentity(
     const linkedByEmailUserId = !linkedByAccountUserId && canLinkByEmail(normalizedProvider, profile, email)
       ? await findUserIdByEmail(tx, email)
       : null
-    const legacyTelegramUserId = await findLegacyTelegramUserId(tx, normalizedProvider, normalizedProviderAccountId)
-    const userId = profile.userId ?? linkedByAccountUserId ?? linkedByEmailUserId ?? legacyTelegramUserId ?? crypto.randomUUID()
-    const isNew = !profile.userId && !linkedByAccountUserId && !linkedByEmailUserId && !legacyTelegramUserId
+    const userId = profile.userId ?? linkedByAccountUserId ?? linkedByEmailUserId ?? crypto.randomUUID()
+    const isNew = !profile.userId && !linkedByAccountUserId && !linkedByEmailUserId
 
     if (isNew) {
       await tx.insert(users).values({


### PR DESCRIPTION
## Summary

Завершает [#122](https://github.com/bon2362/book-club/issues/122) — последний релиз из плана user-identity refactor.

- Физическая миграция двух последних legacy `telegram:*` пользователей на canonical UUID (выполнена прямо в prod БД ранее в этой сессии)
- Удалён dead-код `findLegacyTelegramUserId` и его unit-тест: путь недостижим, в `users` нет ни одного `telegram:*` id
- Документация миграции: `docs/planning-artifacts/user-identity-release-c-migration.md` с маппингом старый id → UUID, FK counts (74 строки), инвариантами

## Сайд-эффект на проде

Два затронутых пользователя (`MashaaKaaa`, `julia555x`) будут разлогинены при следующем заходе (JWT-кука с `telegram:NNN`, такого id в БД больше нет). Повторный вход через Telegram → `user_identities.provider_account_id` резолвит canonical UUID → тот же аккаунт со всеми данными.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (identity suites: 425 passed)
- [ ] Post-merge: убедиться что Vercel prod deployment READY и https://www.slowreading.club отвечает 200

E2E не добавлял: удалён только мёртвый fallback, остальные ветки `resolveOrCreateUserFromIdentity` покрыты существующими unit/E2E тестами и не менялись.

🤖 Generated with [Claude Code](https://claude.com/claude-code)