### PR TITLE
Remove legacy user.email column

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -20,7 +20,7 @@ export default async function AdminPage() {
     db.select().from(bookStatuses).catch(() => []),
     db.select().from(tagDescriptions).catch(() => []),
     db.select().from(bookNewFlags).catch(() => []),
-    db.select({ id: users.id, email: users.email, contactEmail: users.contactEmail, languages: users.languages, prioritiesSet: users.prioritiesSet }).from(users).catch(() => []),
+    db.select({ id: users.id, contactEmail: users.contactEmail, languages: users.languages, prioritiesSet: users.prioritiesSet }).from(users).catch(() => []),
     db.select({ userId: bookPriorities.userId, bookName: bookPriorities.bookName, rank: bookPriorities.rank }).from(bookPriorities).catch(() => []),
   ])
 

--- a/app/api/admin/submissions/[id]/route.ts
+++ b/app/api/admin/submissions/[id]/route.ts
@@ -103,7 +103,7 @@ export async function PATCH(
 
   if (status === 'approved' || status === 'rejected') {
     const [userRow] = await db
-      .select({ email: users.email, contactEmail: users.contactEmail })
+      .select({ contactEmail: users.contactEmail })
       .from(users)
       .where(eq(users.id, submission.userId))
       .limit(1)

--- a/app/api/admin/submissions/route.ts
+++ b/app/api/admin/submissions/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { bookSubmissions, users } from '@/lib/db/schema'
-import { eq, sql } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 
 export async function GET() {
   const session = await auth()
@@ -16,7 +16,7 @@ export async function GET() {
     .select({
       id: bookSubmissions.id,
       userId: bookSubmissions.userId,
-      userEmail: sql<string | null>`coalesce(${users.contactEmail}, ${users.email})`,
+      userEmail: users.contactEmail,
       title: bookSubmissions.title,
       topic: bookSubmissions.topic,
       author: bookSubmissions.author,

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
     .select({
       id: users.id,
       name: users.name,
-      email: users.email,
+      email: users.contactEmail,
       contactEmail: users.contactEmail,
       contacts: users.contacts,
       telegramUsername: users.telegramUsername,

--- a/app/api/test/session/route.ts
+++ b/app/api/test/session/route.ts
@@ -5,7 +5,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { encode } from '@auth/core/jwt'
 import { db } from '@/lib/db'
 import { notificationQueue, userIdentities, users } from '@/lib/db/schema'
-import { eq, or } from 'drizzle-orm'
+import { and, eq, or } from 'drizzle-orm'
 import { isTestEndpointAllowed } from '@/lib/test-mode'
 import { normalizeIdentityProvider, resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
@@ -58,23 +58,32 @@ export async function POST(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   if (!isTestEndpointAllowed()) return notAllowed()
 
-  const { email } = await req.json() as { email: string }
-  const userRows = await db
+  const { email, provider, providerAccountId, telegramUsername } = await req.json() as {
+    email?: string
+    provider?: string
+    providerAccountId?: string
+    telegramUsername?: string
+  }
+  const identityProvider = provider ? normalizeIdentityProvider(provider) : null
+  const identityAccountId = providerAccountId ?? telegramUsername ?? email
+  const userRows = email ? await db
     .select({ id: users.id })
     .from(users)
-    .where(or(eq(users.email, email), eq(users.contactEmail, email)))
-    .limit(1)
+    .where(eq(users.contactEmail, email))
+    .limit(1) : []
   const identityRows = await db
     .select({ userId: userIdentities.userId })
     .from(userIdentities)
-    .where(or(
-      eq(userIdentities.email, email),
-      eq(userIdentities.providerAccountId, email)
-    ))
+    .where(identityProvider && identityAccountId
+      ? and(eq(userIdentities.provider, identityProvider), eq(userIdentities.providerAccountId, identityAccountId))
+      : or(
+        eq(userIdentities.email, email ?? ''),
+        eq(userIdentities.providerAccountId, identityAccountId ?? '')
+      ))
     .limit(1)
   const userId = userRows[0]?.id ?? identityRows[0]?.userId ?? null
 
-  await db.delete(notificationQueue).where(eq(notificationQueue.userEmail, email))
+  if (email) await db.delete(notificationQueue).where(eq(notificationQueue.userEmail, email))
   if (userId) {
     await db.delete(userIdentities).where(eq(userIdentities.userId, userId))
     await db.delete(users).where(eq(users.id, userId))

--- a/app/api/test/signup/route.ts
+++ b/app/api/test/signup/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
   const rows = await db
     .select({ id: users.id })
     .from(users)
-    .where(or(eq(users.email, email), eq(users.contactEmail, email)))
+    .where(eq(users.contactEmail, email))
     .limit(1)
   const identityRows = rows[0]?.id ? [] : await db
     .select({ userId: userIdentities.userId })

--- a/app/api/test/user/route.ts
+++ b/app/api/test/user/route.ts
@@ -17,9 +17,9 @@ export async function GET(req: NextRequest) {
   }
 
   const rows = await db
-    .select({ id: users.id, email: users.email, contactEmail: users.contactEmail })
+    .select({ id: users.id, email: users.contactEmail, contactEmail: users.contactEmail })
     .from(users)
-    .where(or(eq(users.email, email), eq(users.contactEmail, email)))
+    .where(eq(users.contactEmail, email))
     .limit(1)
 
   let userRow = rows[0]
@@ -31,7 +31,7 @@ export async function GET(req: NextRequest) {
       .limit(1)
     if (identityRows[0]?.userId) {
       const byIdentityRows = await db
-        .select({ id: users.id, email: users.email, contactEmail: users.contactEmail })
+        .select({ id: users.id, email: users.contactEmail, contactEmail: users.contactEmail })
         .from(users)
         .where(eq(users.id, identityRows[0].userId))
         .limit(1)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,7 +45,7 @@ export default async function Home() {
     : null
   const dbUserRows = !signupUser && session?.user?.id
     ? await db
-      .select({ name: users.name, email: users.email, contactEmail: users.contactEmail, contacts: users.contacts })
+      .select({ name: users.name, contactEmail: users.contactEmail, contacts: users.contacts })
       .from(users)
       .where(eq(users.id, session.user.id))
       .limit(1)
@@ -56,7 +56,7 @@ export default async function Home() {
     timestamp: '',
     userId: session!.user!.id!,
     name: dbUser.name ?? session?.user?.name ?? '',
-    email: dbUser.email,
+    email: dbUser.contactEmail,
     contactEmail: dbUser.contactEmail,
     contacts: dbUser.contacts,
     selectedBooks: [],

--- a/drizzle/0019_drop_user_email.sql
+++ b/drizzle/0019_drop_user_email.sql
@@ -1,0 +1,30 @@
+INSERT INTO "user_identities" (
+  "id",
+  "user_id",
+  "provider",
+  "provider_account_id",
+  "email",
+  "created_at",
+  "last_seen_at",
+  "metadata"
+)
+SELECT
+  'email:' || u."id",
+  u."id",
+  'email',
+  lower(trim(u."contact_email")),
+  lower(trim(u."contact_email")),
+  u."created_at",
+  COALESCE(u."last_activity_at", u."created_at", now()),
+  '{"source":"drop-user-email-backfill"}'
+FROM "user" u
+WHERE u."contact_email" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM "user_identities" ui WHERE ui."user_id" = u."id"
+  )
+ON CONFLICT ("provider", "provider_account_id") DO NOTHING;
+
+DELETE FROM "verificationToken"
+WHERE "expires" < now();
+
+ALTER TABLE "user" DROP COLUMN IF EXISTS "email";

--- a/drizzle/drop-user-email-migration.test.ts
+++ b/drizzle/drop-user-email-migration.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+describe('0019 drop user.email migration', () => {
+  const sql = readFileSync(join(process.cwd(), 'drizzle/0019_drop_user_email.sql'), 'utf8')
+
+  it('backfills an email identity for contact-email users without any identity', () => {
+    expect(sql).toContain('INSERT INTO "user_identities"')
+    expect(sql).toContain('lower(trim(u."contact_email"))')
+    expect(sql).toContain('WHERE u."contact_email" IS NOT NULL')
+    expect(sql).toContain('WHERE ui."user_id" = u."id"')
+  })
+
+  it('does not overwrite existing identity ownership', () => {
+    expect(sql).toContain('ON CONFLICT ("provider", "provider_account_id") DO NOTHING')
+  })
+
+  it('drops only expired verification tokens before dropping user.email', () => {
+    expect(sql).toContain('DELETE FROM "verificationToken"')
+    expect(sql).toContain('WHERE "expires" < now()')
+    expect(sql).toContain('ALTER TABLE "user" DROP COLUMN IF EXISTS "email"')
+  })
+})

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -19,7 +19,9 @@ test.describe('ProfileDrawer — редактирование профиля', (
   })
 
   test.afterEach(async ({ page }) => {
-    await page.request.delete('/api/test/session', { data: { email: EMAIL } })
+    await page.request.delete('/api/test/session', {
+      data: { email: EMAIL, provider: 'telegram-preauth', telegramUsername: TG_USERNAME },
+    })
   })
 
   test('языки чтения сохраняются после перезагрузки страницы', async ({ page }) => {

--- a/e2e/telegram-auth.spec.ts
+++ b/e2e/telegram-auth.spec.ts
@@ -22,7 +22,9 @@ test.describe('Авторизация через Telegram', () => {
   })
 
   test.afterEach(async ({ page }) => {
-    await page.request.delete('/api/test/session', { data: { email: TG_EMAIL } })
+    await page.request.delete('/api/test/session', {
+      data: { email: TG_EMAIL, provider: 'telegram-preauth', providerAccountId: TG_PROVIDER_ACCOUNT_ID },
+    })
   })
 
   test('ContactsForm не появляется — профиль сохраняется автоматически', async ({ page }) => {

--- a/lib/admin-users.ts
+++ b/lib/admin-users.ts
@@ -74,7 +74,7 @@ export async function getAdminUserSummaries(): Promise<AdminUserSummary[]> {
       .select({
         id: users.id,
         name: users.name,
-        email: users.email,
+        email: users.contactEmail,
         contactEmail: users.contactEmail,
         emailVerified: users.emailVerified,
         createdAt: users.createdAt,
@@ -87,7 +87,7 @@ export async function getAdminUserSummaries(): Promise<AdminUserSummary[]> {
         isAdmin: users.isAdmin,
       })
       .from(users)
-      .orderBy(asc(users.name), asc(users.email)),
+      .orderBy(asc(users.name), asc(users.contactEmail)),
     db.select({ userId: signupBooks.userId, activityAt: signupBooks.signedAt }).from(signupBooks),
     db
       .select({
@@ -155,7 +155,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
     .select({
       id: users.id,
       name: users.name,
-      email: users.email,
+      email: users.contactEmail,
       contactEmail: users.contactEmail,
       emailVerified: users.emailVerified,
       createdAt: users.createdAt,
@@ -205,7 +205,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
         message: feedback.message,
         createdAt: feedback.createdAt,
         userName: users.name,
-        userEmail: users.email,
+        userEmail: users.contactEmail,
         userContactEmail: users.contactEmail,
       })
       .from(feedback)
@@ -265,7 +265,7 @@ export async function getAdminFeedback(): Promise<AdminFeedbackItem[]> {
       message: feedback.message,
       createdAt: feedback.createdAt,
       userName: users.name,
-      userEmail: users.email,
+      userEmail: users.contactEmail,
       userContactEmail: users.contactEmail,
     })
     .from(feedback)

--- a/lib/auth-adapter.test.ts
+++ b/lib/auth-adapter.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@auth/drizzle-adapter', () => ({
+  DrizzleAdapter: jest.fn(() => ({
+    createVerificationToken: jest.fn(),
+    useVerificationToken: jest.fn(),
+    linkAccount: jest.fn(),
+  })),
+}))
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    select: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(),
+  },
+}))
+
+import { db } from '@/lib/db'
+import { users } from '@/lib/db/schema'
+import { IdentityAwareDrizzleAdapter } from './auth-adapter'
+
+function selectChain(rows: unknown[]) {
+  return {
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue(rows),
+  }
+}
+
+function insertChain(row: unknown) {
+  return {
+    values: jest.fn().mockReturnThis(),
+    returning: jest.fn().mockResolvedValue([row]),
+  }
+}
+
+function updateChain(row: unknown) {
+  return {
+    set: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    returning: jest.fn().mockResolvedValue([row]),
+  }
+}
+
+describe('IdentityAwareDrizzleAdapter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('createUser writes contactEmail but does not write a user.email column', async () => {
+    const inserted = {
+      id: 'user-id',
+      name: 'User',
+      contactEmail: 'user@test.com',
+      emailVerified: null,
+      image: null,
+      telegramUsername: null,
+    }
+    const chain = insertChain(inserted)
+    ;(db.insert as jest.Mock).mockReturnValue(chain)
+
+    const adapter = IdentityAwareDrizzleAdapter()
+    const user = await adapter.createUser!({
+      id: 'user-id',
+      name: 'User',
+      email: 'User@Test.com',
+      emailVerified: null,
+      image: null,
+    })
+
+    expect(db.insert).toHaveBeenCalledWith(users)
+    expect(chain.values).toHaveBeenCalledWith(expect.not.objectContaining({ email: expect.anything() }))
+    expect(chain.values).toHaveBeenCalledWith(expect.objectContaining({ contactEmail: 'user@test.com' }))
+    expect(user.email).toBe('user@test.com')
+  })
+
+  it('getUserByEmail resolves by contact_email before identities', async () => {
+    ;(db.select as jest.Mock)
+      .mockReturnValueOnce(selectChain([{ id: 'user-id' }]))
+      .mockReturnValueOnce(selectChain([{
+        id: 'user-id',
+        name: 'User',
+        contactEmail: 'user@test.com',
+        emailVerified: null,
+        image: null,
+        telegramUsername: null,
+      }]))
+
+    const adapter = IdentityAwareDrizzleAdapter()
+    const user = await adapter.getUserByEmail!('USER@test.com')
+
+    expect(user?.id).toBe('user-id')
+    expect(user?.email).toBe('user@test.com')
+  })
+
+  it('updateUser maps email changes to contactEmail', async () => {
+    const updated = {
+      id: 'user-id',
+      name: 'User',
+      contactEmail: 'new@test.com',
+      emailVerified: null,
+      image: null,
+      telegramUsername: null,
+    }
+    const chain = updateChain(updated)
+    ;(db.update as jest.Mock).mockReturnValue(chain)
+
+    const adapter = IdentityAwareDrizzleAdapter()
+    await adapter.updateUser!({ id: 'user-id', email: 'New@Test.com' })
+
+    expect(chain.set).toHaveBeenCalledWith(expect.objectContaining({ contactEmail: 'new@test.com' }))
+    expect(chain.set).toHaveBeenCalledWith(expect.not.objectContaining({ email: expect.anything() }))
+  })
+})

--- a/lib/auth-adapter.ts
+++ b/lib/auth-adapter.ts
@@ -1,0 +1,122 @@
+import { DrizzleAdapter } from '@auth/drizzle-adapter'
+import type { Adapter, AdapterAccount, AdapterUser } from '@auth/core/adapters'
+import { and, eq, or } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { accounts, sessions, userIdentities, users, verificationTokens } from '@/lib/db/schema'
+
+type DbUserRow = typeof users.$inferSelect
+
+function normalizeEmail(email?: string | null): string | null {
+  const normalized = email?.trim().toLowerCase()
+  return normalized || null
+}
+
+function toAdapterUser(user: DbUserRow): AdapterUser {
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.contactEmail ?? null,
+    emailVerified: user.emailVerified,
+    image: user.image,
+    contactEmail: user.contactEmail,
+    telegramUsername: user.telegramUsername,
+  } as AdapterUser
+}
+
+async function getUserById(userId: string): Promise<AdapterUser | null> {
+  const rows = await db.select().from(users).where(eq(users.id, userId)).limit(1)
+  return rows[0] ? toAdapterUser(rows[0]) : null
+}
+
+async function getUserIdByEmail(email: string): Promise<string | null> {
+  const normalizedEmail = normalizeEmail(email)
+  if (!normalizedEmail) return null
+
+  const contactRows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.contactEmail, normalizedEmail))
+    .limit(1)
+  if (contactRows[0]?.id) return contactRows[0].id
+
+  const identityRows = await db
+    .select({ userId: userIdentities.userId })
+    .from(userIdentities)
+    .where(or(
+      eq(userIdentities.email, normalizedEmail),
+      and(eq(userIdentities.provider, 'email'), eq(userIdentities.providerAccountId, normalizedEmail))
+    ))
+    .limit(1)
+  return identityRows[0]?.userId ?? null
+}
+
+export function IdentityAwareDrizzleAdapter(): Adapter {
+  const base = (DrizzleAdapter as (client: typeof db, schema: unknown) => Adapter)(db, {
+    usersTable: users,
+    accountsTable: accounts,
+    sessionsTable: sessions,
+    verificationTokensTable: verificationTokens,
+  })
+
+  return {
+    ...base,
+    async createUser(data) {
+      const email = normalizeEmail(data.email)
+      const id = data.id ?? crypto.randomUUID()
+      const [created] = await db
+        .insert(users)
+        .values({
+          id,
+          name: data.name ?? email,
+          contactEmail: email,
+          emailVerified: data.emailVerified ?? null,
+          image: data.image ?? null,
+        })
+        .returning()
+      return toAdapterUser(created)
+    },
+    getUser: getUserById,
+    async getUserByEmail(email) {
+      const userId = await getUserIdByEmail(email)
+      return userId ? getUserById(userId) : null
+    },
+    async getUserByAccount(account: Pick<AdapterAccount, 'provider' | 'providerAccountId'>) {
+      const identityRows = await db
+        .select({ userId: userIdentities.userId })
+        .from(userIdentities)
+        .where(and(
+          eq(userIdentities.provider, account.provider),
+          eq(userIdentities.providerAccountId, account.providerAccountId)
+        ))
+        .limit(1)
+      const identityUser = identityRows[0]?.userId ? await getUserById(identityRows[0].userId) : null
+      if (identityUser) return identityUser
+
+      const accountRows = await db
+        .select({ userId: accounts.userId })
+        .from(accounts)
+        .where(and(
+          eq(accounts.provider, account.provider),
+          eq(accounts.providerAccountId, account.providerAccountId)
+        ))
+        .limit(1)
+      return accountRows[0]?.userId ? getUserById(accountRows[0].userId) : null
+    },
+    async updateUser(data) {
+      const { id, email, name, image, emailVerified } = data
+      const contactEmail = normalizeEmail(email)
+      const [updated] = await db
+        .update(users)
+        .set({
+          ...(name !== undefined ? { name } : {}),
+          ...(image !== undefined ? { image } : {}),
+          ...(emailVerified !== undefined ? { emailVerified } : {}),
+          ...(contactEmail !== null ? { contactEmail } : {}),
+        })
+        .where(eq(users.id, id))
+        .returning()
+      if (!updated) throw new Error('No user found.')
+      return toAdapterUser(updated)
+    },
+  }
+}

--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -553,13 +553,13 @@ describe('telegram-preauth authorize', () => {
     const token = 'token'
 
     mockPreauthConsume(true)
-    mockDbSelect([{ id: uid, email: 'tg@telegram.user', name: 'Ivan' }])
+    mockDbSelect([{ id: uid, contactEmail: null, name: 'Ivan' }])
 
     const result = await authorize({ uid, token, ts, username: 'ivan_tg' })
 
     expect(result).toMatchObject({
       id: uid,
-      email: 'tg@telegram.user',
+      email: null,
       name: 'Ivan',
       telegramUsername: 'ivan_tg',
     })

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,11 +2,11 @@ import NextAuth from 'next-auth'
 import Google from 'next-auth/providers/google'
 import Resend from 'next-auth/providers/resend'
 import Credentials from 'next-auth/providers/credentials'
-import { DrizzleAdapter } from '@auth/drizzle-adapter'
 import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { userIdentities, users } from '@/lib/db/schema'
+import { eq, or } from 'drizzle-orm'
 import { Resend as ResendClient } from 'resend'
+import { IdentityAwareDrizzleAdapter } from '@/lib/auth-adapter'
 import { authorizeGoogleOneTap } from '@/lib/auth.google-one-tap'
 import { consumeTelegramPreauthToken } from '@/lib/telegram-auth'
 import { bestEffortRecordUserActivity } from '@/lib/user-activity'
@@ -91,7 +91,7 @@ async function sendMagicLinkEmail(email: string, url: string) {
 }
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
-  adapter: DrizzleAdapter(db),
+  adapter: IdentityAwareDrizzleAdapter(),
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,
@@ -126,7 +126,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         const existing = await db.select().from(users).where(eq(users.id, uid)).limit(1)
         if (existing.length === 0) return null
         const user = existing[0]
-        return { id: user.id, email: user.email, contactEmail: user.contactEmail, name: user.name ?? '', telegramUsername: username || null }
+        return { id: user.id, email: user.contactEmail, contactEmail: user.contactEmail, name: user.name ?? '', telegramUsername: username || null }
       },
     }),
   ],
@@ -139,10 +139,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         // account is null for email magic link (Resend doesn't create an accounts row)
         const provider = account?.provider ? normalizeAuthProvider(account.provider) : 'email'
         const now = new Date()
-        if (user.telegramUsername) {
+        if (user.telegramUsername && userId) {
           await db.update(users).set({
             telegramUsername: user.telegramUsername,
-          }).where(userId ? eq(users.id, userId) : eq(users.email, user.email!))
+          }).where(eq(users.id, userId))
         }
         if (userId) {
           await bestEffortRecordUserActivity(userId, 'sign_in', {
@@ -209,14 +209,29 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       const email = (user?.email ?? token.email) as string | undefined
       if (userId || email) {
         const existing = await db
-          .select({ id: users.id, isAdmin: users.isAdmin, contactEmail: users.contactEmail, email: users.email })
+          .select({ id: users.id, isAdmin: users.isAdmin, contactEmail: users.contactEmail })
           .from(users)
-          .where(userId ? eq(users.id, userId) : eq(users.email, email!))
+          .where(userId ? eq(users.id, userId) : eq(users.contactEmail, email!))
           .limit(1)
+        if (existing.length === 0 && email) {
+          const identityRows = await db
+            .select({ userId: userIdentities.userId })
+            .from(userIdentities)
+            .where(or(eq(userIdentities.email, email), eq(userIdentities.providerAccountId, email)))
+            .limit(1)
+          if (identityRows[0]?.userId) {
+            const identityUserRows = await db
+              .select({ id: users.id, isAdmin: users.isAdmin, contactEmail: users.contactEmail })
+              .from(users)
+              .where(eq(users.id, identityRows[0].userId))
+              .limit(1)
+            existing.push(...identityUserRows)
+          }
+        }
         if (existing.length === 0) return null
         token.isAdmin = existing[0].isAdmin
         token.contactEmail = existing[0].contactEmail
-        const contactEmail = existing[0].contactEmail ?? existing[0].email ?? email
+        const contactEmail = existing[0].contactEmail ?? email
         if (!token.isAdmin) {
           token.isAdmin = await bootstrapAdminFromEnv(existing[0].id, contactEmail)
         }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -5,7 +5,6 @@ import {
 export const users = pgTable('user', {
   id: text('id').primaryKey(),
   name: text('name'),
-  email: text('email').unique(),
   contactEmail: text('contact_email'),
   emailVerified: timestamp('emailVerified', { mode: 'date' }),
   createdAt: timestamp('created_at', { mode: 'date' }).notNull().defaultNow(),

--- a/lib/signup-books.ts
+++ b/lib/signup-books.ts
@@ -23,7 +23,7 @@ export async function getAllSignups(): Promise<UserSignup[]> {
     .select({
       userId: users.id,
       name: users.name,
-      email: users.email,
+      email: users.contactEmail,
       contactEmail: users.contactEmail,
       contacts: users.contacts,
       prioritiesSet: users.prioritiesSet,

--- a/lib/user-identities.test.ts
+++ b/lib/user-identities.test.ts
@@ -130,10 +130,10 @@ describe('user identity helpers', () => {
     expect(insertChains[0].table).toBe(users)
     expect(insertChains[0].lastValues).toEqual(expect.objectContaining({
       id: 'generated-uuid',
-      email: null,
       contactEmail: null,
       telegramUsername: 'ivan',
     }))
+    expect(insertChains[0].lastValues).not.toHaveProperty('email')
     expect(insertChains[0].lastValues).toEqual(expect.not.objectContaining({
       authProvider: expect.anything(),
       lastSignInAt: expect.anything(),

--- a/lib/user-identities.ts
+++ b/lib/user-identities.ts
@@ -1,4 +1,4 @@
-import { and, eq, or } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { accounts, userActivityEvents, userIdentities, users } from '@/lib/db/schema'
 
@@ -91,12 +91,6 @@ function normalizeProviderAccountId(provider: IdentityProvider, providerAccountI
   return provider === 'email' ? trimmed.toLowerCase() : trimmed
 }
 
-function userInsertEmail(provider: IdentityProvider, email: string | null): string | null {
-  if (provider === 'telegram') return null
-  if (email) return email
-  throw new Error(`${provider} identity requires email`)
-}
-
 function userContactEmail(provider: IdentityProvider, email: string | null): string | null {
   return provider === 'telegram' ? null : email
 }
@@ -116,7 +110,7 @@ async function findUserIdByEmail(tx: IdentityDb, email: string): Promise<string 
   const rows = await tx
     .select({ id: users.id })
     .from(users)
-    .where(or(eq(users.email, email), eq(users.contactEmail, email)))
+    .where(eq(users.contactEmail, email))
     .limit(1)
   if (rows[0]?.id) return rows[0].id
 
@@ -161,7 +155,7 @@ async function selectResolvedUser(tx: IdentityDb, userId: string, isNew: boolean
   const rows = await tx
     .select({
       id: users.id,
-      email: users.email,
+      email: users.contactEmail,
       contactEmail: users.contactEmail,
       name: users.name,
       image: users.image,
@@ -330,7 +324,6 @@ export async function resolveOrCreateUserFromIdentity(
     if (isNew) {
       await tx.insert(users).values({
         id: userId,
-        email: userInsertEmail(normalizedProvider, email),
         contactEmail: userContactEmail(normalizedProvider, email),
         name: profile.name ?? email ?? normalizeTelegramContact(profile.telegramUsername) ?? normalizedProviderAccountId,
         emailVerified: email && normalizedProvider !== 'telegram' ? now : null,

--- a/scripts/migrate-signups.ts
+++ b/scripts/migrate-signups.ts
@@ -3,7 +3,7 @@ import { neon } from '@neondatabase/serverless'
 import { drizzle } from 'drizzle-orm/neon-http'
 import { signupBooks, users } from '../lib/db/schema'
 import * as schema from '../lib/db/schema'
-import { eq, or } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 
 function createDb() {
   return drizzle(neon(process.env.DATABASE_URL!), { schema })
@@ -74,7 +74,7 @@ export async function migrateSignupRows(
     const userRows = await database
       .select({ id: users.id, name: users.name, contacts: users.contacts })
       .from(users)
-      .where(or(eq(users.email, normalizedEmail), eq(users.contactEmail, normalizedEmail)))
+      .where(eq(users.contactEmail, normalizedEmail))
       .limit(1)
 
     const user = userRows[0]


### PR DESCRIPTION
## Summary
- replace direct `user.email` persistence with `contact_email` plus identity-aware auth lookups
- add a custom NextAuth Drizzle adapter that maps adapter email reads/writes to `contact_email` and `user_identities`
- add migration `0019_drop_user_email.sql` to backfill missing identities, delete expired verification tokens, and drop the legacy column
- harden e2e cleanup for Telegram test identities

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:e2e -- e2e/signup.spec.ts e2e/telegram-auth.spec.ts e2e/admin-users.spec.ts e2e/profile.spec.ts`
- verified prod DB has no leftover e2e users after the cleanup fix

## Deployment note
Apply `drizzle/0019_drop_user_email.sql` only after the new production deployment is READY; the previous production code still reads `user.email`.

Closes #136