### PR TITLE
Clarify user email contact semantics

### DIFF
--- a/app/api/admin/submissions/[id]/route.test.ts
+++ b/app/api/admin/submissions/[id]/route.test.ts
@@ -119,6 +119,17 @@ describe('PATCH /api/admin/submissions/[id] — happy path', () => {
     expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({ to: 'user@test.com', subject: 'Одобрено' }))
   })
 
+  it('не отправляет email на технический Telegram-only адрес', async () => {
+    mockSelect.mockReset()
+    mockSelect
+      .mockResolvedValueOnce([{ title: 'Сапиенс', status: 'approved' }])
+      .mockResolvedValue([{ email: 'telegram:123456@telegram.user' }])
+
+    await PATCH(makeRequest('sub-1', { status: 'approved' }), { params: { id: 'sub-1' } })
+
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
   it('записывает автора заявки на книгу при статусе approved', async () => {
     await PATCH(makeRequest('sub-1', { status: 'approved' }), { params: { id: 'sub-1' } })
     expect(mockInsertValues).toHaveBeenCalledWith({ userId: 'user-1', bookName: 'Сапиенс' })

--- a/app/api/admin/submissions/[id]/route.ts
+++ b/app/api/admin/submissions/[id]/route.ts
@@ -7,6 +7,7 @@ import { bookSubmissions, signupBooks, bookPriorities, users } from '@/lib/db/sc
 import { eq } from 'drizzle-orm'
 import { Resend } from 'resend'
 import { approvedEmail, rejectedEmail } from '@/lib/email-templates/submission-status'
+import { getContactEmail } from '@/lib/user-email'
 
 export async function DELETE(
   _req: NextRequest,
@@ -107,13 +108,15 @@ export async function PATCH(
       .where(eq(users.id, submission.userId))
       .limit(1)
 
-    if (userRow?.email) {
+    const contactEmail = getContactEmail(userRow?.email)
+
+    if (contactEmail) {
       const template = status === 'approved'
         ? approvedEmail(submission.title)
         : rejectedEmail(submission.title, submission.rejectionReason)
       try {
         const resend = new Resend(process.env.RESEND_API_KEY!)
-        await resend.emails.send({ from: FROM, to: userRow.email, ...template })
+        await resend.emails.send({ from: FROM, to: contactEmail, ...template })
       } catch (e) {
         console.error('Email send failed:', e)
       }

--- a/app/api/cron/digest/route.test.ts
+++ b/app/api/cron/digest/route.test.ts
@@ -162,6 +162,16 @@ describe('GET /api/cron/digest', () => {
     expect(callArg.subject).toMatch(/дайджест/i)
   })
 
+  it('не добавляет пустую строку Email в дайджест', async () => {
+    const cooledRow = makeRow({ userEmail: '' })
+    setupDbMock([cooledRow])
+    const res = await GET(makeRequest({ secret: VALID_SECRET }))
+    expect(res.status).toBe(200)
+    const callArg = mockEmailSend.mock.calls[0][0]
+    expect(callArg.text).toContain('Контакт: @test')
+    expect(callArg.text).not.toContain('Email:')
+  })
+
   it('отправляет дайджест при принудительном сбросе (старейшая строка > 2 ч)', async () => {
     const oldRow = makeRow({
       id: 'old',

--- a/app/api/cron/digest/route.ts
+++ b/app/api/cron/digest/route.ts
@@ -73,7 +73,8 @@ export async function GET(req: Request) {
   const lines = captured.map((r, i) => {
     const books = JSON.parse(r.addedBooks) as string[]
     const label = r.isNew ? 'новая запись' : 'обновление'
-    return `${i + 1}. ${r.userName} (${label})\n   Контакт: ${r.contacts}\n   Email: ${r.userEmail}\n   Книги: ${books.join(', ')}`
+    const emailLine = r.userEmail ? `\n   Email: ${r.userEmail}` : ''
+    return `${i + 1}. ${r.userName} (${label})\n   Контакт: ${r.contacts}${emailLine}\n   Книги: ${books.join(', ')}`
   })
   const text = `${subject}\n\n${lines.join('\n\n')}`
 

--- a/app/api/signup/route.test.ts
+++ b/app/api/signup/route.test.ts
@@ -52,29 +52,36 @@ describe('POST /api/signup', () => {
     expect(res.status).toBe(401)
   })
 
-  it('возвращает 400 при пустом name', async () => {
+  it('возвращает 401 если в сессии нет user.id', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com' } })
+
+    const res = await POST(makeRequest({ name: 'Test', contacts: 'tg', selectedBooks: [] }))
+    expect(res.status).toBe(401)
+  })
+
+  it('возвращает 400 при пустом name', async () => {
+    mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
 
     const res = await POST(makeRequest({ name: '   ', contacts: 'tg', selectedBooks: [] }))
     expect(res.status).toBe(400)
   })
 
   it('возвращает 400 при некорректном contacts (не строка)', async () => {
-    mockAuth.mockResolvedValue({ user: { email: 'test@test.com' } })
+    mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
 
     const res = await POST(makeRequest({ name: 'Test', contacts: 123, selectedBooks: [] }))
     expect(res.status).toBe(400)
   })
 
   it('возвращает 400 при отсутствии selectedBooks', async () => {
-    mockAuth.mockResolvedValue({ user: { email: 'test@test.com' } })
+    mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
 
     const res = await POST(makeRequest({ name: 'Test', contacts: 'tg' }))
     expect(res.status).toBe(400)
   })
 
   it('возвращает 400 если selectedBooks не массив', async () => {
-    mockAuth.mockResolvedValue({ user: { email: 'test@test.com' } })
+    mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
 
     const res = await POST(makeRequest({ name: 'Test', contacts: 'tg', selectedBooks: 'Book A' }))
     expect(res.status).toBe(400)
@@ -180,6 +187,22 @@ describe('POST /api/signup', () => {
         contacts: '@t',
         addedBooks: JSON.stringify(['Книга А', 'Книга Б']),
         isNew: true,
+      })
+    )
+  })
+
+  it('не пишет технический Telegram-only email в очередь уведомлений', async () => {
+    const mockValues = jest.fn().mockReturnValue({ catch: jest.fn() })
+    mockInsert.mockReturnValue({ values: mockValues })
+    mockAuth.mockResolvedValue({ user: { email: 'telegram:123456@telegram.user', id: 'user-1' } })
+    mockUpsertSignup.mockResolvedValue({ isNew: true, addedBooks: ['Книга А'] })
+
+    await POST(makeRequest({ name: 'Test', contacts: '@telegram', selectedBooks: ['Книга А'] }))
+
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userEmail: '',
+        contacts: '@telegram',
       })
     )
   })

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -5,10 +5,12 @@ import { db } from '@/lib/db'
 import { bookPriorities, notificationQueue, users } from '@/lib/db/schema'
 import { and, eq, notInArray } from 'drizzle-orm'
 import { bestEffortRecordUserActivity, buildUserActivityDedupeKey } from '@/lib/user-activity'
+import { getContactEmail } from '@/lib/user-email'
 
 export async function POST(req: NextRequest) {
   const session = await auth()
-  if (!session?.user?.email) {
+  const pgUserId = session?.user?.id
+  if (!pgUserId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -17,11 +19,6 @@ export async function POST(req: NextRequest) {
 
   if (!name?.trim() || typeof contacts !== 'string' || !Array.isArray(selectedBooks)) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
-  }
-
-  const pgUserId = session.user.id
-  if (!pgUserId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const selectedBookNames = selectedBooks as string[]
@@ -87,7 +84,7 @@ export async function POST(req: NextRequest) {
   if (result.addedBooks.length > 0 && process.env.NEXTAUTH_TEST_MODE !== 'true') {
     db.insert(notificationQueue).values({
       userName: name.trim(),
-      userEmail: session.user.email,
+      userEmail: getContactEmail(session.user.email) ?? '',
       contacts: contacts.trim(),
       addedBooks: JSON.stringify(result.addedBooks),
       isNew: result.isNew,

--- a/components/nd/BooksPage.tsx
+++ b/components/nd/BooksPage.tsx
@@ -20,6 +20,7 @@ import AboutBlock, { type AboutBlockHandle, type AboutBlockHeader, type AboutBlo
 import Footer from './Footer'
 import FeedbackForm from './FeedbackForm'
 import { useScrollHide } from '@/lib/scroll-hide-context'
+import { getContactEmail } from '@/lib/user-email'
 
 interface Props {
   books: BookWithCover[]
@@ -41,10 +42,11 @@ async function saveSelection(name: string, contacts: string, books: string[]) {
 export default function BooksPage({ books, currentUser, tagDescriptions, introHeader, introSections }: Props) {
   const { data: session } = useSession()
   const { isHidden } = useScrollHide()
-  const isLoggedIn = !!session?.user?.email
+  const isLoggedIn = !!session?.user?.id
   const isAdmin = !!session?.user?.isAdmin
   const telegramUsername = session?.user?.telegramUsername ?? null
   const telegramName = session?.user?.name ?? null
+  const contactEmail = getContactEmail(session?.user?.email)
 
   const [aboutVisible, setAboutVisible] = useState(true)
   const aboutRef = useRef<AboutBlockHandle>(null)
@@ -103,6 +105,8 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
   const [selectedBooks, setSelectedBooks] = useState<string[]>(
     currentUser?.selectedBooks ?? []
   )
+  const selectedBooksRef = useRef(selectedBooks)
+  const saveSelectionQueueRef = useRef<Promise<void>>(Promise.resolve())
   const [authModalOpen, setAuthModalOpen] = useState(false)
   const [showContactsForm, setShowContactsForm] = useState(false)
   const [profileDrawerOpen, setProfileDrawerOpen] = useState(false)
@@ -112,11 +116,23 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
   const [submitIntent, setSubmitIntent] = useState(false)
   const [feedbackFormOpen, setFeedbackFormOpen] = useState(false)
 
+  function enqueueSaveSelection(name: string, contacts: string, booksList: string[]): Promise<void> {
+    const nextSave = saveSelectionQueueRef.current
+      .catch(() => undefined)
+      .then(() => saveSelection(name, contacts, booksList))
+    saveSelectionQueueRef.current = nextSave
+    return nextSave
+  }
+
   useEffect(() => {
     if (!showPriorityHint || priorityHintPaused) return
     const t = setTimeout(() => setShowPriorityHint(false), 20000)
     return () => clearTimeout(t)
   }, [showPriorityHint, priorityHintPaused])
+
+  useEffect(() => {
+    selectedBooksRef.current = selectedBooks
+  }, [selectedBooks])
 
   useEffect(() => {
     const stored = localStorage.getItem('submitIntent') === '1'
@@ -157,7 +173,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
         // Telegram users already provided name and username — auto-save without showing the form
         const name = telegramName || telegramUsername
         const contacts = '@' + telegramUsername
-        saveSelection(name, contacts, [])
+        enqueueSaveSelection(name, contacts, [])
           .then(() => setSavedUser({ name, contacts }))
           .catch(console.error)
       } else {
@@ -202,12 +218,14 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
       return
     }
 
-    const isAdding = !selectedBooks.includes(book.name)
+    const currentSelection = selectedBooksRef.current
+    const isAdding = !currentSelection.includes(book.name)
     const next = isAdding
-      ? [...selectedBooks, book.name]
-      : selectedBooks.filter(n => n !== book.name)
+      ? [...currentSelection, book.name]
+      : currentSelection.filter(n => n !== book.name)
 
     track(isAdding ? 'book_signup' : 'book_unsignup', { bookName: book.name })
+    selectedBooksRef.current = next
     setSelectedBooks(next)
 
     if (isAdding && next.length === 2 && !localStorage.getItem('hint_priorities_seen')) {
@@ -215,16 +233,17 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
       setShowPriorityHint(true)
     }
 
-    saveSelection(effectiveUser.name, effectiveUser.contacts, next).catch(console.error)
+    enqueueSaveSelection(effectiveUser.name, effectiveUser.contacts, next).catch(console.error)
   }
 
   async function handleSaveContacts(name: string, contacts: string) {
     const booksList = pendingBook
-      ? [...selectedBooks, pendingBook.name]
-      : selectedBooks
-    await saveSelection(name, contacts, booksList)
+      ? [...selectedBooksRef.current, pendingBook.name]
+      : selectedBooksRef.current
+    await enqueueSaveSelection(name, contacts, booksList)
     setSavedUser({ name, contacts })
     if (pendingBook) {
+      selectedBooksRef.current = booksList
       setSelectedBooks(booksList)
       setPendingBook(null)
     }
@@ -236,16 +255,18 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
   }
 
   async function handleToggleByName(bookName: string): Promise<void> {
-    const original = selectedBooks
-    const isAdding = !selectedBooks.includes(bookName)
+    const original = selectedBooksRef.current
+    const isAdding = !original.includes(bookName)
     const next = isAdding
-      ? [...selectedBooks, bookName]
-      : selectedBooks.filter(n => n !== bookName)
+      ? [...original, bookName]
+      : original.filter(n => n !== bookName)
     track(isAdding ? 'book_signup' : 'book_unsignup', { bookName })
+    selectedBooksRef.current = next
     setSelectedBooks(next)
     try {
-      await saveSelection(effectiveUser!.name, effectiveUser!.contacts, next)
+      await enqueueSaveSelection(effectiveUser!.name, effectiveUser!.contacts, next)
     } catch (err) {
+      selectedBooksRef.current = original
       setSelectedBooks(original) // rollback to snapshot taken before optimistic update
       throw err
     }
@@ -557,7 +578,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
           isOpen={feedbackFormOpen}
           onClose={() => setFeedbackFormOpen(false)}
           currentUser={currentUser}
-          userEmail={session?.user?.email ?? undefined}
+          userEmail={contactEmail ?? undefined}
         />
       )}
 

--- a/components/nd/Header.tsx
+++ b/components/nd/Header.tsx
@@ -6,6 +6,7 @@ import { track } from '@/lib/analytics'
 import Link from 'next/link'
 import SubmitBookButton from './SubmitBookButton'
 import { useScrollHide } from '@/lib/scroll-hide-context'
+import { getContactEmail } from '@/lib/user-email'
 
 interface Props {
   onEditProfile?: () => void
@@ -21,6 +22,9 @@ export default function Header({ onEditProfile, onSignIn, onSubmitBook, onWhatIs
   const [whatIsThisHovered, setWhatIsThisHovered] = useState(false)
   const { isHidden } = useScrollHide()
   const headerRef = useRef<HTMLElement>(null)
+  const contactEmail = getContactEmail(session?.user?.email)
+  const telegramHandle = session?.user?.telegramUsername ? `@${session.user.telegramUsername}` : null
+  const userLabel = displayName || session?.user?.name || telegramHandle || contactEmail || ''
 
   useEffect(() => {
     const el = headerRef.current
@@ -167,7 +171,7 @@ export default function Header({ onEditProfile, onSignIn, onSubmitBook, onWhatIs
                     whiteSpace: 'nowrap',
                   }}
                 >
-                  {displayName || (session.user.name ?? session.user.email)}
+                  {userLabel}
                 </button>
               )}
               {/* Mobile: кнопка входа в админку */}
@@ -218,7 +222,7 @@ export default function Header({ onEditProfile, onSignIn, onSubmitBook, onWhatIs
                     flexShrink: 0,
                   }}
                 >
-                  {(displayName || session.user.name || session.user.email || '?')[0].toUpperCase()}
+                  {(userLabel || '?')[0].toUpperCase()}
                 </button>
               )}
             </>

--- a/components/nd/ProfileDrawer.tsx
+++ b/components/nd/ProfileDrawer.tsx
@@ -20,6 +20,7 @@ import {
   arrayMove,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { getContactEmail } from '@/lib/user-email'
 
 interface Submission {
   id: string
@@ -454,7 +455,9 @@ export default function ProfileDrawer({
     })
   )
 
-  const displayName = effectiveUser?.name?.trim() || session?.user?.name || session?.user?.email || ''
+  const contactEmail = getContactEmail(session?.user?.email)
+  const telegramHandle = session?.user?.telegramUsername ? `@${session.user.telegramUsername}` : null
+  const displayName = effectiveUser?.name?.trim() || session?.user?.name || telegramHandle || contactEmail || ''
   const profileUnchanged = name.trim() === (effectiveUser?.name ?? '') && contacts.trim() === (effectiveUser?.contacts ?? '')
 
   // ─────────────────────────────────────────────
@@ -958,9 +961,7 @@ export default function ProfileDrawer({
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
                   }}>
-                    {session?.user?.telegramUsername
-                      ? '@' + session.user.telegramUsername
-                      : session?.user?.email}
+                    {telegramHandle ?? contactEmail ?? '—'}
                   </span>
                 </div>
                 <button

--- a/lib/user-email.test.ts
+++ b/lib/user-email.test.ts
@@ -1,0 +1,28 @@
+import { getContactEmail, isSyntheticTelegramEmail } from './user-email'
+
+describe('user email helpers', () => {
+  describe('isSyntheticTelegramEmail', () => {
+    it('распознаёт технический email Telegram-only пользователя', () => {
+      expect(isSyntheticTelegramEmail('telegram:123456@telegram.user')).toBe(true)
+      expect(isSyntheticTelegramEmail(' telegram:abc-def@telegram.user ')).toBe(true)
+    })
+
+    it('не считает обычные адреса синтетическими', () => {
+      expect(isSyntheticTelegramEmail('reader@example.com')).toBe(false)
+      expect(isSyntheticTelegramEmail('telegram-user@example.com')).toBe(false)
+      expect(isSyntheticTelegramEmail(null)).toBe(false)
+    })
+  })
+
+  describe('getContactEmail', () => {
+    it('возвращает обычный email без внешних пробелов', () => {
+      expect(getContactEmail(' reader@example.com ')).toBe('reader@example.com')
+    })
+
+    it('возвращает null для пустого и синтетического email', () => {
+      expect(getContactEmail('')).toBeNull()
+      expect(getContactEmail(null)).toBeNull()
+      expect(getContactEmail('telegram:123456@telegram.user')).toBeNull()
+    })
+  })
+})

--- a/lib/user-email.ts
+++ b/lib/user-email.ts
@@ -1,0 +1,11 @@
+const SYNTHETIC_TELEGRAM_EMAIL_RE = /^telegram:[^@]+@telegram\.user$/i
+
+export function isSyntheticTelegramEmail(email?: string | null): boolean {
+  return SYNTHETIC_TELEGRAM_EMAIL_RE.test(email?.trim() ?? '')
+}
+
+export function getContactEmail(email?: string | null): string | null {
+  const normalized = email?.trim()
+  if (!normalized || isSyntheticTelegramEmail(normalized)) return null
+  return normalized
+}


### PR DESCRIPTION
## Summary

- keep `user.email` as a legacy non-null auth field, but add helpers to filter synthetic Telegram-only emails from contact flows
- use `session.user.id` for signup/login gating instead of assuming `session.user.email` is a real identity signal
- avoid sending submission-status emails and admin digest email lines to synthetic Telegram addresses
- serialize book selection saves to prevent rapid signup clicks from overwriting newer selections

## Tests

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:e2e -- e2e/signup.spec.ts e2e/telegram-auth.spec.ts`

Closes #132
