### PR TITLE
fix(tests): align user-identities mock with removed legacy select

### DIFF
--- a/lib/user-identities.test.ts
+++ b/lib/user-identities.test.ts
@@ -114,7 +114,6 @@ describe('user identity helpers', () => {
   it('создаёт нового Telegram user с UUID и technical placeholder email', async () => {
     queueSelects(
       [],
-      [],
       [{ id: 'generated-uuid', email: 'telegram:123@telegram.user', name: 'Ivan', image: null, telegramUsername: 'ivan' }]
     )
     const insertChains = mockInserts()


### PR DESCRIPTION
## Summary
Hotfix для CI на main после merge #125. Тест 'создаёт нового Telegram user с UUID' падал с 'User not found for identity: generated-uuid' — после удаления findLegacyTelegramUserId Telegram-флоу делает на один SELECT меньше, но queueSelects продолжал подавать три ответа.

## Test plan
- [x] npm test (jest lib/user-identities.test.ts): 9/9 passed
- [ ] CI на main зелёный после merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)