### PR TITLE
Use book ids for signup runtime

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -19,7 +19,7 @@ export default async function AdminPage() {
     fetchBooksForAdmin(),
     db.select().from(tagDescriptions).catch(() => []),
     db.select({ id: users.id, contactEmail: users.contactEmail, languages: users.languages, prioritiesSet: users.prioritiesSet }).from(users).catch(() => []),
-    db.select({ userId: bookPriorities.userId, bookName: bookPriorities.bookName, rank: bookPriorities.rank }).from(bookPriorities).catch(() => []),
+    db.select({ userId: bookPriorities.userId, bookId: bookPriorities.bookId, bookName: bookPriorities.bookName, rank: bookPriorities.rank }).from(bookPriorities).catch(() => []),
   ])
 
   const userLanguagesMap: Record<string, string[]> = {}
@@ -33,10 +33,10 @@ export default async function AdminPage() {
     }
   }
 
-  const bookPrioritiesMap: Record<string, { bookName: string; rank: number }[]> = {}
+  const bookPrioritiesMap: Record<string, { bookId: string | null; bookName: string; rank: number }[]> = {}
   for (const row of allPriorityRows) {
     if (!bookPrioritiesMap[row.userId]) bookPrioritiesMap[row.userId] = []
-    bookPrioritiesMap[row.userId].push({ bookName: row.bookName, rank: row.rank })
+    bookPrioritiesMap[row.userId].push({ bookId: row.bookId, bookName: row.bookName, rank: row.rank })
   }
   for (const pgId of Object.keys(bookPrioritiesMap)) {
     bookPrioritiesMap[pgId].sort((a, b) => a.rank - b.rank)
@@ -54,7 +54,10 @@ export default async function AdminPage() {
   const byBook = books
     .map(book => ({
       book,
-      users: signups.filter(s => s.selectedBooks.includes(book.name)),
+      users: signups.filter(s =>
+        (s.selectedBookIds ?? []).includes(book.id) ||
+        (!(s.selectedBookIds?.length) && s.selectedBooks.includes(book.name))
+      ),
     }))
 
   const sha = process.env.VERCEL_GIT_COMMIT_SHA

--- a/app/api/admin/priorities/route.ts
+++ b/app/api/admin/priorities/route.ts
@@ -13,13 +13,16 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
+  const bookId = req.nextUrl.searchParams.get('bookId')
   const bookName = req.nextUrl.searchParams.get('book')
-  if (!bookName) {
-    return NextResponse.json({ error: 'Missing book parameter' }, { status: 400 })
+  if (!bookId && !bookName) {
+    return NextResponse.json({ error: 'Missing bookId parameter' }, { status: 400 })
   }
 
   const signups = await getAllSignups()
-  const bookSignups = signups.filter(s => s.selectedBooks.includes(bookName))
+  const bookSignups = bookId
+    ? signups.filter(s => (s.selectedBookIds ?? []).includes(bookId))
+    : signups.filter(s => s.selectedBooks.includes(bookName!))
 
   if (bookSignups.length === 0) {
     return NextResponse.json({ users: [] })
@@ -38,7 +41,7 @@ export async function GET(req: NextRequest) {
         .from(bookPriorities)
         .where(
           and(
-            eq(bookPriorities.bookName, bookName),
+            bookId ? eq(bookPriorities.bookId, bookId) : eq(bookPriorities.bookName, bookName!),
             inArray(bookPriorities.userId, userIds)
           )
         )

--- a/app/api/admin/remove-book/route.test.ts
+++ b/app/api/admin/remove-book/route.test.ts
@@ -42,21 +42,21 @@ beforeEach(() => {
 describe('DELETE /api/admin/remove-book — security', () => {
   it('[SEC] возвращает 403 при isAdmin=undefined', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'user@test.com' } })
-    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookName: 'Book A' }))
+    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookId: 'book-a' }))
     expect(res.status).toBe(403)
     expect(signups.removeBookFromSignup).not.toHaveBeenCalled()
   })
 
   it('[SEC] возвращает 403 при isAdmin=null', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'user@test.com', isAdmin: null } })
-    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookName: 'Book A' }))
+    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookId: 'book-a' }))
     expect(res.status).toBe(403)
     expect(signups.removeBookFromSignup).not.toHaveBeenCalled()
   })
 
   it('[SEC] не-админ не может удалить книгу другого пользователя', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'attacker@test.com', isAdmin: false } })
-    const res = await DELETE(makeRequest({ userId: 'victim@test.com', bookName: 'Book A' }))
+    const res = await DELETE(makeRequest({ userId: 'victim@test.com', bookId: 'book-a' }))
     expect(res.status).toBe(403)
     expect(signups.removeBookFromSignup).not.toHaveBeenCalled()
   })
@@ -66,7 +66,7 @@ describe('DELETE /api/admin/remove-book — security', () => {
     process.env.NEXTAUTH_TEST_MODE = 'true'
     try {
       mockAuth.mockResolvedValue({ user: { email: 'attacker@test.com', isAdmin: false } })
-      const res = await DELETE(makeRequest({ userId: 'victim@test.com', bookName: 'Book A' }))
+      const res = await DELETE(makeRequest({ userId: 'victim@test.com', bookId: 'book-a' }))
       expect(res.status).toBe(403)
     } finally {
       process.env.NEXTAUTH_TEST_MODE = original
@@ -78,25 +78,25 @@ describe('DELETE /api/admin/remove-book', () => {
   it('возвращает 403 без сессии', async () => {
     mockAuth.mockResolvedValue(null)
 
-    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookName: 'Book A' }))
+    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookId: 'book-a' }))
     expect(res.status).toBe(403)
   })
 
   it('возвращает 403 без isAdmin', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'user@test.com', isAdmin: false } })
 
-    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookName: 'Book A' }))
+    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookId: 'book-a' }))
     expect(res.status).toBe(403)
   })
 
   it('возвращает 400 при отсутствии userId', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'admin@test.com', isAdmin: true } })
 
-    const res = await DELETE(makeRequest({ bookName: 'Book A' }))
+    const res = await DELETE(makeRequest({ bookId: 'book-a' }))
     expect(res.status).toBe(400)
   })
 
-  it('возвращает 400 при отсутствии bookName', async () => {
+  it('возвращает 400 при отсутствии bookId', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'admin@test.com', isAdmin: true } })
 
     const res = await DELETE(makeRequest({ userId: 'user@test.com' }))
@@ -107,12 +107,12 @@ describe('DELETE /api/admin/remove-book', () => {
     mockAuth.mockResolvedValue({ user: { email: 'admin@test.com', isAdmin: true } })
     mockRemoveBook.mockResolvedValue(undefined)
 
-    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookName: 'Book A' }))
+    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookId: 'book-a' }))
     const data = await res.json()
 
     expect(res.status).toBe(200)
     expect(data.ok).toBe(true)
-    expect(signups.removeBookFromSignup).toHaveBeenCalledWith('pg-user-1', 'Book A')
+    expect(signups.removeBookFromSignup).toHaveBeenCalledWith('pg-user-1', 'book-a')
   })
 })
 
@@ -133,7 +133,7 @@ describe('DELETE /api/admin/remove-book — priority re-rank', () => {
     const mockUpdateWhere = jest.fn().mockResolvedValue(undefined)
     ;(db.update as jest.Mock).mockReturnValue({ set: jest.fn().mockReturnThis(), where: mockUpdateWhere })
 
-    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookName: 'Book B' }))
+    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookId: 'book-b' }))
     const data = await res.json()
 
     expect(res.status).toBe(200)
@@ -155,7 +155,7 @@ describe('DELETE /api/admin/remove-book — priority re-rank', () => {
     const selectNoPriorityChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) }
     ;(db.select as jest.Mock).mockReturnValueOnce(selectNoPriorityChain)
 
-    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookName: 'Book A' }))
+    const res = await DELETE(makeRequest({ userId: 'pg-user-1', bookId: 'book-a' }))
     expect(res.status).toBe(200)
     expect(db.delete).not.toHaveBeenCalled()
     expect(db.update).not.toHaveBeenCalled()

--- a/app/api/admin/remove-book/route.ts
+++ b/app/api/admin/remove-book/route.ts
@@ -13,18 +13,18 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const { userId, bookName } = await req.json() as { userId: string; bookName: string }
-  if (!userId || !bookName) {
+  const { userId, bookId } = await req.json() as { userId: string; bookId: string }
+  if (!userId || !bookId) {
     return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
   }
 
-  await removeBookFromSignup(userId, bookName)
+  await removeBookFromSignup(userId, bookId)
 
   // Find this book's current rank
   const existing = await db
     .select({ rank: bookPriorities.rank })
     .from(bookPriorities)
-    .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookName, bookName)))
+    .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, bookId)))
   const priorityRow = existing[0]
   if (!priorityRow) return NextResponse.json({ ok: true })
 
@@ -33,7 +33,7 @@ export async function DELETE(req: NextRequest) {
   // Delete the priority entry
   await db
     .delete(bookPriorities)
-    .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookName, bookName)))
+    .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, bookId)))
 
   // Re-rank: close the gap (rank > deletedRank → rank - 1)
   await db

--- a/app/api/admin/route.test.ts
+++ b/app/api/admin/route.test.ts
@@ -4,19 +4,35 @@
 import { GET } from './route'
 import * as authModule from '@/lib/auth'
 import * as signupsModule from '@/lib/signup-books'
-import * as sheetsModule from '@/lib/sheets'
+import * as booksModule from '@/lib/books'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
 jest.mock('@/lib/signup-books', () => ({ getAllSignups: jest.fn() }))
-jest.mock('@/lib/sheets', () => ({ fetchBooks: jest.fn() }))
+jest.mock('@/lib/books', () => ({ fetchBooksForAdmin: jest.fn() }))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockGetAllSignups = signupsModule.getAllSignups as jest.Mock
-const mockFetchBooks = sheetsModule.fetchBooks as jest.Mock
+const mockFetchBooksForAdmin = booksModule.fetchBooksForAdmin as jest.Mock
 
 const sampleSignups = [
-  { userId: 'u1', name: 'Ivan', email: 'i@t.ru', contacts: '@ivan', timestamp: '', selectedBooks: ['Книга A', 'Книга B'] },
-  { userId: 'u2', name: 'Anna', email: 'a@t.ru', contacts: '@anna', timestamp: '', selectedBooks: ['Книга A'] },
+  {
+    userId: 'u1',
+    name: 'Ivan',
+    email: 'i@t.ru',
+    contacts: '@ivan',
+    timestamp: '',
+    selectedBooks: ['Книга A', 'Книга B'],
+    selectedBookIds: ['1', '2'],
+  },
+  {
+    userId: 'u2',
+    name: 'Anna',
+    email: 'a@t.ru',
+    contacts: '@anna',
+    timestamp: '',
+    selectedBooks: ['Книга A'],
+    selectedBookIds: ['1'],
+  },
 ]
 
 const sampleBooks = [
@@ -47,7 +63,7 @@ describe('GET /api/admin', () => {
   it('возвращает пользователей и группировку по книгам', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'admin@t.ru', isAdmin: true } })
     mockGetAllSignups.mockResolvedValue(sampleSignups)
-    mockFetchBooks.mockResolvedValue(sampleBooks)
+    mockFetchBooksForAdmin.mockResolvedValue(sampleBooks)
 
     const res = await GET()
     const data = await res.json()
@@ -62,7 +78,7 @@ describe('GET /api/admin', () => {
   it('не включает в byBook книги без записей', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'admin@t.ru', isAdmin: true } })
     mockGetAllSignups.mockResolvedValue([])
-    mockFetchBooks.mockResolvedValue(sampleBooks)
+    mockFetchBooksForAdmin.mockResolvedValue(sampleBooks)
 
     const res = await GET()
     const data = await res.json()

--- a/app/api/admin/route.ts
+++ b/app/api/admin/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { getAllSignups } from '@/lib/signup-books'
-import { fetchBooks } from '@/lib/sheets'
+import { fetchBooksForAdmin } from '@/lib/books'
 
 export async function GET() {
   const session = await auth()
@@ -9,12 +9,15 @@ export async function GET() {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const [signups, books] = await Promise.all([getAllSignups(), fetchBooks()])
+  const [signups, books] = await Promise.all([getAllSignups(), fetchBooksForAdmin()])
 
-  // Group by book: book name → list of users who selected it
+  // Group by book: book id → list of users who selected it
   const byBook: Record<string, typeof signups> = {}
   for (const book of books) {
-    const users = signups.filter(s => s.selectedBooks.includes(book.name))
+    const users = signups.filter(s =>
+      (s.selectedBookIds ?? []).includes(book.id) ||
+      (!(s.selectedBookIds?.length) && s.selectedBooks.includes(book.name))
+    )
     if (users.length > 0) byBook[book.name] = users
   }
 

--- a/app/api/admin/signup-books/route.ts
+++ b/app/api/admin/signup-books/route.ts
@@ -13,23 +13,23 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const { userId, bookName } = await req.json() as { userId?: string; bookName?: string }
-  if (!userId || !bookName) {
+  const { userId, bookId } = await req.json() as { userId?: string; bookId?: string }
+  if (!userId || !bookId) {
     return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
   }
 
   const [existing] = await db
     .select({ rank: bookPriorities.rank })
     .from(bookPriorities)
-    .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookName, bookName)))
+    .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, bookId)))
     .limit(1)
 
-  await removeBookFromSignup(userId, bookName)
+  await removeBookFromSignup(userId, bookId)
 
   if (existing) {
     await db
       .delete(bookPriorities)
-      .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookName, bookName)))
+      .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, bookId)))
 
     await db
       .update(bookPriorities)

--- a/app/api/priorities/route.test.ts
+++ b/app/api/priorities/route.test.ts
@@ -63,8 +63,8 @@ describe('GET /api/priorities', () => {
   it('возвращает приоритеты отсортированные по rank', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
     const rows = [
-      { bookName: 'Книга А', rank: 1 },
-      { bookName: 'Книга Б', rank: 2 },
+      { bookId: 'book-a', bookName: 'Книга А', rank: 1 },
+      { bookId: 'book-b', bookName: 'Книга Б', rank: 2 },
     ]
     ;(db.select as jest.Mock).mockReturnValue(makeSelectMock(rows))
 
@@ -79,28 +79,35 @@ describe('GET /api/priorities', () => {
 describe('PUT /api/priorities', () => {
   it('возвращает 401 без сессии', async () => {
     mockAuth.mockResolvedValue(null)
-    const res = await PUT(makePut({ books: ['Книга А'] }))
+    const res = await PUT(makePut({ bookIds: ['book-a'] }))
     expect(res.status).toBe(401)
   })
 
   it('возвращает 400 если books не массив', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
-    const res = await PUT(makePut({ books: 'Книга А' }))
+    const res = await PUT(makePut({ bookIds: 'book-a' }))
     expect(res.status).toBe(400)
   })
 
   it('возвращает 400 если books пустой массив', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
-    const res = await PUT(makePut({ books: [] }))
+    const res = await PUT(makePut({ bookIds: [] }))
     expect(res.status).toBe(400)
   })
 
   it('сохраняет приоритеты и устанавливает prioritiesSet=true', async () => {
     mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
+    ;(db.select as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue([
+          { id: 'book-a', title: 'Книга А' },
+          { id: 'book-b', title: 'Книга Б' },
+        ]),
+      }),
+    })
 
     const mockInsert = {
-      values: jest.fn().mockReturnThis(),
-      onConflictDoUpdate: jest.fn().mockResolvedValue(undefined),
+      values: jest.fn().mockResolvedValue(undefined),
     }
     const mockDelete = {
       where: jest.fn().mockResolvedValue(undefined),
@@ -113,12 +120,16 @@ describe('PUT /api/priorities', () => {
     ;(db.delete as jest.Mock).mockReturnValue(mockDelete)
     ;(db.update as jest.Mock).mockReturnValue(mockUpdate)
 
-    const res = await PUT(makePut({ books: ['Книга А', 'Книга Б'] }))
+    const res = await PUT(makePut({ bookIds: ['book-a', 'book-b'] }))
     const data = await res.json()
 
     expect(res.status).toBe(200)
     expect(data.ok).toBe(true)
     expect(db.insert).toHaveBeenCalled()
+    expect(mockInsert.values).toHaveBeenCalledWith([
+      expect.objectContaining({ bookId: 'book-a', bookName: 'Книга А', rank: 1 }),
+      expect.objectContaining({ bookId: 'book-b', bookName: 'Книга Б', rank: 2 }),
+    ])
     expect(db.update).toHaveBeenCalled()
     expect(mockRecordUserActivity).toHaveBeenCalledWith('user-1', 'priorities_updated', expect.objectContaining({
       source: 'api',

--- a/app/api/priorities/route.ts
+++ b/app/api/priorities/route.ts
@@ -4,8 +4,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { bookPriorities, users } from '@/lib/db/schema'
-import { eq, asc, and, notInArray, sql } from 'drizzle-orm'
+import { bookPriorities, books as booksTable, users } from '@/lib/db/schema'
+import { eq, asc, inArray } from 'drizzle-orm'
 import { bestEffortRecordUserActivity, buildUserActivityDedupeKey } from '@/lib/user-activity'
 
 export async function GET() {
@@ -17,7 +17,7 @@ export async function GET() {
   const userId = (session!.user as { id: string }).id
 
   const rows = await db
-    .select({ bookName: bookPriorities.bookName, rank: bookPriorities.rank })
+    .select({ bookId: bookPriorities.bookId, bookName: bookPriorities.bookName, rank: bookPriorities.rank })
     .from(bookPriorities)
     .where(eq(bookPriorities.userId, userId))
     .orderBy(asc(bookPriorities.rank))
@@ -34,44 +34,52 @@ export async function PUT(req: NextRequest) {
   const userId = (session!.user as { id: string }).id
 
   const body = await req.json()
-  const { books } = body as { books: unknown }
+  const { bookIds, books } = body as { bookIds?: unknown; books?: unknown }
+  const rawSelection = Array.isArray(bookIds) ? bookIds : books
 
   if (
-    !Array.isArray(books) ||
-    books.length === 0 ||
-    books.some(b => typeof b !== 'string' || !b.trim())
+    !Array.isArray(rawSelection) ||
+    rawSelection.length === 0 ||
+    rawSelection.some(b => typeof b !== 'string' || !b.trim())
   ) {
-    return NextResponse.json({ error: 'books must be a non-empty array of strings' }, { status: 400 })
+    return NextResponse.json({ error: 'bookIds must be a non-empty array of strings' }, { status: 400 })
   }
 
-  const validBooks = (books as string[]).map(b => b.trim()).filter(Boolean)
+  const requested = Array.from(new Set((rawSelection as string[]).map(b => b.trim()).filter(Boolean)))
+  const bookRows = Array.isArray(bookIds)
+    ? await db
+      .select({ id: booksTable.id, title: booksTable.title })
+      .from(booksTable)
+      .where(inArray(booksTable.id, requested))
+    : await db
+      .select({ id: booksTable.id, title: booksTable.title })
+      .from(booksTable)
+      .where(inArray(booksTable.title, requested))
+  const rowsById = new Map(bookRows.map(row => [row.id, row]))
+  const rowsByTitle = new Map(bookRows.map(row => [row.title, row]))
+  const validBooks = requested.flatMap(value => {
+    const row = Array.isArray(bookIds) ? rowsById.get(value) : rowsByTitle.get(value)
+    return row ? [{ bookId: row.id, bookName: row.title }] : []
+  })
+  if (validBooks.length !== requested.length) {
+    return NextResponse.json({ error: 'Some books were not found' }, { status: 400 })
+  }
   const now = new Date()
+
+  await db
+    .delete(bookPriorities)
+    .where(eq(bookPriorities.userId, userId))
 
   await db
     .insert(bookPriorities)
     .values(
-      validBooks.map((bookName, index) => ({
+      validBooks.map((book, index) => ({
         userId,
-        bookName,
+        bookName: book.bookName,
+        bookId: book.bookId,
         rank: index + 1,
         updatedAt: now,
       }))
-    )
-    .onConflictDoUpdate({
-      target: [bookPriorities.userId, bookPriorities.bookName],
-      set: {
-        rank: sql`excluded.rank`,
-        updatedAt: now,
-      },
-    })
-
-  await db
-    .delete(bookPriorities)
-    .where(
-      and(
-        eq(bookPriorities.userId, userId),
-        notInArray(bookPriorities.bookName, validBooks)
-      )
     )
 
   await db
@@ -83,7 +91,7 @@ export async function PUT(req: NextRequest) {
     occurredAt: now,
     source: 'api',
     sourceId: userId,
-    dedupeKey: buildUserActivityDedupeKey(['api', 'priorities_updated', userId, JSON.stringify(validBooks)]),
+    dedupeKey: buildUserActivityDedupeKey(['api', 'priorities_updated', userId, JSON.stringify(validBooks.map(book => book.bookId))]),
     metadata: { booksCount: validBooks.length },
   })
 

--- a/app/api/signup/route.test.ts
+++ b/app/api/signup/route.test.ts
@@ -9,7 +9,7 @@ import * as dbModule from '@/lib/db'
 import * as activityModule from '@/lib/user-activity'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
-jest.mock('@/lib/signup-books', () => ({ upsertSignup: jest.fn() }))
+jest.mock('@/lib/signup-books', () => ({ upsertSignup: jest.fn(), upsertSignupByBookIds: jest.fn() }))
 jest.mock('@/lib/db', () => ({
   db: {
     insert: jest.fn().mockReturnValue({ values: jest.fn().mockReturnValue({ catch: jest.fn() }) }),
@@ -33,6 +33,7 @@ jest.mock('@/lib/user-activity', () => ({
 
 const mockAuth = authModule.auth as jest.Mock
 const mockUpsertSignup = signups.upsertSignup as jest.Mock
+const mockUpsertSignupByBookIds = signups.upsertSignupByBookIds as jest.Mock
 const mockInsert = dbModule.db.insert as jest.Mock
 const mockRecordUserActivity = activityModule.bestEffortRecordUserActivity as jest.Mock
 
@@ -44,59 +45,68 @@ function makeRequest(body: object) {
   })
 }
 
+function upsertResult(books: string[] = [], bookIds: string[] = books.map((_, i) => `book-${i + 1}`), isNew = false) {
+  return { isNew, addedBooks: books, addedBookIds: bookIds }
+}
+
 describe('POST /api/signup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('возвращает 401 без сессии', async () => {
     mockAuth.mockResolvedValue(null)
 
-    const res = await POST(makeRequest({ name: 'Test', contacts: 'tg', selectedBooks: [] }))
+    const res = await POST(makeRequest({ name: 'Test', contacts: 'tg', selectedBookIds: [] }))
     expect(res.status).toBe(401)
   })
 
   it('возвращает 401 если в сессии нет user.id', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com' } })
 
-    const res = await POST(makeRequest({ name: 'Test', contacts: 'tg', selectedBooks: [] }))
+    const res = await POST(makeRequest({ name: 'Test', contacts: 'tg', selectedBookIds: [] }))
     expect(res.status).toBe(401)
   })
 
   it('возвращает 400 при пустом name', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
 
-    const res = await POST(makeRequest({ name: '   ', contacts: 'tg', selectedBooks: [] }))
+    const res = await POST(makeRequest({ name: '   ', contacts: 'tg', selectedBookIds: [] }))
     expect(res.status).toBe(400)
   })
 
-  it('возвращает 400 при некорректном contacts (не строка)', async () => {
+  it('возвращает 400 при некорректном contacts', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
 
-    const res = await POST(makeRequest({ name: 'Test', contacts: 123, selectedBooks: [] }))
+    const res = await POST(makeRequest({ name: 'Test', contacts: 123, selectedBookIds: [] }))
     expect(res.status).toBe(400)
   })
 
-  it('возвращает 400 при отсутствии selectedBooks', async () => {
+  it('возвращает 400 при отсутствии selectedBookIds и selectedBooks', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
 
     const res = await POST(makeRequest({ name: 'Test', contacts: 'tg' }))
     expect(res.status).toBe(400)
   })
 
-  it('возвращает 400 если selectedBooks не массив', async () => {
+  it('возвращает 400 если selectedBookIds не массив', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
 
-    const res = await POST(makeRequest({ name: 'Test', contacts: 'tg', selectedBooks: 'Book A' }))
+    const res = await POST(makeRequest({ name: 'Test', contacts: 'tg', selectedBookIds: 'Book A' }))
     expect(res.status).toBe(400)
   })
 
-  it('возвращает 200 при успешной записи', async () => {
+  it('сохраняет запись по bookId', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
-    mockUpsertSignup.mockResolvedValue({ isNew: true, addedBooks: ['Book A'] })
+    mockUpsertSignupByBookIds.mockResolvedValue(upsertResult(['Book A'], ['book-a'], true))
 
-    const res = await POST(makeRequest({ name: 'Test User', contacts: '@test', selectedBooks: ['Book A'] }))
+    const res = await POST(makeRequest({ name: 'Test User', contacts: '@test', selectedBookIds: ['book-a'] }))
     const data = await res.json()
 
     expect(res.status).toBe(200)
     expect(data.ok).toBe(true)
-    expect(signups.upsertSignup).toHaveBeenCalledWith('user-1', ['Book A'])
+    expect(signups.upsertSignupByBookIds).toHaveBeenCalledWith('user-1', ['book-a'])
+    expect(signups.upsertSignup).not.toHaveBeenCalled()
     expect(mockRecordUserActivity).toHaveBeenCalledWith('user-1', 'profile_submitted', expect.objectContaining({
       source: 'api',
       metadata: expect.objectContaining({ selectedBooksCount: 1, addedBooksCount: 1 }),
@@ -107,13 +117,23 @@ describe('POST /api/signup', () => {
     }))
   })
 
+  it('поддерживает legacy selectedBooks по названиям на переходный период', async () => {
+    mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
+    mockUpsertSignup.mockResolvedValue(upsertResult(['Book A'], ['book-a'], true))
+
+    const res = await POST(makeRequest({ name: 'Test User', contacts: '@test', selectedBooks: ['Book A'] }))
+
+    expect(res.status).toBe(200)
+    expect(signups.upsertSignup).toHaveBeenCalledWith('user-1', ['Book A'])
+  })
+
   it('обрезает пробелы в name и contacts', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
-    mockUpsertSignup.mockResolvedValue({ isNew: false, addedBooks: [] })
+    mockUpsertSignupByBookIds.mockResolvedValue(upsertResult())
 
-    await POST(makeRequest({ name: '  Test User  ', contacts: '  @test  ', selectedBooks: [] }))
+    await POST(makeRequest({ name: '  Test User  ', contacts: '  @test  ', selectedBookIds: [] }))
 
-    expect(signups.upsertSignup).toHaveBeenCalledWith('user-1', [])
+    expect(signups.upsertSignupByBookIds).toHaveBeenCalledWith('user-1', [])
     expect(mockRecordUserActivity).toHaveBeenCalledWith('user-1', 'profile_submitted', expect.any(Object))
   })
 
@@ -123,38 +143,38 @@ describe('POST /api/signup', () => {
     const mockSet = jest.fn().mockReturnValue({ where: mockWhere })
     ;(db.update as jest.Mock).mockReturnValue({ set: mockSet })
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
-    mockUpsertSignup.mockResolvedValue({ isNew: false, addedBooks: [] })
+    mockUpsertSignupByBookIds.mockResolvedValue(upsertResult())
 
-    await POST(makeRequest({ name: '  Latest Name  ', contacts: '  @latest  ', selectedBooks: [] }))
+    await POST(makeRequest({ name: '  Latest Name  ', contacts: '  @latest  ', selectedBookIds: [] }))
 
     expect(db.update).toHaveBeenCalled()
     expect(mockSet).toHaveBeenCalledWith({ name: 'Latest Name', contacts: '@latest', prioritiesSet: false })
   })
 
-  it('сбрасывает prioritiesSet=false когда selectedBooks пустой', async () => {
+  it('сбрасывает prioritiesSet=false когда selectedBookIds пустой', async () => {
     const { db } = await import('@/lib/db')
     const mockWhere = jest.fn().mockResolvedValue(undefined)
     const mockSet = jest.fn().mockReturnValue({ where: mockWhere })
     ;(db.update as jest.Mock).mockReturnValue({ set: mockSet })
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
-    mockUpsertSignup.mockResolvedValue({ isNew: false, addedBooks: [] })
+    mockUpsertSignupByBookIds.mockResolvedValue(upsertResult())
 
-    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBooks: [] }))
+    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBookIds: [] }))
 
     expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({
       prioritiesSet: false,
     }))
   })
 
-  it('не сбрасывает prioritiesSet если selectedBooks не пустой', async () => {
+  it('не сбрасывает prioritiesSet если selectedBookIds не пустой', async () => {
     const { db } = await import('@/lib/db')
     const mockWhere = jest.fn().mockResolvedValue(undefined)
     const mockSet = jest.fn().mockReturnValue({ where: mockWhere })
     ;(db.update as jest.Mock).mockReturnValue({ set: mockSet })
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
-    mockUpsertSignup.mockResolvedValue({ isNew: false, addedBooks: [] })
+    mockUpsertSignupByBookIds.mockResolvedValue(upsertResult(['Книга А'], ['book-a']))
 
-    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBooks: ['Книга А'] }))
+    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBookIds: ['book-a'] }))
 
     expect(mockSet).toHaveBeenCalledWith(expect.not.objectContaining({
       prioritiesSet: expect.anything(),
@@ -164,9 +184,9 @@ describe('POST /api/signup', () => {
   it('удаляет приоритеты для книг, которых нет в новом списке', async () => {
     const { db } = await import('@/lib/db')
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
-    mockUpsertSignup.mockResolvedValue({ isNew: false, addedBooks: [] })
+    mockUpsertSignupByBookIds.mockResolvedValue(upsertResult(['Книга А'], ['book-a']))
 
-    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBooks: ['Книга А'] }))
+    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBookIds: ['book-a'] }))
 
     expect(db.delete).toHaveBeenCalled()
   })
@@ -175,9 +195,9 @@ describe('POST /api/signup', () => {
     const mockValues = jest.fn().mockReturnValue({ catch: jest.fn() })
     mockInsert.mockReturnValue({ values: mockValues })
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
-    mockUpsertSignup.mockResolvedValue({ isNew: true, addedBooks: ['Книга А', 'Книга Б'] })
+    mockUpsertSignupByBookIds.mockResolvedValue(upsertResult(['Книга А', 'Книга Б'], ['book-a', 'book-b'], true))
 
-    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBooks: ['Книга А', 'Книга Б'] }))
+    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBookIds: ['book-a', 'book-b'] }))
 
     expect(mockInsert).toHaveBeenCalled()
     expect(mockValues).toHaveBeenCalledWith(
@@ -195,9 +215,9 @@ describe('POST /api/signup', () => {
     const mockValues = jest.fn().mockReturnValue({ catch: jest.fn() })
     mockInsert.mockReturnValue({ values: mockValues })
     mockAuth.mockResolvedValue({ user: { email: 'telegram:123456@telegram.user', id: 'user-1' } })
-    mockUpsertSignup.mockResolvedValue({ isNew: true, addedBooks: ['Книга А'] })
+    mockUpsertSignupByBookIds.mockResolvedValue(upsertResult(['Книга А'], ['book-a'], true))
 
-    await POST(makeRequest({ name: 'Test', contacts: '@telegram', selectedBooks: ['Книга А'] }))
+    await POST(makeRequest({ name: 'Test', contacts: '@telegram', selectedBookIds: ['book-a'] }))
 
     expect(mockValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -209,9 +229,9 @@ describe('POST /api/signup', () => {
 
   it('не добавляет в очередь если новых книг нет', async () => {
     mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
-    mockUpsertSignup.mockResolvedValue({ isNew: false, addedBooks: [] })
+    mockUpsertSignupByBookIds.mockResolvedValue(upsertResult())
 
-    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBooks: ['Книга А'] }))
+    await POST(makeRequest({ name: 'Test', contacts: '@t', selectedBookIds: ['book-a'] }))
 
     expect(mockInsert).not.toHaveBeenCalled()
   })

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
-import { upsertSignup } from '@/lib/signup-books'
+import { upsertSignup, upsertSignupByBookIds } from '@/lib/signup-books'
+import type { UpsertResult } from '@/lib/signup-books'
 import { db } from '@/lib/db'
 import { bookPriorities, notificationQueue, users } from '@/lib/db/schema'
-import { and, eq, notInArray } from 'drizzle-orm'
+import { and, eq, isNull, notInArray, or } from 'drizzle-orm'
 import { bestEffortRecordUserActivity, buildUserActivityDedupeKey } from '@/lib/user-activity'
 import { getUserContactEmail } from '@/lib/user-email'
 
@@ -15,30 +16,44 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json()
-  const { name, contacts, selectedBooks } = body
+  const { name, contacts, selectedBooks, selectedBookIds } = body
 
-  if (!name?.trim() || typeof contacts !== 'string' || !Array.isArray(selectedBooks)) {
+  const hasBookIds = Array.isArray(selectedBookIds)
+  const hasLegacyBookNames = Array.isArray(selectedBooks)
+  if (!name?.trim() || typeof contacts !== 'string' || (!hasBookIds && !hasLegacyBookNames)) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 
-  const selectedBookNames = selectedBooks as string[]
+  const selectedBookIdsList = hasBookIds ? selectedBookIds as string[] : []
+  const selectedBookNames = hasLegacyBookNames ? selectedBooks as string[] : []
+  const selectedCount = hasBookIds ? selectedBookIdsList.length : selectedBookNames.length
+  let result: UpsertResult
+  try {
+    result = hasBookIds
+      ? await upsertSignupByBookIds(pgUserId, selectedBookIdsList)
+      : await upsertSignup(pgUserId, selectedBookNames)
+  } catch {
+    return NextResponse.json({ error: 'Some books were not found' }, { status: 400 })
+  }
+
   await db.update(users).set({
     name: name.trim(),
     contacts: contacts.trim(),
-    ...(selectedBookNames.length === 0 ? { prioritiesSet: false } : {}),
+    ...(selectedCount === 0 ? { prioritiesSet: false } : {}),
   }).where(eq(users.id, pgUserId))
 
-  const result = await upsertSignup(pgUserId, selectedBookNames)
-
-  // Clean up book_priorities for books no longer in selectedBooks.
+  // Clean up book_priorities for books no longer in selectedBookIds.
   // Uses session.user.id (Postgres user UUID), not session.user.email (Sheets userId).
-  if (selectedBookNames.length > 0) {
+  if (result.addedBookIds.length > 0) {
     await db
       .delete(bookPriorities)
       .where(
         and(
           eq(bookPriorities.userId, pgUserId),
-          notInArray(bookPriorities.bookName, selectedBookNames)
+          or(
+            isNull(bookPriorities.bookId),
+            notInArray(bookPriorities.bookId, result.addedBookIds)
+          )
         )
       )
       .catch(() => {}) // non-critical — don't fail the request
@@ -56,25 +71,25 @@ export async function POST(req: NextRequest) {
     pgUserId,
     name.trim(),
     contacts.trim(),
-    JSON.stringify(selectedBookNames),
+    JSON.stringify(result.addedBookIds),
   ])
   await bestEffortRecordUserActivity(pgUserId, 'profile_submitted', {
     source: 'api',
     sourceId: pgUserId,
     dedupeKey: profileDedupeKey,
     metadata: {
-      selectedBooksCount: selectedBookNames.length,
+      selectedBooksCount: result.addedBookIds.length,
       addedBooksCount: result.addedBooks.length,
     },
   })
 
-  if (selectedBookNames.length > 0) {
+  if (result.addedBookIds.length > 0) {
     await bestEffortRecordUserActivity(pgUserId, 'books_selected', {
       source: 'api',
       sourceId: pgUserId,
-      dedupeKey: buildUserActivityDedupeKey(['api', 'books_selected', pgUserId, JSON.stringify(selectedBookNames)]),
+      dedupeKey: buildUserActivityDedupeKey(['api', 'books_selected', pgUserId, JSON.stringify(result.addedBookIds)]),
       metadata: {
-        selectedBooksCount: selectedBookNames.length,
+        selectedBooksCount: result.addedBookIds.length,
         addedBooksCount: result.addedBooks.length,
       },
     })

--- a/app/api/test/user/route.ts
+++ b/app/api/test/user/route.ts
@@ -47,7 +47,7 @@ export async function GET(req: NextRequest) {
   const [accountRows, sessionRows, signupBookRows, identityRows] = await Promise.all([
     db.select({ userId: accounts.userId }).from(accounts).where(eq(accounts.userId, userId)),
     db.select({ userId: sessions.userId }).from(sessions).where(eq(sessions.userId, userId)),
-    db.select({ bookName: signupBooks.bookName }).from(signupBooks).where(eq(signupBooks.userId, userId)),
+    db.select({ bookId: signupBooks.bookId, bookName: signupBooks.bookName }).from(signupBooks).where(eq(signupBooks.userId, userId)),
     db
       .select({
         provider: userIdentities.provider,
@@ -67,5 +67,6 @@ export async function GET(req: NextRequest) {
     sessionCount: sessionRows.length,
     signupBookCount: signupBookRows.length,
     signupBooks: signupBookRows.map(row => row.bookName),
+    signupBookIds: signupBookRows.map(row => row.bookId).filter(Boolean),
   })
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,6 +46,7 @@ export default async function Home() {
     contactEmail: dbUser.contactEmail,
     contacts: dbUser.contacts,
     selectedBooks: [],
+    selectedBookIds: [],
   } : null)
 
   const tagDescMap = Object.fromEntries(tagDescs.map(d => [d.tag, d.description]))

--- a/components/nd/AdminPanel.tsx
+++ b/components/nd/AdminPanel.tsx
@@ -41,7 +41,7 @@ interface Props {
   tagDescriptions: Record<string, string>
   newFlags: Record<string, boolean>
   userLanguages?: Record<string, string[]>
-  bookPrioritiesMap: Record<string, { bookName: string; rank: number }[]>
+  bookPrioritiesMap: Record<string, { bookId?: string | null; bookName: string; rank: number }[]>
   prioritiesSetMap: Record<string, boolean>
 }
 
@@ -422,13 +422,13 @@ export default function AdminPanel({
     }
   }
 
-  async function handleRemoveBook(userId: string, bookName: string, userName: string) {
+  async function handleRemoveBook(userId: string, bookId: string, bookName: string, userName: string) {
     if (!window.confirm(`Снять ${userName} с книги «${bookName}»?`)) return
     try {
       const res = await fetch('/api/admin/signup-books', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId, bookName }),
+        body: JSON.stringify({ userId, bookId }),
       })
       if (!res.ok) return
       setAdminUsers(prev => prev.map(u => u.id === userId ? { ...u, booksCount: Math.max(0, u.booksCount - 1) } : u))
@@ -437,8 +437,8 @@ export default function AdminPanel({
         return {
           ...prev,
           user: { ...prev.user, booksCount: Math.max(0, prev.user.booksCount - 1) },
-          signupBooks: prev.signupBooks.filter(b => b.bookName !== bookName),
-          priorities: prev.priorities.filter(p => p.bookName !== bookName),
+          signupBooks: prev.signupBooks.filter(b => b.bookId !== bookId),
+          priorities: prev.priorities.filter(p => p.bookId !== bookId),
         }
       })
     } catch {
@@ -996,7 +996,7 @@ export default function AdminPanel({
                       {(() => {
                         const withRanks = bookUsers.map(u => {
                           const userPriorities = bookPrioritiesMap[u.userId] ?? [] // uses original prop intentionally; По книгам is static server data
-                          const entry = userPriorities.find(p => p.bookName === book.name)
+                          const entry = userPriorities.find(p => p.bookId === book.id || (!p.bookId && p.bookName === book.name))
                           return { name: u.name, rank: entry?.rank ?? null, userId: u.userId }
                         })
                         withRanks.sort((a, b) => {
@@ -1365,9 +1365,9 @@ export default function AdminPanel({
         data={selectedAdminUser}
         loading={userDrawerLoading}
         onClose={closeUserDrawer}
-        onRemoveSignup={(bookName) => {
+        onRemoveSignup={(bookId, bookName) => {
           if (!selectedAdminUser) return
-          handleRemoveBook(selectedAdminUser.user.id, bookName, selectedAdminUser.user.name || selectedAdminUser.user.contactEmail || selectedAdminUser.user.telegramDisplay)
+          handleRemoveBook(selectedAdminUser.user.id, bookId, bookName, selectedAdminUser.user.name || selectedAdminUser.user.contactEmail || selectedAdminUser.user.telegramDisplay)
         }}
         onDeleteUser={() => {
           if (!selectedAdminUser) return

--- a/components/nd/AdminUserDrawer.tsx
+++ b/components/nd/AdminUserDrawer.tsx
@@ -8,7 +8,7 @@ interface Props {
   data: AdminUserDetails | null
   loading: boolean
   onClose: () => void
-  onRemoveSignup: (bookName: string) => void
+  onRemoveSignup: (bookId: string, bookName: string) => void
   onDeleteUser: () => void
   onOpenSubmission: (submissionId: string) => void
 }
@@ -90,11 +90,11 @@ export default function AdminUserDrawer({ isOpen, data, loading, onClose, onRemo
   }, [isOpen, onClose])
 
   const user = data?.user
-  const priorityMap = new Map((data?.priorities ?? []).map(row => [row.bookName, row.rank]))
+  const priorityMap = new Map((data?.priorities ?? []).map(row => [row.bookId ?? row.bookName, row.rank]))
   const ranked = (data?.signupBooks ?? [])
-    .filter(row => priorityMap.has(row.bookName))
-    .sort((a, b) => priorityMap.get(a.bookName)! - priorityMap.get(b.bookName)!)
-  const unranked = (data?.signupBooks ?? []).filter(row => !priorityMap.has(row.bookName))
+    .filter(row => priorityMap.has(row.bookId ?? row.bookName))
+    .sort((a, b) => priorityMap.get(a.bookId ?? a.bookName)! - priorityMap.get(b.bookId ?? b.bookName)!)
+  const unranked = (data?.signupBooks ?? []).filter(row => !priorityMap.has(row.bookId ?? row.bookName))
   const sortedBooks = user?.prioritiesSet ? [...ranked, ...unranked] : (data?.signupBooks ?? [])
 
   return (
@@ -184,14 +184,15 @@ export default function AdminUserDrawer({ isOpen, data, loading, onClose, onRemo
                 {sortedBooks.length === 0 ? <p style={{ color: '#BBB', fontStyle: 'italic', fontSize: '0.82rem' }}>Нет записей</p> : (
                   <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem' }}>
                     {sortedBooks.map(row => {
-                      const rank = priorityMap.get(row.bookName)
+                      const rowKey = row.bookId ?? row.bookName
+                      const rank = priorityMap.get(rowKey)
                       const label = !user.prioritiesSet ? '?' : rank ?? '+'
                       const isRanked = user.prioritiesSet && rank !== undefined
                       return (
-                        <span key={row.bookName} style={{ display: 'inline-flex', alignItems: 'center', background: '#F5F5F5', borderRadius: 2, overflow: 'hidden', fontSize: '0.78rem' }}>
+                        <span key={rowKey} style={{ display: 'inline-flex', alignItems: 'center', background: '#F5F5F5', borderRadius: 2, overflow: 'hidden', fontSize: '0.78rem' }}>
                           <span style={{ background: isRanked ? '#111' : '#E5E5E5', color: isRanked ? '#fff' : '#AAA', padding: '0.22rem 0.45rem', fontWeight: 700 }}>{label}</span>
                           <span style={{ padding: '0.22rem 0.5rem' }}>{row.bookName}</span>
-                          <button onClick={() => onRemoveSignup(row.bookName)} title="Снять запись" style={{ background: 'none', border: 'none', color: '#999', cursor: 'pointer', padding: '0 0.4rem' }}>×</button>
+                          <button onClick={() => row.bookId && onRemoveSignup(row.bookId, row.bookName)} disabled={!row.bookId} title="Снять запись" style={{ background: 'none', border: 'none', color: '#999', cursor: row.bookId ? 'pointer' : 'not-allowed', padding: '0 0.4rem' }}>×</button>
                         </span>
                       )
                     })}

--- a/components/nd/BooksPage.tsx
+++ b/components/nd/BooksPage.tsx
@@ -30,11 +30,11 @@ interface Props {
   introSections: AboutBlockSection[]
 }
 
-async function saveSelection(name: string, contacts: string, books: string[]) {
+async function saveSelection(name: string, contacts: string, bookIds: string[]) {
   const res = await fetch('/api/signup', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, contacts, selectedBooks: books }),
+    body: JSON.stringify({ name, contacts, selectedBookIds: bookIds }),
   })
   if (!res.ok) throw new Error(`Signup failed: ${res.status}`)
 }
@@ -110,7 +110,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
   const [showMyBooks, setShowMyBooks] = useState(false)
   const [showNew, setShowNew] = useState(false)
   const [selectedBooks, setSelectedBooks] = useState<string[]>(
-    currentUser?.selectedBooks ?? []
+    currentUser?.selectedBookIds ?? books.filter(book => currentUser?.selectedBooks.includes(book.name)).map(book => book.id)
   )
   const selectedBooksRef = useRef(selectedBooks)
   const saveSelectionQueueRef = useRef<Promise<void>>(Promise.resolve())
@@ -195,7 +195,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
     if (filterTag) result = result.filter(b => b.tags.includes(filterTag))
     if (filterAuthor) result = result.filter(b => bookMatchesAuthor(b, filterAuthor))
     result = result.filter(b => showRead ? b.status === 'read' : b.status !== 'read')
-    if (showMyBooks) result = result.filter(b => selectedBooks.includes(b.name))
+    if (showMyBooks) result = result.filter(b => selectedBooks.includes(b.id))
     if (showNew) result = result.filter(b => b.isNew)
     return result
   }, [books, query, filterTag, filterAuthor, showRead, showMyBooks, showNew, selectedBooks])
@@ -217,10 +217,10 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
     }
 
     const currentSelection = selectedBooksRef.current
-    const isAdding = !currentSelection.includes(book.name)
+    const isAdding = !currentSelection.includes(book.id)
     const next = isAdding
-      ? [...currentSelection, book.name]
-      : currentSelection.filter(n => n !== book.name)
+      ? [...currentSelection, book.id]
+      : currentSelection.filter(id => id !== book.id)
 
     track(isAdding ? 'book_signup' : 'book_unsignup', { bookName: book.name })
     selectedBooksRef.current = next
@@ -242,7 +242,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
     }
 
     const booksList = pendingBook
-      ? [...selectedBooksRef.current, pendingBook.name]
+      ? [...selectedBooksRef.current, pendingBook.id]
       : selectedBooksRef.current
     await enqueueSaveSelection(name, contacts, booksList)
     setSavedUser({ name, contacts })
@@ -258,13 +258,14 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
     await signOut()
   }
 
-  async function handleToggleByName(bookName: string): Promise<void> {
+  async function handleToggleById(bookId: string): Promise<void> {
     const original = selectedBooksRef.current
-    const isAdding = !original.includes(bookName)
+    const book = books.find(b => b.id === bookId)
+    const isAdding = !original.includes(bookId)
     const next = isAdding
-      ? [...original, bookName]
-      : original.filter(n => n !== bookName)
-    track(isAdding ? 'book_signup' : 'book_unsignup', { bookName })
+      ? [...original, bookId]
+      : original.filter(id => id !== bookId)
+    track(isAdding ? 'book_signup' : 'book_unsignup', { bookId, bookName: book?.name })
     selectedBooksRef.current = next
     setSelectedBooks(next)
     try {
@@ -470,7 +471,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: '1.5rem' }}>
             <SubmitBookCard onClick={handleSubmitBookClick} />
             {filteredBooks.map(book => (
-              <BookCard key={book.id} book={book} isSelected={selectedBooks.includes(book.name)} onToggle={handleToggle} />
+              <BookCard key={book.id} book={book} isSelected={selectedBooks.includes(book.id)} onToggle={handleToggle} />
             ))}
           </div>
         ) : (
@@ -497,7 +498,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
                 </td>
               </tr>
               {filteredBooks.map(book => (
-                <BookRow key={book.id} book={book} isSelected={selectedBooks.includes(book.name)} onToggle={handleToggle} />
+                <BookRow key={book.id} book={book} isSelected={selectedBooks.includes(book.id)} onToggle={handleToggle} />
               ))}
             </tbody>
           </table>
@@ -573,7 +574,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
         savedUser={savedUser}
         onSaveContacts={handleSaveContacts}
         onDeleteAccount={handleDeleteAccount}
-        onToggleBook={handleToggleByName}
+        onToggleBook={handleToggleById}
       />
       {feedbackFormOpen && (
         <FeedbackForm

--- a/components/nd/ProfileDrawer.tsx
+++ b/components/nd/ProfileDrawer.tsx
@@ -41,7 +41,7 @@ interface Props {
   telegramLocked?: boolean
   onSaveContacts: (name: string, contacts: string) => Promise<void>
   onDeleteAccount: () => Promise<void>
-  onToggleBook: (bookName: string) => Promise<void>
+  onToggleBook: (bookId: string) => Promise<void>
 }
 
 type Tab = 'signup' | 'submitted' | 'profile'
@@ -99,7 +99,7 @@ function SortableBookItem({
   const isTop3 = prioritiesSet && rank <= 3 && !isUnsubscribed
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={setNodeRef} style={style} data-testid="priority-book-row" data-book-id={id}>
       {isTop3 ? (
         <span style={{
           width: 24, height: 24,
@@ -224,7 +224,7 @@ export default function ProfileDrawer({
   const [localUnsubscribed, setLocalUnsubscribed] = useState<Set<string>>(new Set())
 
   // ── Book priorities (Записал:ась tab) ──
-  const [priorityOrder, setPriorityOrder] = useState<string[]>([]) // book names in rank order
+  const [priorityOrder, setPriorityOrder] = useState<string[]>([]) // book ids in rank order
   const [prioritiesLoaded, setPrioritiesLoaded] = useState(false)
   const [prioritiesSet, setPrioritiesSet] = useState(false) // true = user has sorted at least once
   const [prioritiesSaving, setPrioritiesSaving] = useState<'idle' | 'saving' | 'saved'>('idle')
@@ -257,10 +257,10 @@ export default function ProfileDrawer({
     if (!isOpen || activeTab !== 'signup' || prioritiesLoaded) return
     fetch('/api/priorities')
       .then(r => r.json())
-      .then((data: { bookName: string; rank: number }[]) => {
-        const rankedNames = data.map(d => d.bookName)
-        const unranked = selectedBooks.filter(b => !rankedNames.includes(b))
-        const merged = [...rankedNames.filter(b => selectedBooks.includes(b)), ...unranked]
+      .then((data: { bookId: string | null; bookName: string; rank: number }[]) => {
+        const rankedIds = data.map(d => d.bookId).filter((id): id is string => Boolean(id))
+        const unranked = selectedBooks.filter(id => !rankedIds.includes(id))
+        const merged = [...rankedIds.filter(id => selectedBooks.includes(id)), ...unranked]
         setPriorityOrder(merged.length > 0 ? merged : [...selectedBooks])
         setPrioritiesSet(data.length > 0)
         setPrioritiesLoaded(true)
@@ -317,17 +317,19 @@ export default function ProfileDrawer({
   }, [isOpen])
 
   // ── Unsubscribe / re-subscribe ──
-  async function handleToggle(bookName: string) {
-    const wasUnsubscribed = localUnsubscribed.has(bookName)
+  async function handleToggle(bookId: string) {
+    const book = books.find(b => b.id === bookId)
+    const bookName = book?.name ?? 'книгу'
+    const wasUnsubscribed = localUnsubscribed.has(bookId)
     // Optimistic update
     setLocalUnsubscribed(prev => {
       const next = new Set(prev)
-      if (wasUnsubscribed) next.delete(bookName)
-      else next.add(bookName)
+      if (wasUnsubscribed) next.delete(bookId)
+      else next.add(bookId)
       return next
     })
     try {
-      await onToggleBook(bookName)
+      await onToggleBook(bookId)
       const msg = wasUnsubscribed
         ? `Вы успешно записались на «${bookName}»`
         : `Вы успешно отписались от «${bookName}»`
@@ -336,8 +338,8 @@ export default function ProfileDrawer({
       // Rollback local state
       setLocalUnsubscribed(prev => {
         const next = new Set(prev)
-        if (wasUnsubscribed) next.add(bookName)
-        else next.delete(bookName)
+        if (wasUnsubscribed) next.add(bookId)
+        else next.delete(bookId)
         return next
       })
       const msg = wasUnsubscribed ? 'Не удалось записаться' : 'Не удалось отписаться'
@@ -355,7 +357,7 @@ export default function ProfileDrawer({
         await fetch('/api/priorities', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ books: booksToSave }),
+          body: JSON.stringify({ bookIds: booksToSave }),
         })
         setPrioritiesSet(true)
         setPrioritiesSaving('saved')
@@ -618,19 +620,19 @@ export default function ProfileDrawer({
                 ) : (
                   <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                     <SortableContext items={priorityOrder} strategy={verticalListSortingStrategy}>
-                      {priorityOrder.map((bookName, index) => {
-                        const book = books.find(b => b.name === bookName)
+                      {priorityOrder.map((bookId, index) => {
+                        const book = books.find(b => b.id === bookId)
                         if (!book) return null
                         return (
                           <SortableBookItem
-                            key={bookName}
-                            id={bookName}
+                            key={bookId}
+                            id={bookId}
                             rank={index + 1}
                             prioritiesSet={prioritiesSet}
-                            name={bookName}
+                            name={book.name}
                             author={book.author}
-                            isUnsubscribed={localUnsubscribed.has(bookName)}
-                            onToggle={() => handleToggle(bookName)}
+                            isUnsubscribed={localUnsubscribed.has(bookId)}
+                            onToggle={() => handleToggle(bookId)}
                           />
                         )
                       })}

--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -100,4 +100,41 @@ test('повторный submit заменяет список книг, а не 
 
   const userState = await (await page.request.get(`/api/test/user?email=${encodeURIComponent(TEST_EMAIL)}`)).json()
   expect(userState.signupBooks.sort()).toEqual(['Тестовая книга 1', 'Тестовая книга 3'])
+  expect(userState.signupBookIds.sort()).toEqual(['__test_book_1__', '__test_book_3__'])
+})
+
+test('приоритеты сохраняются и после reload читаются по bookId', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByLabel(/имя/i)).toBeVisible()
+  await page.getByLabel(/имя/i).fill(TEST_NAME)
+  await page.getByLabel(/telegram/i).fill(TEST_CONTACT)
+  await page.getByRole('button', { name: /сохранить/i }).click()
+  await expect(page.getByLabel(/имя/i)).not.toBeVisible()
+
+  const book1 = page.locator('article').filter({ hasText: 'Тестовая книга 1' })
+  const book3 = page.locator('article').filter({ hasText: 'Тестовая книга 3' })
+  await book1.getByRole('button', { name: /хочу читать/i }).click()
+  await book3.getByRole('button', { name: /хочу читать/i }).click()
+
+  await expect.poll(async () => {
+    const userState = await (await page.request.get(`/api/test/user?email=${encodeURIComponent(TEST_EMAIL)}`)).json()
+    return userState.signupBookIds.sort()
+  }).toEqual(['__test_book_1__', '__test_book_3__'])
+
+  const savePriorities = await page.request.put('/api/priorities', {
+    data: { bookIds: ['__test_book_3__', '__test_book_1__'] },
+  })
+  expect(savePriorities.ok()).toBeTruthy()
+
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.waitForLoadState('networkidle')
+  await page.getByRole('button', { name: TEST_NAME }).click()
+  const dialog = page.getByRole('dialog', { name: /личный кабинет/i })
+  await expect(dialog).toBeVisible()
+
+  await expect.poll(async () =>
+    dialog.getByTestId('priority-book-row').evaluateAll(rows =>
+      rows.map(row => row.getAttribute('data-book-id'))
+    )
+  ).toEqual(['__test_book_3__', '__test_book_1__'])
 })

--- a/lib/admin-users.ts
+++ b/lib/admin-users.ts
@@ -27,8 +27,8 @@ export interface AdminUserSummary {
 
 export interface AdminUserDetails {
   user: AdminUserSummary & { prioritiesSet: boolean }
-  signupBooks: { bookName: string; signedAt: string }[]
-  priorities: { bookName: string; rank: number }[]
+  signupBooks: { bookId: string | null; bookName: string; signedAt: string }[]
+  priorities: { bookId: string | null; bookName: string; rank: number }[]
   submissions: {
     id: string
     title: string
@@ -165,12 +165,12 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
 
   const [signupRows, priorityRows, submissionRows, feedbackRows, identityRows] = await Promise.all([
     db
-      .select({ bookName: signupBooks.bookName, signedAt: signupBooks.signedAt })
+      .select({ bookId: signupBooks.bookId, bookName: signupBooks.bookName, signedAt: signupBooks.signedAt })
       .from(signupBooks)
       .where(eq(signupBooks.userId, userId))
       .orderBy(asc(signupBooks.signedAt), asc(signupBooks.bookName)),
     db
-      .select({ bookName: bookPriorities.bookName, rank: bookPriorities.rank, updatedAt: bookPriorities.updatedAt })
+      .select({ bookId: bookPriorities.bookId, bookName: bookPriorities.bookName, rank: bookPriorities.rank, updatedAt: bookPriorities.updatedAt })
       .from(bookPriorities)
       .where(eq(bookPriorities.userId, userId))
       .orderBy(asc(bookPriorities.rank)),
@@ -221,7 +221,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
 
   return {
     user: { ...summary, prioritiesSet: userRow.prioritiesSet ?? false },
-    signupBooks: signupRows.map(row => ({ bookName: row.bookName, signedAt: row.signedAt.toISOString() })),
+    signupBooks: signupRows.map(row => ({ bookId: row.bookId, bookName: row.bookName, signedAt: row.signedAt.toISOString() })),
     priorities: priorityRows,
     submissions: submissionRows.map(row => ({
       id: row.id,

--- a/lib/signup-books.test.ts
+++ b/lib/signup-books.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { getAllSignups, removeBookFromSignup, upsertSignup } from './signup-books'
+import { getAllSignups, removeBookFromSignup, upsertSignup, upsertSignupByBookIds } from './signup-books'
 import { db } from '@/lib/db'
 
 jest.mock('@/lib/db', () => ({
@@ -29,6 +29,7 @@ describe('signup-books', () => {
           contacts: '@ivan',
           prioritiesSet: true,
           bookName: 'Книга A',
+          bookId: 'book-a',
           signedAt: new Date('2026-01-01T00:00:00Z'),
         },
         {
@@ -38,6 +39,7 @@ describe('signup-books', () => {
           contacts: '@ivan',
           prioritiesSet: true,
           bookName: 'Книга B',
+          bookId: 'book-b',
           signedAt: new Date('2026-01-01T00:00:00Z'),
         },
       ]),
@@ -54,6 +56,7 @@ describe('signup-books', () => {
         email: 'ivan@test.com',
         contacts: '@ivan',
         selectedBooks: ['Книга A', 'Книга B'],
+        selectedBookIds: ['book-a', 'book-b'],
         prioritiesSet: true,
       },
     ])
@@ -65,14 +68,39 @@ describe('signup-books', () => {
     ;(sql.transaction as jest.Mock).mockImplementation(async (fn) => fn(tx))
     // title→book_id lookup
     ;(db.select as jest.Mock).mockReturnValue({
-      from: jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue([]) }),
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue([
+          { id: 'book-a', title: 'Книга A' },
+          { id: 'book-b', title: 'Книга B' },
+        ]),
+      }),
     })
 
     const result = await upsertSignup('user-1', [' Книга A ', 'Книга A', 'Книга B'])
 
     expect(sql.transaction).toHaveBeenCalled()
     expect(tx).toHaveBeenCalledTimes(3)
-    expect(result).toEqual({ isNew: false, addedBooks: ['Книга A', 'Книга B'] })
+    expect(result).toEqual({ isNew: false, addedBooks: ['Книга A', 'Книга B'], addedBookIds: ['book-a', 'book-b'] })
+  })
+
+  it('upsertSignupByBookIds пишет book_id и legacy book_name cache', async () => {
+    const { sql } = await import('@/lib/db')
+    const tx = jest.fn().mockReturnValue('query')
+    ;(sql.transaction as jest.Mock).mockImplementation(async (fn) => fn(tx))
+    ;(db.select as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue([
+          { id: 'book-a', title: 'Книга A' },
+          { id: 'book-b', title: 'Книга B' },
+        ]),
+      }),
+    })
+
+    const result = await upsertSignupByBookIds('user-1', ['book-a', 'book-a', 'book-b'])
+
+    expect(sql.transaction).toHaveBeenCalled()
+    expect(tx).toHaveBeenCalledTimes(3)
+    expect(result).toEqual({ isNew: false, addedBooks: ['Книга A', 'Книга B'], addedBookIds: ['book-a', 'book-b'] })
   })
 
   it('upsertSignup с пустым списком только очищает записи пользователя', async () => {
@@ -85,13 +113,14 @@ describe('signup-books', () => {
     expect(sql.transaction).toHaveBeenCalled()
     expect(tx).toHaveBeenCalledTimes(1)
     expect(result.addedBooks).toEqual([])
+    expect(result.addedBookIds).toEqual([])
   })
 
   it('removeBookFromSignup удаляет одну книгу пользователя', async () => {
     const where = jest.fn().mockResolvedValue(undefined)
     ;(db.delete as jest.Mock).mockReturnValue({ where })
 
-    await removeBookFromSignup('user-1', 'Книга A')
+    await removeBookFromSignup('user-1', 'book-a')
 
     expect(db.delete).toHaveBeenCalled()
     expect(where).toHaveBeenCalled()

--- a/lib/signup-books.ts
+++ b/lib/signup-books.ts
@@ -10,12 +10,19 @@ export interface UserSignup {
   contactEmail?: string | null
   contacts: string
   selectedBooks: string[]
+  selectedBookIds?: string[]
   prioritiesSet?: boolean
 }
 
 export interface UpsertResult {
   isNew: boolean
   addedBooks: string[]
+  addedBookIds: string[]
+}
+
+interface SignupBookInput {
+  id: string
+  title: string
 }
 
 export async function getAllSignups(): Promise<UserSignup[]> {
@@ -28,6 +35,7 @@ export async function getAllSignups(): Promise<UserSignup[]> {
       contacts: users.contacts,
       prioritiesSet: users.prioritiesSet,
       bookName: signupBooks.bookName,
+      bookId: signupBooks.bookId,
       signedAt: signupBooks.signedAt,
     })
     .from(signupBooks)
@@ -39,6 +47,7 @@ export async function getAllSignups(): Promise<UserSignup[]> {
     const existing = byUser.get(row.userId)
     if (existing) {
       existing.selectedBooks.push(row.bookName)
+      if (row.bookId) (existing.selectedBookIds ??= []).push(row.bookId)
       continue
     }
 
@@ -50,6 +59,7 @@ export async function getAllSignups(): Promise<UserSignup[]> {
       contactEmail: row.contactEmail,
       contacts: row.contacts ?? '',
       selectedBooks: [row.bookName],
+      selectedBookIds: row.bookId ? [row.bookId] : [],
       prioritiesSet: row.prioritiesSet,
     })
   }
@@ -57,40 +67,78 @@ export async function getAllSignups(): Promise<UserSignup[]> {
   return Array.from(byUser.values())
 }
 
-export async function upsertSignup(userId: string, bookNames: string[]): Promise<UpsertResult> {
-  const normalized = Array.from(new Set(bookNames.map(b => b.trim()).filter(Boolean)))
+function normalizeIds(bookIds: string[]): string[] {
+  return Array.from(new Set(bookIds.map(b => b.trim()).filter(Boolean)))
+}
 
-  // Best-effort title → book_id lookup so new rows get book_id populated.
-  // If the title matches multiple non-archived books, we deliberately leave book_id NULL —
-  // picking the first match would silently misroute the signup. Cleanup 0023 will block
-  // (and Stage 3 moves writes to bookId so titles stop being ambiguous on the wire).
-  const titleToBookId = new Map<string, string | null>()
-  if (normalized.length > 0) {
-    const rows = await db
-      .select({ id: books.id, title: books.title })
-      .from(books)
-      .where(inArray(books.title, normalized))
-    const countByTitle = new Map<string, number>()
-    for (const r of rows) countByTitle.set(r.title, (countByTitle.get(r.title) ?? 0) + 1)
-    for (const r of rows) {
-      if ((countByTitle.get(r.title) ?? 0) === 1) titleToBookId.set(r.title, r.id)
-      else titleToBookId.set(r.title, null)
-    }
+async function resolveBooksByIds(bookIds: string[]): Promise<SignupBookInput[]> {
+  const normalized = normalizeIds(bookIds)
+  if (normalized.length === 0) return []
+  const rows = await db
+    .select({ id: books.id, title: books.title })
+    .from(books)
+    .where(inArray(books.id, normalized))
+  const byId = new Map(rows.map(row => [row.id, row.title]))
+  const resolved = normalized.flatMap(id => {
+    const title = byId.get(id)
+    return title ? [{ id, title }] : []
+  })
+  if (resolved.length !== normalized.length) {
+    throw new Error('BOOK_ID_NOT_FOUND')
   }
+  return resolved
+}
+
+async function resolveBooksByNames(bookNames: string[]): Promise<SignupBookInput[]> {
+  const normalized = normalizeIds(bookNames)
+  if (normalized.length === 0) return []
+
+  const rows = await db
+    .select({ id: books.id, title: books.title })
+    .from(books)
+    .where(inArray(books.title, normalized))
+  const countByTitle = new Map<string, number>()
+  for (const r of rows) countByTitle.set(r.title, (countByTitle.get(r.title) ?? 0) + 1)
+  const uniqueByTitle = new Map<string, string>()
+  for (const r of rows) {
+    if ((countByTitle.get(r.title) ?? 0) === 1) uniqueByTitle.set(r.title, r.id)
+  }
+  return normalized.flatMap(title => {
+    const id = uniqueByTitle.get(title)
+    return id ? [{ id, title }] : []
+  })
+}
+
+async function upsertResolvedSignup(userId: string, selectedBooks: SignupBookInput[]): Promise<UpsertResult> {
+  const unique = new Map<string, SignupBookInput>()
+  for (const book of selectedBooks) unique.set(book.id, book)
+  const normalized = Array.from(unique.values())
 
   await sql.transaction(tx => [
     tx`DELETE FROM signup_books WHERE user_id = ${userId}`,
-    ...normalized.map(bookName => {
-      const bookId = titleToBookId.get(bookName) ?? null
-      return tx`INSERT INTO signup_books (user_id, book_name, book_id) VALUES (${userId}, ${bookName}, ${bookId}) ON CONFLICT DO NOTHING`
-    }),
+    ...normalized.map(book =>
+      tx`INSERT INTO signup_books (user_id, book_name, book_id) VALUES (${userId}, ${book.title}, ${book.id}) ON CONFLICT DO NOTHING`
+    ),
   ])
 
-  return { isNew: false, addedBooks: normalized }
+  return { isNew: false, addedBooks: normalized.map(book => book.title), addedBookIds: normalized.map(book => book.id) }
 }
 
-export async function removeBookFromSignup(userId: string, bookName: string): Promise<void> {
+export async function upsertSignupByBookIds(userId: string, bookIds: string[]): Promise<UpsertResult> {
+  return upsertResolvedSignup(userId, await resolveBooksByIds(bookIds))
+}
+
+export async function upsertSignup(userId: string, bookNames: string[]): Promise<UpsertResult> {
+  const normalized = normalizeIds(bookNames)
+  const resolved = await resolveBooksByNames(normalized)
+  if (resolved.length !== normalized.length) {
+    throw new Error('BOOK_NAME_NOT_FOUND')
+  }
+  return upsertResolvedSignup(userId, resolved)
+}
+
+export async function removeBookFromSignup(userId: string, bookId: string): Promise<void> {
   await db
     .delete(signupBooks)
-    .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookName, bookName)))
+    .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
 }


### PR DESCRIPTION
## Summary
- switch signup and priority runtime payloads to books.id while keeping legacy title fallback
- update admin grouping/removal and user drawer data to use book_id
- add E2E coverage for persisted signup book ids and priority order after reload

## Checks
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- npm run build
- npm run test:e2e -- e2e/signup.spec.ts e2e/admin-users.spec.ts

E2E: нужен — меняли персистентный flow записи на книги, сохранения приоритетов и admin remove; покрыто signup/admin-users specs with reload checks.