### PR TITLE
Record user_created activity events

### DIFF
--- a/drizzle/0017_user_created_activity_backfill.sql
+++ b/drizzle/0017_user_created_activity_backfill.sql
@@ -1,0 +1,42 @@
+INSERT INTO "user_activity_events" (
+	"id",
+	"user_id",
+	"type",
+	"occurred_at",
+	"source",
+	"source_id",
+	"dedupe_key",
+	"metadata"
+)
+SELECT
+	concat('backfill:user_created:', u."id"),
+	u."id",
+	'user_created',
+	u."created_at",
+	'backfill',
+	'user',
+	concat('backfill:user_created:', u."id"),
+	json_build_object('sourceTable', 'user', 'sourceColumn', 'created_at')::text
+FROM "user" u
+WHERE u."created_at" IS NOT NULL
+ON CONFLICT ("dedupe_key") DO NOTHING;
+--> statement-breakpoint
+WITH latest_activity AS (
+	SELECT
+		"user_id",
+		max("occurred_at") AS "occurred_at"
+	FROM "user_activity_events"
+	GROUP BY "user_id"
+)
+UPDATE "user" u
+SET "last_activity_at" = CASE
+	WHEN u."last_activity_at" IS NULL OR u."last_activity_at" < latest_activity."occurred_at"
+		THEN latest_activity."occurred_at"
+	ELSE u."last_activity_at"
+END
+FROM latest_activity
+WHERE u."id" = latest_activity."user_id"
+	AND (
+		u."last_activity_at" IS NULL
+		OR u."last_activity_at" < latest_activity."occurred_at"
+	);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1779290200000,
       "tag": "0016_seed_intro_sections",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1779438400000,
+      "tag": "0017_user_created_activity_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/user-created-activity-migration.test.ts
+++ b/drizzle/user-created-activity-migration.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+describe('0017 user_created activity backfill migration', () => {
+  const sql = readFileSync(join(process.cwd(), 'drizzle/0017_user_created_activity_backfill.sql'), 'utf8')
+
+  it('creates one user_created event per existing user from created_at with stable dedupe keys', () => {
+    expect(sql).toContain('FROM "user" u')
+    expect(sql).toContain('\'user_created\'')
+    expect(sql).toContain('u."created_at"')
+    expect(sql).toContain('concat(\'backfill:user_created:\', u."id")')
+    expect(sql).toContain('ON CONFLICT ("dedupe_key") DO NOTHING')
+  })
+
+  it('updates last_activity_at only when the backfilled event is newer or the cache is missing', () => {
+    expect(sql).toContain('max("occurred_at") AS "occurred_at"')
+    expect(sql).toContain('WHEN u."last_activity_at" IS NULL OR u."last_activity_at" < latest_activity."occurred_at"')
+    expect(sql).toContain('ELSE u."last_activity_at"')
+    expect(sql).toContain('u."last_activity_at" IS NULL')
+    expect(sql).toContain('OR u."last_activity_at" < latest_activity."occurred_at"')
+  })
+})

--- a/lib/user-identities.test.ts
+++ b/lib/user-identities.test.ts
@@ -11,7 +11,7 @@ jest.mock('@/lib/db', () => ({
 }))
 
 import { db } from '@/lib/db'
-import { accounts, userIdentities, users } from '@/lib/db/schema'
+import { accounts, userActivityEvents, userIdentities, users } from '@/lib/db/schema'
 import {
   IdentityConflictError,
   linkIdentityToUser,
@@ -137,8 +137,21 @@ describe('user identity helpers', () => {
       authProvider: expect.anything(),
       lastSignInAt: expect.anything(),
     }))
-    expect(insertChains[1].table).toBe(userIdentities)
+    expect(insertChains[1].table).toBe(userActivityEvents)
     expect(insertChains[1].lastValues).toEqual(expect.objectContaining({
+      userId: 'generated-uuid',
+      type: 'user_created',
+      occurredAt: expect.any(Date),
+      source: 'auth',
+      sourceId: 'telegram',
+      dedupeKey: 'user_created:generated-uuid',
+      metadata: JSON.stringify({ provider: 'telegram' }),
+    }))
+    expect(insertChains[1].onConflictDoNothing).toHaveBeenCalledWith({
+      target: userActivityEvents.dedupeKey,
+    })
+    expect(insertChains[2].table).toBe(userIdentities)
+    expect(insertChains[2].lastValues).toEqual(expect.objectContaining({
       userId: 'generated-uuid',
       provider: 'telegram',
       providerAccountId: '123',
@@ -166,6 +179,7 @@ describe('user identity helpers', () => {
 
     expect(result.id).toBe('user-uuid')
     expect(insertChains.some(chain => chain.table === users)).toBe(false)
+    expect(insertChains.some(chain => chain.table === userActivityEvents)).toBe(false)
     expect(insertChains[0].table).toBe(userIdentities)
     expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
       userId: 'user-uuid',
@@ -203,6 +217,7 @@ describe('user identity helpers', () => {
 
     expect(result.id).toBe('account-owner')
     expect(insertChains.some(chain => chain.table === users)).toBe(false)
+    expect(insertChains.some(chain => chain.table === userActivityEvents)).toBe(false)
     expect(insertChains[0].table).toBe(userIdentities)
     expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
       userId: 'account-owner',

--- a/lib/user-identities.ts
+++ b/lib/user-identities.ts
@@ -1,6 +1,6 @@
 import { and, eq } from 'drizzle-orm'
 import { db } from '@/lib/db'
-import { accounts, userIdentities, users } from '@/lib/db/schema'
+import { accounts, userActivityEvents, userIdentities, users } from '@/lib/db/schema'
 
 export const IDENTITY_PROVIDERS = ['google', 'email', 'telegram'] as const
 
@@ -185,6 +185,31 @@ async function updateUserCache(
     .where(eq(users.id, userId))
 }
 
+async function bestEffortRecordUserCreated(
+  tx: IdentityDb,
+  userId: string,
+  provider: IdentityProvider,
+  now: Date
+): Promise<void> {
+  try {
+    await tx
+      .insert(userActivityEvents)
+      .values({
+        userId,
+        type: 'user_created',
+        occurredAt: now,
+        source: 'auth',
+        sourceId: provider,
+        dedupeKey: `user_created:${userId}`,
+        metadata: JSON.stringify({ provider }),
+      })
+      .onConflictDoNothing({ target: userActivityEvents.dedupeKey })
+  } catch (error) {
+    const errorName = error instanceof Error ? error.name : typeof error
+    console.error('Failed to record user_created activity', { errorName })
+  }
+}
+
 async function upsertIdentity(
   tx: IdentityDb,
   userId: string,
@@ -301,6 +326,7 @@ export async function resolveOrCreateUserFromIdentity(
         lastActivityAt: now,
         isAdmin: profile.isAdmin ?? false,
       })
+      await bestEffortRecordUserCreated(tx, userId, normalizedProvider, now)
     } else {
       await updateUserCache(tx, userId, profile, now)
     }


### PR DESCRIPTION
## Summary
- record `user_created` activity when `resolveOrCreateUserFromIdentity` inserts a new user
- add idempotent 0017 backfill for existing users
- cover runtime and migration behavior with focused tests

## Verification
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- npm run build

E2E: не нужен — изменение не затрагивает UI/browser flow или auth redirect/session chain; только server-side activity logging and data backfill.

Closes #130