### PR TITLE
Fix profile saves triggering book selection activity

### DIFF
--- a/app/api/profile/route.test.ts
+++ b/app/api/profile/route.test.ts
@@ -90,7 +90,7 @@ describe('PATCH /api/profile — auth', () => {
 describe('PATCH /api/profile — happy path', () => {
   it('сохраняет языки и возвращает обновлённый массив', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
-    mockUpdateResult.mockResolvedValue([{ languages: '["ru","en"]' }])
+    mockUpdateResult.mockResolvedValue([{ name: 'User', contacts: '@user', languages: '["ru","en"]' }])
     const req = new NextRequest('http://localhost/api/profile', {
       method: 'PATCH',
       body: JSON.stringify({ languages: ['ru', 'en'] }),
@@ -103,6 +103,24 @@ describe('PATCH /api/profile — happy path', () => {
     expect(mockRecordUserActivity).toHaveBeenCalledWith('user-1', 'profile_updated', expect.objectContaining({
       source: 'api',
       metadata: { languages: ['ru', 'en'] },
+    }))
+  })
+
+  it('сохраняет имя и контакты без повторного выбора книг', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
+    mockUpdateResult.mockResolvedValue([{ name: 'User New', contacts: '@new', languages: null }])
+    const req = new NextRequest('http://localhost/api/profile', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: ' User New ', contacts: ' @new ' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toEqual({ name: 'User New', contacts: '@new', languages: null })
+    expect(mockRecordUserActivity).toHaveBeenCalledWith('user-1', 'profile_updated', expect.objectContaining({
+      source: 'api',
+      metadata: { name: 'User New', contacts: '@new' },
     }))
   })
 })
@@ -119,6 +137,19 @@ describe('PATCH /api/profile — validation', () => {
     expect(res.status).toBe(400)
     const data = await res.json()
     expect(data.error).toBe('Invalid languages')
+  })
+
+  it('возвращает 400 если name/contacts невалидны', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
+    const req = new NextRequest('http://localhost/api/profile', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: '', contacts: '@user' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.error).toBe('Invalid profile')
   })
 
   it('возвращает 400 если тело запроса невалидный JSON', async () => {

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -5,7 +5,7 @@ import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
-import { bestEffortRecordUserActivity, buildUserActivityDedupeKey } from '@/lib/user-activity'
+import { bestEffortRecordUserActivity, buildUserActivityDedupeKey, type UserActivityMetadata } from '@/lib/user-activity'
 
 export async function GET() {
   const session = await auth()
@@ -32,22 +32,51 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  let languages: string[]
+  let body: { languages?: unknown; name?: unknown; contacts?: unknown }
   try {
-    const body = await req.json() as { languages: unknown }
-    if (!Array.isArray(body.languages) || !body.languages.every(x => typeof x === 'string')) {
-      return NextResponse.json({ error: 'Invalid languages' }, { status: 400 })
-    }
-    languages = body.languages
+    body = await req.json() as { languages?: unknown; name?: unknown; contacts?: unknown }
   } catch {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
   }
 
+  const updates: {
+    languages?: string
+    name?: string
+    contacts?: string
+  } = {}
+  const metadata: UserActivityMetadata = {}
+
+  if ('languages' in body) {
+    if (!Array.isArray(body.languages) || !body.languages.every(x => typeof x === 'string')) {
+      return NextResponse.json({ error: 'Invalid languages' }, { status: 400 })
+    }
+    updates.languages = JSON.stringify(body.languages)
+    metadata.languages = body.languages
+  }
+
+  if ('name' in body || 'contacts' in body) {
+    if (typeof body.name !== 'string' || !body.name.trim() || typeof body.contacts !== 'string') {
+      return NextResponse.json({ error: 'Invalid profile' }, { status: 400 })
+    }
+    updates.name = body.name.trim()
+    updates.contacts = body.contacts.trim()
+    metadata.name = updates.name
+    metadata.contacts = updates.contacts
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No profile fields to update' }, { status: 400 })
+  }
+
   const updated = await db
     .update(users)
-    .set({ languages: JSON.stringify(languages) })
+    .set(updates)
     .where(eq(users.id, session.user.id))
-    .returning({ languages: users.languages })
+    .returning({
+      name: users.name,
+      contacts: users.contacts,
+      languages: users.languages,
+    })
 
   if (updated.length === 0) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
@@ -56,10 +85,14 @@ export async function PATCH(req: NextRequest) {
   await bestEffortRecordUserActivity(session.user.id, 'profile_updated', {
     source: 'api',
     sourceId: session.user.id,
-    dedupeKey: buildUserActivityDedupeKey(['api', 'profile_updated', session.user.id, JSON.stringify(languages)]),
-    metadata: { languages },
+    dedupeKey: buildUserActivityDedupeKey(['api', 'profile_updated', session.user.id, JSON.stringify(metadata)]),
+    metadata,
   })
 
-  const saved = updated[0].languages
-  return NextResponse.json({ languages: saved ? JSON.parse(saved) as string[] : languages })
+  const saved = updated[0]
+  return NextResponse.json({
+    name: saved.name,
+    contacts: saved.contacts,
+    languages: saved.languages ? JSON.parse(saved.languages) as string[] : null,
+  })
 }

--- a/components/nd/BooksPage.tsx
+++ b/components/nd/BooksPage.tsx
@@ -39,6 +39,15 @@ async function saveSelection(name: string, contacts: string, books: string[]) {
   if (!res.ok) throw new Error(`Signup failed: ${res.status}`)
 }
 
+async function saveProfile(name: string, contacts: string) {
+  const res = await fetch('/api/profile', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, contacts }),
+  })
+  if (!res.ok) throw new Error(`Profile save failed: ${res.status}`)
+}
+
 export default function BooksPage({ books, currentUser, tagDescriptions, introHeader, introSections }: Props) {
   const { data: session } = useSession()
   const { isHidden } = useScrollHide()
@@ -226,6 +235,12 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
   }
 
   async function handleSaveContacts(name: string, contacts: string) {
+    if (currentUser && !pendingBook) {
+      await saveProfile(name, contacts)
+      setSavedUser({ name, contacts })
+      return
+    }
+
     const booksList = pendingBook
       ? [...selectedBooksRef.current, pendingBook.name]
       : selectedBooksRef.current

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -70,6 +70,13 @@ test.describe('ProfileDrawer — редактирование профиля', (
   })
 
   test('изменение имени отображается сразу в интерфейсе', async ({ page }) => {
+    const signupRequests: string[] = []
+    page.on('request', request => {
+      if (request.method() === 'POST' && new URL(request.url()).pathname === '/api/signup') {
+        signupRequests.push(request.url())
+      }
+    })
+
     await page.goto('/')
     await page.waitForLoadState('networkidle')
 
@@ -92,5 +99,6 @@ test.describe('ProfileDrawer — редактирование профиля', (
 
     // После сохранения кнопка показывает "Сохранено ✓"
     await expect(page.getByRole('button', { name: /сохранено/i })).toBeVisible()
+    expect(signupRequests).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
- Route existing-user profile name/contact saves through `/api/profile` instead of `/api/signup`
- Extend `/api/profile` PATCH to save `name` and `contacts` as profile updates
- Add unit and E2E coverage that profile drawer saves do not POST `/api/signup`

## Checks
- npm run lint
- npm run typecheck
- npm test
- NEXTAUTH_TEST_MODE=true NEXT_PUBLIC_DISABLE_ANALYTICS=true npm run test:e2e -- e2e/profile.spec.ts

E2E: нужен — меняется profile drawer save flow and persisted profile update behavior.