### PR TITLE
Migrate user email to explicit contact email

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -20,7 +20,7 @@ export default async function AdminPage() {
     db.select().from(bookStatuses).catch(() => []),
     db.select().from(tagDescriptions).catch(() => []),
     db.select().from(bookNewFlags).catch(() => []),
-    db.select({ id: users.id, email: users.email, languages: users.languages, prioritiesSet: users.prioritiesSet }).from(users).catch(() => []),
+    db.select({ id: users.id, email: users.email, contactEmail: users.contactEmail, languages: users.languages, prioritiesSet: users.prioritiesSet }).from(users).catch(() => []),
     db.select({ userId: bookPriorities.userId, bookName: bookPriorities.bookName, rank: bookPriorities.rank }).from(bookPriorities).catch(() => []),
   ])
 

--- a/app/api/admin/submissions/[id]/route.ts
+++ b/app/api/admin/submissions/[id]/route.ts
@@ -7,7 +7,7 @@ import { bookSubmissions, signupBooks, bookPriorities, users } from '@/lib/db/sc
 import { eq } from 'drizzle-orm'
 import { Resend } from 'resend'
 import { approvedEmail, rejectedEmail } from '@/lib/email-templates/submission-status'
-import { getContactEmail } from '@/lib/user-email'
+import { getUserContactEmail } from '@/lib/user-email'
 
 export async function DELETE(
   _req: NextRequest,
@@ -103,12 +103,12 @@ export async function PATCH(
 
   if (status === 'approved' || status === 'rejected') {
     const [userRow] = await db
-      .select({ email: users.email })
+      .select({ email: users.email, contactEmail: users.contactEmail })
       .from(users)
       .where(eq(users.id, submission.userId))
       .limit(1)
 
-    const contactEmail = getContactEmail(userRow?.email)
+    const contactEmail = getUserContactEmail(userRow)
 
     if (contactEmail) {
       const template = status === 'approved'

--- a/app/api/admin/submissions/route.ts
+++ b/app/api/admin/submissions/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { bookSubmissions, users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 
 export async function GET() {
   const session = await auth()
@@ -16,7 +16,7 @@ export async function GET() {
     .select({
       id: bookSubmissions.id,
       userId: bookSubmissions.userId,
-      userEmail: users.email,
+      userEmail: sql<string | null>`coalesce(${users.contactEmail}, ${users.email})`,
       title: bookSubmissions.title,
       topic: bookSubmissions.topic,
       author: bookSubmissions.author,

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -17,6 +17,7 @@ export async function GET() {
       id: users.id,
       name: users.name,
       email: users.email,
+      contactEmail: users.contactEmail,
       contacts: users.contacts,
       telegramUsername: users.telegramUsername,
       legacyAuthProvider: users.authProvider,

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -5,7 +5,7 @@ import { db } from '@/lib/db'
 import { bookPriorities, notificationQueue, users } from '@/lib/db/schema'
 import { and, eq, notInArray } from 'drizzle-orm'
 import { bestEffortRecordUserActivity, buildUserActivityDedupeKey } from '@/lib/user-activity'
-import { getContactEmail } from '@/lib/user-email'
+import { getUserContactEmail } from '@/lib/user-email'
 
 export async function POST(req: NextRequest) {
   const session = await auth()
@@ -84,7 +84,7 @@ export async function POST(req: NextRequest) {
   if (result.addedBooks.length > 0 && process.env.NEXTAUTH_TEST_MODE !== 'true') {
     db.insert(notificationQueue).values({
       userName: name.trim(),
-      userEmail: getContactEmail(session.user.email) ?? '',
+      userEmail: getUserContactEmail(session.user) ?? '',
       contacts: contacts.trim(),
       addedBooks: JSON.stringify(result.addedBooks),
       isNew: result.isNew,

--- a/app/api/test/session/route.test.ts
+++ b/app/api/test/session/route.test.ts
@@ -84,6 +84,7 @@ describe('/api/test/session guards', () => {
     ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
       id: 'canonical-test-uuid',
       email: 'user@test.com',
+      contactEmail: 'user@test.com',
       name: 'User',
     })
 
@@ -111,7 +112,8 @@ describe('/api/test/session guards', () => {
     process.env.NEXTAUTH_SECRET = 'secret'
     ;(resolveOrCreateUserFromIdentity as jest.Mock).mockResolvedValue({
       id: 'telegram-canonical-uuid',
-      email: 'tg@test.com',
+      email: null,
+      contactEmail: null,
       name: 'Telegram User',
     })
 
@@ -124,11 +126,11 @@ describe('/api/test/session guards', () => {
 
     expect(res.status).toBe(200)
     expect(resolveOrCreateUserFromIdentity).toHaveBeenCalledWith('telegram', 'reader_tg', expect.objectContaining({
-      email: 'tg@test.com',
+      email: null,
       telegramUsername: 'reader_tg',
     }))
     expect(encode).toHaveBeenCalledWith(expect.objectContaining({
-      token: expect.objectContaining({ sub: 'telegram-canonical-uuid' }),
+      token: expect.objectContaining({ sub: 'telegram-canonical-uuid', email: null, contactEmail: null }),
     }))
   })
 })

--- a/app/api/test/session/route.ts
+++ b/app/api/test/session/route.ts
@@ -17,13 +17,17 @@ export async function POST(req: NextRequest) {
   if (!isTestEndpointAllowed()) return notAllowed()
 
   const { email, name, isAdmin, telegramUsername, provider, providerAccountId } = await req.json() as {
-    email: string; name: string; isAdmin?: boolean; telegramUsername?: string; provider?: string; providerAccountId?: string
+    email?: string; name: string; isAdmin?: boolean; telegramUsername?: string; provider?: string; providerAccountId?: string
   }
   const identityProvider = normalizeIdentityProvider(provider ?? 'email')
   const identityAccountId = providerAccountId ?? (identityProvider === 'telegram' ? telegramUsername ?? email : email)
+  const identityEmail = identityProvider === 'telegram' ? null : email
+  if (!identityAccountId) {
+    return NextResponse.json({ error: 'Missing identity account id' }, { status: 400 })
+  }
 
   const user = await resolveOrCreateUserFromIdentity(identityProvider, identityAccountId, {
-    email,
+    email: identityEmail,
     name,
     emailVerified: identityProvider !== 'telegram',
     telegramUsername: telegramUsername ?? null,
@@ -34,12 +38,12 @@ export async function POST(req: NextRequest) {
   await db.update(users).set({
     name,
     telegramUsername: telegramUsername ?? null,
-    emailVerified: new Date(),
+    emailVerified: identityProvider === 'telegram' ? null : new Date(),
     isAdmin: isAdmin ?? false,
   }).where(eq(users.id, user.id))
 
   const token = await encode({
-    token: { sub: user.id, email, name, isAdmin: isAdmin ?? false, telegramUsername: telegramUsername ?? null, provider: provider ?? null },
+    token: { sub: user.id, email: user.email ?? identityEmail ?? null, name, isAdmin: isAdmin ?? false, telegramUsername: telegramUsername ?? null, provider: provider ?? null, contactEmail: user.contactEmail },
     secret: (process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET)!,
     salt: 'authjs.session-token',
   })
@@ -55,12 +59,26 @@ export async function DELETE(req: NextRequest) {
   if (!isTestEndpointAllowed()) return notAllowed()
 
   const { email } = await req.json() as { email: string }
+  const userRows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(or(eq(users.email, email), eq(users.contactEmail, email)))
+    .limit(1)
+  const identityRows = await db
+    .select({ userId: userIdentities.userId })
+    .from(userIdentities)
+    .where(or(
+      eq(userIdentities.email, email),
+      eq(userIdentities.providerAccountId, email)
+    ))
+    .limit(1)
+  const userId = userRows[0]?.id ?? identityRows[0]?.userId ?? null
+
   await db.delete(notificationQueue).where(eq(notificationQueue.userEmail, email))
-  await db.delete(userIdentities).where(or(
-    eq(userIdentities.email, email),
-    eq(userIdentities.providerAccountId, email)
-  ))
-  await db.delete(users).where(eq(users.email, email))
+  if (userId) {
+    await db.delete(userIdentities).where(eq(userIdentities.userId, userId))
+    await db.delete(users).where(eq(users.id, userId))
+  }
 
   const res = NextResponse.json({ ok: true })
   res.cookies.delete('authjs.session-token')

--- a/app/api/test/signup/route.ts
+++ b/app/api/test/signup/route.ts
@@ -4,9 +4,9 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-import { signupBooks, users } from '@/lib/db/schema'
+import { signupBooks, userIdentities, users } from '@/lib/db/schema'
 import { upsertSignup } from '@/lib/signup-books'
-import { eq } from 'drizzle-orm'
+import { eq, or } from 'drizzle-orm'
 import { isTestEndpointAllowed } from '@/lib/test-mode'
 
 function notAllowed() {
@@ -22,9 +22,14 @@ export async function POST(req: NextRequest) {
   const rows = await db
     .select({ id: users.id })
     .from(users)
-    .where(eq(users.email, email))
+    .where(or(eq(users.email, email), eq(users.contactEmail, email)))
     .limit(1)
-  const canonicalUserId = rows[0]?.id ?? userId
+  const identityRows = rows[0]?.id ? [] : await db
+    .select({ userId: userIdentities.userId })
+    .from(userIdentities)
+    .where(or(eq(userIdentities.email, email), eq(userIdentities.providerAccountId, email)))
+    .limit(1)
+  const canonicalUserId = rows[0]?.id ?? identityRows[0]?.userId ?? userId
 
   await db.update(users).set({ name, contacts }).where(eq(users.id, canonicalUserId))
   await upsertSignup(canonicalUserId, selectedBooks)

--- a/app/api/test/user/route.ts
+++ b/app/api/test/user/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
 import { accounts, sessions, signupBooks, userIdentities, users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { eq, or } from 'drizzle-orm'
 import { isTestEndpointAllowed } from '@/lib/test-mode'
 
 function notAllowed() {
@@ -17,16 +17,33 @@ export async function GET(req: NextRequest) {
   }
 
   const rows = await db
-    .select({ id: users.id, email: users.email })
+    .select({ id: users.id, email: users.email, contactEmail: users.contactEmail })
     .from(users)
-    .where(eq(users.email, email))
+    .where(or(eq(users.email, email), eq(users.contactEmail, email)))
     .limit(1)
 
-  if (rows.length === 0) {
+  let userRow = rows[0]
+  if (!userRow) {
+    const identityRows = await db
+      .select({ userId: userIdentities.userId })
+      .from(userIdentities)
+      .where(or(eq(userIdentities.email, email), eq(userIdentities.providerAccountId, email)))
+      .limit(1)
+    if (identityRows[0]?.userId) {
+      const byIdentityRows = await db
+        .select({ id: users.id, email: users.email, contactEmail: users.contactEmail })
+        .from(users)
+        .where(eq(users.id, identityRows[0].userId))
+        .limit(1)
+      userRow = byIdentityRows[0]
+    }
+  }
+
+  if (!userRow) {
     return NextResponse.json({ exists: false, accountCount: 0, sessionCount: 0, signupBookCount: 0 })
   }
 
-  const userId = rows[0].id
+  const userId = userRow.id
   const [accountRows, sessionRows, signupBookRows, identityRows] = await Promise.all([
     db.select({ userId: accounts.userId }).from(accounts).where(eq(accounts.userId, userId)),
     db.select({ userId: sessions.userId }).from(sessions).where(eq(sessions.userId, userId)),
@@ -43,7 +60,7 @@ export async function GET(req: NextRequest) {
 
   return NextResponse.json({
     exists: true,
-    user: rows[0],
+    user: userRow,
     accountCount: accountRows.length,
     identityCount: identityRows.length,
     identities: identityRows,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,7 +45,7 @@ export default async function Home() {
     : null
   const dbUserRows = !signupUser && session?.user?.id
     ? await db
-      .select({ name: users.name, email: users.email, contacts: users.contacts })
+      .select({ name: users.name, email: users.email, contactEmail: users.contactEmail, contacts: users.contacts })
       .from(users)
       .where(eq(users.id, session.user.id))
       .limit(1)
@@ -57,6 +57,7 @@ export default async function Home() {
     userId: session!.user!.id!,
     name: dbUser.name ?? session?.user?.name ?? '',
     email: dbUser.email,
+    contactEmail: dbUser.contactEmail,
     contacts: dbUser.contacts,
     selectedBooks: [],
   } : null)

--- a/components/nd/AdminPanel.tsx
+++ b/components/nd/AdminPanel.tsx
@@ -698,7 +698,7 @@ export default function AdminPanel({
     if (feedbackFilter === 'anonymous' && item.userId) return false
     const q = feedbackSearch.trim().toLowerCase()
     if (!q) return true
-    return `${item.message} ${item.userName ?? item.name ?? ''} ${item.userEmail ?? item.email ?? ''}`.toLowerCase().includes(q)
+    return `${item.message} ${item.userName ?? item.name ?? ''} ${item.userContactEmail ?? item.userEmail ?? item.email ?? ''}`.toLowerCase().includes(q)
   })
 
   function setSort(key: UserSortKey) {
@@ -1330,7 +1330,7 @@ export default function AdminPanel({
               <div style={{ display: 'grid', gap: '0.6rem' }}>
                 {filteredFeedback.map(item => {
                   const displayName = item.userName ?? item.name ?? 'Аноним'
-                  const displayEmail = item.userEmail ?? item.email
+                  const displayEmail = item.userContactEmail ?? item.userEmail ?? item.email
                   return (
                     <article key={item.id} style={{ border: '1px solid #E5E5E5', background: '#fff', padding: '0.8rem 0.9rem' }}>
                       <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', marginBottom: '0.45rem', alignItems: 'baseline' }}>
@@ -1365,11 +1365,11 @@ export default function AdminPanel({
         onClose={closeUserDrawer}
         onRemoveSignup={(bookName) => {
           if (!selectedAdminUser) return
-          handleRemoveBook(selectedAdminUser.user.id, bookName, selectedAdminUser.user.name || selectedAdminUser.user.email)
+          handleRemoveBook(selectedAdminUser.user.id, bookName, selectedAdminUser.user.name || selectedAdminUser.user.contactEmail || selectedAdminUser.user.telegramDisplay)
         }}
         onDeleteUser={() => {
           if (!selectedAdminUser) return
-          handleDeleteUser(selectedAdminUser.user.id, selectedAdminUser.user.name || selectedAdminUser.user.email)
+          handleDeleteUser(selectedAdminUser.user.id, selectedAdminUser.user.name || selectedAdminUser.user.contactEmail || selectedAdminUser.user.telegramDisplay)
         }}
         onOpenSubmission={(submissionId) => {
           closeUserDrawer()

--- a/components/nd/AdminUserDrawer.tsx
+++ b/components/nd/AdminUserDrawer.tsx
@@ -114,7 +114,7 @@ export default function AdminUserDrawer({ isOpen, data, loading, onClose, onRemo
       <aside
         role="dialog"
         aria-modal="true"
-        aria-label={user ? `Карточка пользователя ${user.name || user.email}` : 'Карточка пользователя'}
+        aria-label={user ? `Карточка пользователя ${user.name || user.contactEmail || user.telegramDisplay || user.id}` : 'Карточка пользователя'}
         style={{
           position: 'fixed',
           top: 0,
@@ -139,7 +139,7 @@ export default function AdminUserDrawer({ isOpen, data, loading, onClose, onRemo
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.55rem', flexWrap: 'wrap', marginTop: '0.2rem' }}>
               <h2 style={{ fontFamily: serif, fontSize: '1.35rem', margin: 0, color: '#111' }}>
-                {loading ? 'Загрузка…' : user?.name || user?.email || 'Пользователь'}
+                {loading ? 'Загрузка…' : user?.name || user?.contactEmail || user?.telegramDisplay || 'Пользователь'}
               </h2>
               {user?.isAdmin && <span style={adminBadge}>Admin</span>}
             </div>
@@ -162,7 +162,7 @@ export default function AdminUserDrawer({ isOpen, data, loading, onClose, onRemo
                 <dl style={{ display: 'grid', gridTemplateColumns: '130px 1fr', gap: '0.45rem 0.9rem', margin: 0, fontSize: '0.82rem' }}>
                   <dt style={{ color: '#999' }}>Имя</dt><dd style={{ margin: 0 }}>{user.name || '—'}</dd>
                   <dt style={{ color: '#999' }}>Telegram</dt><dd style={{ margin: 0 }}>{user.telegramDisplay || '—'}</dd>
-                  <dt style={{ color: '#999' }}>Email</dt><dd style={{ margin: 0 }}>{user.email}</dd>
+                  <dt style={{ color: '#999' }}>Email</dt><dd style={{ margin: 0 }}>{user.contactEmail || '—'}</dd>
                   <dt style={{ color: '#999' }}>Языки</dt><dd style={{ margin: 0 }}>{user.languages.length ? user.languages.join(', ') : '—'}</dd>
                   <dt style={{ color: '#999' }}>Последняя активность</dt><dd style={{ margin: 0 }}>{formatDate(user.lastActivityAt)}</dd>
                   <dt style={{ color: '#999' }}>Дата создания</dt><dd style={{ margin: 0 }}>{formatDate(user.createdAt)}</dd>

--- a/components/nd/BooksPage.tsx
+++ b/components/nd/BooksPage.tsx
@@ -20,7 +20,7 @@ import AboutBlock, { type AboutBlockHandle, type AboutBlockHeader, type AboutBlo
 import Footer from './Footer'
 import FeedbackForm from './FeedbackForm'
 import { useScrollHide } from '@/lib/scroll-hide-context'
-import { getContactEmail } from '@/lib/user-email'
+import { getUserContactEmail } from '@/lib/user-email'
 
 interface Props {
   books: BookWithCover[]
@@ -46,7 +46,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
   const isAdmin = !!session?.user?.isAdmin
   const telegramUsername = session?.user?.telegramUsername ?? null
   const telegramName = session?.user?.name ?? null
-  const contactEmail = getContactEmail(session?.user?.email)
+  const contactEmail = getUserContactEmail(session?.user)
 
   const [aboutVisible, setAboutVisible] = useState(true)
   const aboutRef = useRef<AboutBlockHandle>(null)

--- a/components/nd/Header.tsx
+++ b/components/nd/Header.tsx
@@ -6,7 +6,7 @@ import { track } from '@/lib/analytics'
 import Link from 'next/link'
 import SubmitBookButton from './SubmitBookButton'
 import { useScrollHide } from '@/lib/scroll-hide-context'
-import { getContactEmail } from '@/lib/user-email'
+import { getUserContactEmail } from '@/lib/user-email'
 
 interface Props {
   onEditProfile?: () => void
@@ -22,7 +22,7 @@ export default function Header({ onEditProfile, onSignIn, onSubmitBook, onWhatIs
   const [whatIsThisHovered, setWhatIsThisHovered] = useState(false)
   const { isHidden } = useScrollHide()
   const headerRef = useRef<HTMLElement>(null)
-  const contactEmail = getContactEmail(session?.user?.email)
+  const contactEmail = getUserContactEmail(session?.user)
   const telegramHandle = session?.user?.telegramUsername ? `@${session.user.telegramUsername}` : null
   const userLabel = displayName || session?.user?.name || telegramHandle || contactEmail || ''
 

--- a/components/nd/ProfileDrawer.tsx
+++ b/components/nd/ProfileDrawer.tsx
@@ -20,7 +20,7 @@ import {
   arrayMove,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { getContactEmail } from '@/lib/user-email'
+import { getUserContactEmail } from '@/lib/user-email'
 
 interface Submission {
   id: string
@@ -455,7 +455,7 @@ export default function ProfileDrawer({
     })
   )
 
-  const contactEmail = getContactEmail(session?.user?.email)
+  const contactEmail = getUserContactEmail(session?.user)
   const telegramHandle = session?.user?.telegramUsername ? `@${session.user.telegramUsername}` : null
   const displayName = effectiveUser?.name?.trim() || session?.user?.name || telegramHandle || contactEmail || ''
   const profileUnchanged = name.trim() === (effectiveUser?.name ?? '') && contacts.trim() === (effectiveUser?.contacts ?? '')

--- a/drizzle/0018_contact_email_nullable_user_email.sql
+++ b/drizzle/0018_contact_email_nullable_user_email.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "contact_email" text;
+
+UPDATE "user"
+SET "contact_email" = "email"
+WHERE "contact_email" IS NULL
+  AND "email" IS NOT NULL
+  AND "email" !~* '^telegram:[^@]+@telegram\.user$';
+
+ALTER TABLE "user" ALTER COLUMN "email" DROP NOT NULL;
+
+UPDATE "user"
+SET "email" = NULL
+WHERE "email" ~* '^telegram:[^@]+@telegram\.user$';

--- a/drizzle/contact-email-migration.test.ts
+++ b/drizzle/contact-email-migration.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+describe('0018 contact email / nullable user email migration', () => {
+  const sql = readFileSync(join(process.cwd(), 'drizzle/0018_contact_email_nullable_user_email.sql'), 'utf8')
+
+  it('adds an explicit nullable contact_email column', () => {
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "contact_email" text')
+  })
+
+  it('backfills contact_email only from real legacy emails', () => {
+    expect(sql).toContain('SET "contact_email" = "email"')
+    expect(sql).toContain('"email" !~* \'^telegram:[^@]+@telegram\\.user$\'')
+  })
+
+  it('drops NOT NULL before removing synthetic Telegram-only emails', () => {
+    expect(sql).toContain('SET "email" = NULL')
+    expect(sql).toContain('"email" ~* \'^telegram:[^@]+@telegram\\.user$\'')
+    expect(sql).toContain('ALTER COLUMN "email" DROP NOT NULL')
+    expect(sql.indexOf('ALTER COLUMN "email" DROP NOT NULL')).toBeLessThan(sql.indexOf('SET "email" = NULL'))
+  })
+})

--- a/e2e/admin-users.spec.ts
+++ b/e2e/admin-users.spec.ts
@@ -101,7 +101,7 @@ test.describe('админка — пользователи и фидбеки', (
     page.on('dialog', dialog => dialog.accept())
     await page.getByRole('dialog').getByRole('button', { name: /удалить пользователя/i }).click()
 
-    await expect(page.getByRole('dialog')).not.toBeVisible()
+    await expect(page.getByRole('dialog')).toHaveCount(0, { timeout: 10_000 })
     await expect(page.locator('tr').filter({ hasText: USER_NAME })).toHaveCount(0)
   })
 
@@ -110,8 +110,11 @@ test.describe('админка — пользователи и фидбеки', (
     await page.waitForLoadState('networkidle')
     const feedbackTab = page.locator('button').filter({ hasText: /фидбеки/i }).first()
     await expect(feedbackTab).toBeVisible()
-    const feedbackCount = Number((await feedbackTab.textContent())?.match(/Фидбеки \((\d+)\)/i)?.[1] ?? 0)
-    expect(feedbackCount).toBeGreaterThanOrEqual(2)
+    let feedbackCount = 0
+    await expect.poll(async () => {
+      feedbackCount = Number((await feedbackTab.textContent())?.match(/Фидбеки \((\d+)\)/i)?.[1] ?? 0)
+      return feedbackCount
+    }).toBeGreaterThanOrEqual(2)
     await expect(feedbackTab.getByLabel(`${feedbackCount} новых`)).toBeVisible()
 
     await page.getByRole('button', { name: /фидбеки/i }).click()

--- a/lib/admin-users.ts
+++ b/lib/admin-users.ts
@@ -13,7 +13,8 @@ import { formatTelegramDisplay } from '@/lib/telegram-display'
 export interface AdminUserSummary {
   id: string
   name: string
-  email: string
+  email: string | null
+  contactEmail: string | null
   contacts: string | null
   telegramUsername: string | null
   telegramDisplay: string
@@ -48,6 +49,7 @@ export interface AdminFeedbackItem {
   createdAt: string
   userName: string | null
   userEmail: string | null
+  userContactEmail: string | null
 }
 
 function parseLanguages(value: string | null): string[] {
@@ -73,6 +75,7 @@ export async function getAdminUserSummaries(): Promise<AdminUserSummary[]> {
         id: users.id,
         name: users.name,
         email: users.email,
+        contactEmail: users.contactEmail,
         emailVerified: users.emailVerified,
         createdAt: users.createdAt,
         contacts: users.contacts,
@@ -103,7 +106,8 @@ export function buildAdminUserSummaries(
   userRows: {
     id: string
     name: string | null
-    email: string
+    email: string | null
+    contactEmail?: string | null
     contacts: string | null
     telegramUsername: string | null
     authProvider?: string | null
@@ -133,6 +137,7 @@ export function buildAdminUserSummaries(
     id: row.id,
     name: row.name ?? '',
     email: row.email,
+    contactEmail: row.contactEmail ?? null,
     contacts: row.contacts,
     telegramUsername: row.telegramUsername,
     telegramDisplay: formatTelegramDisplay(row),
@@ -151,6 +156,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
       id: users.id,
       name: users.name,
       email: users.email,
+      contactEmail: users.contactEmail,
       emailVerified: users.emailVerified,
       createdAt: users.createdAt,
       contacts: users.contacts,
@@ -200,6 +206,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
         createdAt: feedback.createdAt,
         userName: users.name,
         userEmail: users.email,
+        userContactEmail: users.contactEmail,
       })
       .from(feedback)
       .leftJoin(users, eq(feedback.userId, users.id))
@@ -243,6 +250,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
       createdAt: row.createdAt.toISOString(),
       userName: row.userName,
       userEmail: row.userEmail,
+      userContactEmail: row.userContactEmail,
     })),
   }
 }
@@ -258,6 +266,7 @@ export async function getAdminFeedback(): Promise<AdminFeedbackItem[]> {
       createdAt: feedback.createdAt,
       userName: users.name,
       userEmail: users.email,
+      userContactEmail: users.contactEmail,
     })
     .from(feedback)
     .leftJoin(users, eq(feedback.userId, users.id))
@@ -272,5 +281,6 @@ export async function getAdminFeedback(): Promise<AdminFeedbackItem[]> {
     createdAt: row.createdAt.toISOString(),
     userName: row.userName,
     userEmail: row.userEmail,
+    userContactEmail: row.userContactEmail,
   }))
 }

--- a/lib/auth.google-one-tap.ts
+++ b/lib/auth.google-one-tap.ts
@@ -3,7 +3,7 @@ import { resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 export async function authorizeGoogleOneTap(
   credential: string
-): Promise<{ id: string; email: string; name: string } | null> {
+): Promise<{ id: string; email: string | null; contactEmail: string | null; name: string } | null> {
   try {
     const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID)
     const ticket = await client.verifyIdToken({
@@ -21,7 +21,7 @@ export async function authorizeGoogleOneTap(
       emailVerified: email_verified !== false,
       metadata: { source: 'google-one-tap' },
     })
-    return { id: user.id, email: user.email, name: user.name ?? email }
+    return { id: user.id, email: user.email, contactEmail: user.contactEmail, name: user.name ?? email }
   } catch {
     return null
   }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -126,7 +126,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         const existing = await db.select().from(users).where(eq(users.id, uid)).limit(1)
         if (existing.length === 0) return null
         const user = existing[0]
-        return { id: user.id, email: user.email, name: user.name ?? '', telegramUsername: username || null }
+        return { id: user.id, email: user.email, contactEmail: user.contactEmail, name: user.name ?? '', telegramUsername: username || null }
       },
     }),
   ],
@@ -197,6 +197,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (user) {
         token.telegramUsername = user.telegramUsername ?? token.telegramUsername
         token.provider = account?.provider ?? token.provider
+        token.contactEmail = user.contactEmail ?? token.contactEmail
       }
 
       if (process.env.NEXTAUTH_TEST_MODE === 'true') {
@@ -208,17 +209,19 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       const email = (user?.email ?? token.email) as string | undefined
       if (userId || email) {
         const existing = await db
-          .select({ id: users.id, isAdmin: users.isAdmin })
+          .select({ id: users.id, isAdmin: users.isAdmin, contactEmail: users.contactEmail, email: users.email })
           .from(users)
           .where(userId ? eq(users.id, userId) : eq(users.email, email!))
           .limit(1)
         if (existing.length === 0) return null
         token.isAdmin = existing[0].isAdmin
+        token.contactEmail = existing[0].contactEmail
+        const contactEmail = existing[0].contactEmail ?? existing[0].email ?? email
         if (!token.isAdmin) {
-          token.isAdmin = await bootstrapAdminFromEnv(existing[0].id, email)
+          token.isAdmin = await bootstrapAdminFromEnv(existing[0].id, contactEmail)
         }
         const ownerEmails = (process.env.POSTHOG_OWNER_EMAILS ?? '').split(',').map(s => s.trim()).filter(Boolean)
-        token.isExcludedFromAnalytics = ownerEmails.length > 0 && ownerEmails.includes(email ?? '')
+        token.isExcludedFromAnalytics = ownerEmails.length > 0 && ownerEmails.includes(contactEmail ?? '')
       }
       return token
     },
@@ -229,6 +232,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         session.user.isExcludedFromAnalytics = token.isExcludedFromAnalytics as boolean | undefined
         session.user.telegramUsername = token.telegramUsername
         session.user.provider = token.provider
+        session.user.contactEmail = token.contactEmail ?? null
       }
       return session
     },

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -5,7 +5,8 @@ import {
 export const users = pgTable('user', {
   id: text('id').primaryKey(),
   name: text('name'),
-  email: text('email').notNull().unique(),
+  email: text('email').unique(),
+  contactEmail: text('contact_email'),
   emailVerified: timestamp('emailVerified', { mode: 'date' }),
   createdAt: timestamp('created_at', { mode: 'date' }).notNull().defaultNow(),
   image: text('image'),

--- a/lib/signup-books.ts
+++ b/lib/signup-books.ts
@@ -6,7 +6,8 @@ export interface UserSignup {
   timestamp: string
   userId: string
   name: string
-  email: string
+  email: string | null
+  contactEmail?: string | null
   contacts: string
   selectedBooks: string[]
   prioritiesSet?: boolean
@@ -23,6 +24,7 @@ export async function getAllSignups(): Promise<UserSignup[]> {
       userId: users.id,
       name: users.name,
       email: users.email,
+      contactEmail: users.contactEmail,
       contacts: users.contacts,
       prioritiesSet: users.prioritiesSet,
       bookName: signupBooks.bookName,
@@ -45,6 +47,7 @@ export async function getAllSignups(): Promise<UserSignup[]> {
       userId: row.userId,
       name: row.name ?? '',
       email: row.email,
+      contactEmail: row.contactEmail,
       contacts: row.contacts ?? '',
       selectedBooks: [row.bookName],
       prioritiesSet: row.prioritiesSet,

--- a/lib/user-email.test.ts
+++ b/lib/user-email.test.ts
@@ -1,4 +1,4 @@
-import { getContactEmail, isSyntheticTelegramEmail } from './user-email'
+import { getContactEmail, getUserContactEmail, isSyntheticTelegramEmail } from './user-email'
 
 describe('user email helpers', () => {
   describe('isSyntheticTelegramEmail', () => {
@@ -23,6 +23,17 @@ describe('user email helpers', () => {
       expect(getContactEmail('')).toBeNull()
       expect(getContactEmail(null)).toBeNull()
       expect(getContactEmail('telegram:123456@telegram.user')).toBeNull()
+    })
+  })
+
+  describe('getUserContactEmail', () => {
+    it('предпочитает явный contactEmail', () => {
+      expect(getUserContactEmail({ contactEmail: 'contact@example.com', email: 'legacy@example.com' })).toBe('contact@example.com')
+    })
+
+    it('использует legacy email только если он реальный', () => {
+      expect(getUserContactEmail({ contactEmail: null, email: 'legacy@example.com' })).toBe('legacy@example.com')
+      expect(getUserContactEmail({ contactEmail: null, email: 'telegram:123@telegram.user' })).toBeNull()
     })
   })
 })

--- a/lib/user-email.ts
+++ b/lib/user-email.ts
@@ -9,3 +9,7 @@ export function getContactEmail(email?: string | null): string | null {
   if (!normalized || isSyntheticTelegramEmail(normalized)) return null
   return normalized
 }
+
+export function getUserContactEmail(user?: { contactEmail?: string | null; email?: string | null } | null): string | null {
+  return getContactEmail(user?.contactEmail) ?? getContactEmail(user?.email)
+}

--- a/lib/user-identities.test.ts
+++ b/lib/user-identities.test.ts
@@ -112,10 +112,10 @@ describe('user identity helpers', () => {
     expect((db as unknown as { transaction: jest.Mock }).transaction).toHaveBeenCalled()
   })
 
-  it('создаёт нового Telegram user с UUID и technical placeholder email', async () => {
+  it('создаёт нового Telegram user с UUID без user.email/contactEmail', async () => {
     queueSelects(
       [],
-      [{ id: 'generated-uuid', email: 'telegram:123@telegram.user', name: 'Ivan', image: null, telegramUsername: 'ivan' }]
+      [{ id: 'generated-uuid', email: null, contactEmail: null, name: 'Ivan', image: null, telegramUsername: 'ivan' }]
     )
     const insertChains = mockInserts()
     mockUpdate()
@@ -130,7 +130,8 @@ describe('user identity helpers', () => {
     expect(insertChains[0].table).toBe(users)
     expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
       id: 'generated-uuid',
-      email: 'telegram:123@telegram.user',
+      email: null,
+      contactEmail: null,
       telegramUsername: 'ivan',
     }))
     expect(insertChains[0].lastValues).toEqual(expect.not.objectContaining({

--- a/lib/user-identities.ts
+++ b/lib/user-identities.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm'
+import { and, eq, or } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { accounts, userActivityEvents, userIdentities, users } from '@/lib/db/schema'
 
@@ -29,7 +29,8 @@ export interface IdentityProfile {
 
 export interface ResolvedIdentityUser {
   id: string
-  email: string
+  email: string | null
+  contactEmail: string | null
   name: string | null
   image: string | null
   telegramUsername: string | null
@@ -90,14 +91,14 @@ function normalizeProviderAccountId(provider: IdentityProvider, providerAccountI
   return provider === 'email' ? trimmed.toLowerCase() : trimmed
 }
 
-function syntheticTelegramEmail(providerAccountId: string): string {
-  return `telegram:${providerAccountId}@telegram.user`
+function userInsertEmail(provider: IdentityProvider, email: string | null): string | null {
+  if (provider === 'telegram') return null
+  if (email) return email
+  throw new Error(`${provider} identity requires email`)
 }
 
-function userInsertEmail(provider: IdentityProvider, providerAccountId: string, email: string | null): string {
-  if (email) return email
-  if (provider === 'telegram') return syntheticTelegramEmail(providerAccountId)
-  throw new Error(`${provider} identity requires email`)
+function userContactEmail(provider: IdentityProvider, email: string | null): string | null {
+  return provider === 'telegram' ? null : email
 }
 
 function metadataToText(metadata?: IdentityMetadata): string | null {
@@ -115,9 +116,16 @@ async function findUserIdByEmail(tx: IdentityDb, email: string): Promise<string 
   const rows = await tx
     .select({ id: users.id })
     .from(users)
-    .where(eq(users.email, email))
+    .where(or(eq(users.email, email), eq(users.contactEmail, email)))
     .limit(1)
-  return rows[0]?.id ?? null
+  if (rows[0]?.id) return rows[0].id
+
+  const identityRows = await tx
+    .select({ userId: userIdentities.userId })
+    .from(userIdentities)
+    .where(eq(userIdentities.email, email))
+    .limit(1)
+  return identityRows[0]?.userId ?? null
 }
 
 async function findIdentityUserId(
@@ -154,6 +162,7 @@ async function selectResolvedUser(tx: IdentityDb, userId: string, isNew: boolean
     .select({
       id: users.id,
       email: users.email,
+      contactEmail: users.contactEmail,
       name: users.name,
       image: users.image,
       telegramUsername: users.telegramUsername,
@@ -170,13 +179,16 @@ async function selectResolvedUser(tx: IdentityDb, userId: string, isNew: boolean
 async function updateUserCache(
   tx: IdentityDb,
   userId: string,
+  provider: IdentityProvider,
   profile: IdentityProfile,
   now: Date
 ): Promise<void> {
+  const contactEmail = userContactEmail(provider, normalizeEmail(profile.email))
   await tx
     .update(users)
     .set({
       lastActivityAt: now,
+      ...(contactEmail ? { contactEmail } : {}),
       ...(profile.name ? { name: profile.name } : {}),
       ...(profile.image ? { image: profile.image } : {}),
       ...(normalizeTelegramContact(profile.telegramUsername) ? { telegramUsername: normalizeTelegramContact(profile.telegramUsername) } : {}),
@@ -281,7 +293,7 @@ export async function linkIdentityToUser(
       throw new IdentityConflictError(`Identity ${normalizedProvider}:${normalizedProviderAccountId} is already linked to another user`)
     }
     const identityUserId = await upsertIdentity(tx, userId, normalizedProvider, normalizedProviderAccountId, profile, now)
-    await updateUserCache(tx, identityUserId, profile, now)
+    await updateUserCache(tx, identityUserId, normalizedProvider, profile, now)
     await syncGoogleAccount(tx, identityUserId, normalizedProvider, normalizedProviderAccountId)
     return selectResolvedUser(tx, identityUserId, false)
   })
@@ -303,7 +315,7 @@ export async function resolveOrCreateUserFromIdentity(
     if (existingIdentityUserId) {
       const userId = existingIdentityUserId
       await upsertIdentity(tx, userId, normalizedProvider, normalizedProviderAccountId, profile, now)
-      await updateUserCache(tx, userId, profile, now)
+      await updateUserCache(tx, userId, normalizedProvider, profile, now)
       await syncGoogleAccount(tx, userId, normalizedProvider, normalizedProviderAccountId)
       return selectResolvedUser(tx, userId, false)
     }
@@ -318,7 +330,8 @@ export async function resolveOrCreateUserFromIdentity(
     if (isNew) {
       await tx.insert(users).values({
         id: userId,
-        email: userInsertEmail(normalizedProvider, normalizedProviderAccountId, email),
+        email: userInsertEmail(normalizedProvider, email),
+        contactEmail: userContactEmail(normalizedProvider, email),
         name: profile.name ?? email ?? normalizeTelegramContact(profile.telegramUsername) ?? normalizedProviderAccountId,
         emailVerified: email && normalizedProvider !== 'telegram' ? now : null,
         image: profile.image ?? null,
@@ -328,7 +341,7 @@ export async function resolveOrCreateUserFromIdentity(
       })
       await bestEffortRecordUserCreated(tx, userId, normalizedProvider, now)
     } else {
-      await updateUserCache(tx, userId, profile, now)
+      await updateUserCache(tx, userId, normalizedProvider, profile, now)
     }
 
     const identityUserId = await upsertIdentity(tx, userId, normalizedProvider, normalizedProviderAccountId, profile, now)

--- a/scripts/migrate-signups.ts
+++ b/scripts/migrate-signups.ts
@@ -3,7 +3,7 @@ import { neon } from '@neondatabase/serverless'
 import { drizzle } from 'drizzle-orm/neon-http'
 import { signupBooks, users } from '../lib/db/schema'
 import * as schema from '../lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { eq, or } from 'drizzle-orm'
 
 function createDb() {
   return drizzle(neon(process.env.DATABASE_URL!), { schema })
@@ -74,7 +74,7 @@ export async function migrateSignupRows(
     const userRows = await database
       .select({ id: users.id, name: users.name, contacts: users.contacts })
       .from(users)
-      .where(eq(users.email, normalizedEmail))
+      .where(or(eq(users.email, normalizedEmail), eq(users.contactEmail, normalizedEmail)))
       .limit(1)
 
     const user = userRows[0]

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -8,10 +8,12 @@ declare module 'next-auth' {
       isExcludedFromAnalytics?: boolean
       telegramUsername?: string | null
       provider?: string | null
+      contactEmail?: string | null
     } & DefaultSession['user']
   }
   interface User {
     telegramUsername?: string | null
+    contactEmail?: string | null
   }
 }
 
@@ -21,5 +23,6 @@ declare module '@auth/core/jwt' {
     isExcludedFromAnalytics?: boolean
     telegramUsername?: string | null
     provider?: string | null
+    contactEmail?: string | null
   }
 }


### PR DESCRIPTION
## Summary
- make users.email nullable and add users.contact_email for real contact email
- stop creating synthetic Telegram emails; keep Telegram-only sessions email/contactEmail null
- update auth/session, admin/profile/signup APIs and UI to use contactEmail with legacy email fallback where needed
- harden test endpoints and E2E waits around admin feedback/user drawer

## Migration
- Applied 0018 manually to the configured Neon DB before rollout: email nullable, synthetic Telegram email count = 0, contact_email backfilled for real legacy emails.

## Tests
- npm run lint
- npm run typecheck
- npm test
- NEXTAUTH_TEST_MODE=true npm run dev + npm run test:e2e -- e2e/signup.spec.ts e2e/telegram-auth.spec.ts e2e/admin-users.spec.ts e2e/profile.spec.ts

E2E: нужен — меняется auth/session/contact-email цепочка и persistent signup/profile/admin flows; пройдено 10/10.

Closes #134