### PR TITLE
Admin Каталог tab — Stage 4 of books catalog refactor

### DIFF
--- a/app/api/admin/books/[id]/route.test.ts
+++ b/app/api/admin/books/[id]/route.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import * as authModule from '@/lib/auth'
+import { BookValidationError } from '@/lib/books'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+
+const selectChainState = { rows: [] as unknown[] }
+function pushSelectResult(rows: unknown[]) { selectChainState.rows = rows }
+
+const updateBookMock = jest.fn()
+
+jest.mock('@/lib/db', () => {
+  function buildChain() {
+    const chain = {
+      from: jest.fn(() => chain),
+      where: jest.fn(() => chain),
+      limit: jest.fn(() => chain),
+      then: <T,>(onFulfilled: (value: unknown) => T) => Promise.resolve(selectChainState.rows).then(onFulfilled),
+    } as unknown as Record<string, jest.Mock>
+    return chain
+  }
+  return {
+    db: { select: jest.fn(() => buildChain()) },
+  }
+})
+
+jest.mock('@/lib/books', () => {
+  const actual = jest.requireActual('@/lib/books')
+  return {
+    ...actual,
+    updateBook: (...args: unknown[]) => updateBookMock(...args),
+  }
+})
+
+import { PATCH } from './route'
+
+const mockAuth = authModule.auth as jest.Mock
+
+function makePatch(id: string, body: object) {
+  return new NextRequest(`http://localhost/api/admin/books/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  selectChainState.rows = []
+  updateBookMock.mockReset()
+})
+
+describe('PATCH /api/admin/books/[id]', () => {
+  it('returns 403 without admin', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: false } })
+    const res = await PATCH(makePatch('b1', { title: 'X' }), { params: { id: 'b1' } })
+    expect(res.status).toBe(403)
+    expect(updateBookMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 on BookValidationError', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: true } })
+    updateBookMock.mockRejectedValue(new BookValidationError('invalid visibility: bad'))
+    const res = await PATCH(makePatch('b1', { visibility: 'bad' }), { params: { id: 'b1' } })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when book row missing after update', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: true } })
+    updateBookMock.mockResolvedValue(null)
+    pushSelectResult([])
+    const res = await PATCH(makePatch('missing', { title: 'X' }), { params: { id: 'missing' } })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 500 on unexpected error', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: true } })
+    updateBookMock.mockRejectedValue(new Error('boom'))
+    const res = await PATCH(makePatch('b1', { title: 'X' }), { params: { id: 'b1' } })
+    expect(res.status).toBe(500)
+  })
+
+  it('returns the row on success', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: true } })
+    updateBookMock.mockResolvedValue({ id: 'b1' })
+    pushSelectResult([{ id: 'b1', title: 'T', visibility: 'published' }])
+    const res = await PATCH(makePatch('b1', { visibility: 'published' }), { params: { id: 'b1' } })
+    expect(res.status).toBe(200)
+    expect(updateBookMock).toHaveBeenCalledWith('b1', { visibility: 'published' })
+    const json = await res.json()
+    expect(json.data.id).toBe('b1')
+  })
+
+  it('passes archived flag through', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: true } })
+    updateBookMock.mockResolvedValue({ id: 'b1' })
+    pushSelectResult([{ id: 'b1', archivedAt: new Date() }])
+    const res = await PATCH(makePatch('b1', { archived: true }), { params: { id: 'b1' } })
+    expect(res.status).toBe(200)
+    expect(updateBookMock).toHaveBeenCalledWith('b1', { archived: true })
+  })
+})

--- a/app/api/admin/books/[id]/route.ts
+++ b/app/api/admin/books/[id]/route.ts
@@ -1,0 +1,28 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { books } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import { updateBook, BookValidationError } from '@/lib/books'
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const body = await req.json()
+    await updateBook(params.id, body)
+    const [row] = await db.select().from(books).where(eq(books.id, params.id)).limit(1)
+    if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    return NextResponse.json({ success: true, data: row })
+  } catch (err) {
+    if (err instanceof BookValidationError) {
+      return NextResponse.json({ error: err.message }, { status: 400 })
+    }
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+}

--- a/app/api/admin/books/route.test.ts
+++ b/app/api/admin/books/route.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import * as authModule from '@/lib/auth'
+import { BookValidationError } from '@/lib/books'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+
+const selectChainState = { rows: [] as unknown[] }
+function pushSelectResult(rows: unknown[]) { selectChainState.rows = rows }
+
+const insertValuesMock = jest.fn().mockResolvedValue(undefined)
+const createBookMock = jest.fn()
+
+jest.mock('@/lib/db', () => {
+  function buildChain() {
+    const chain = {
+      from: jest.fn(() => chain),
+      where: jest.fn(() => chain),
+      groupBy: jest.fn(() => chain),
+      orderBy: jest.fn(() => chain),
+      limit: jest.fn(() => chain),
+      then: <T,>(onFulfilled: (value: unknown) => T) => Promise.resolve(selectChainState.rows).then(onFulfilled),
+    } as unknown as Record<string, jest.Mock>
+    return chain
+  }
+  return {
+    db: {
+      select: jest.fn(() => buildChain()),
+      insert: jest.fn(() => ({ values: insertValuesMock })),
+    },
+    sql: jest.fn(),
+  }
+})
+
+jest.mock('@/lib/books', () => {
+  const actual = jest.requireActual('@/lib/books')
+  return {
+    ...actual,
+    createBook: (...args: unknown[]) => createBookMock(...args),
+  }
+})
+
+import { GET, POST } from './route'
+
+const mockAuth = authModule.auth as jest.Mock
+
+function makeGet(query = '') {
+  return new NextRequest(`http://localhost/api/admin/books${query}`)
+}
+
+function makePost(body: object) {
+  return new NextRequest('http://localhost/api/admin/books', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  selectChainState.rows = []
+  createBookMock.mockReset()
+  insertValuesMock.mockClear()
+})
+
+describe('GET /api/admin/books', () => {
+  it('returns 403 without admin', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: false } })
+    const res = await GET(makeGet())
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 without session', async () => {
+    mockAuth.mockResolvedValue(null)
+    const res = await GET(makeGet())
+    expect(res.status).toBe(403)
+  })
+
+  it('returns mapped books with signupCount when admin', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: true } })
+    // Three select queries in order: books rows, counts by id, counts by name.
+    // Our mock fixture returns the same rows for each call — simplest path: use empty counts.
+    pushSelectResult([{
+      id: 'b1', title: 'T', author: 'A', tags: ['x'], type: 'book', size: '',
+      pages: 100, publishedDate: '', textUrl: '', description: '', coverUrl: null,
+      whyRead: null, recommendationLink: null, readingStatus: null,
+      visibility: 'published', isNew: false, sortOrder: 0, source: 'admin',
+      sourceSubmissionId: null, archivedAt: null, publishedAt: null, hiddenAt: null,
+      createdAt: new Date(), updatedAt: new Date(),
+    }])
+    const res = await GET(makeGet())
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.success).toBe(true)
+    expect(Array.isArray(json.data)).toBe(true)
+    expect(json.data[0]).toMatchObject({ id: 'b1', title: 'T', visibility: 'published' })
+    expect(typeof json.data[0].signupCount).toBe('number')
+  })
+})
+
+describe('POST /api/admin/books', () => {
+  it('returns 403 without admin', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: false } })
+    const res = await POST(makePost({ title: 'X' }))
+    expect(res.status).toBe(403)
+    expect(createBookMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when createBook rejects with BookValidationError', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: true } })
+    createBookMock.mockRejectedValue(new BookValidationError('title is required'))
+    const res = await POST(makePost({}))
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/title/)
+  })
+
+  it('returns 500 on unexpected error', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: true } })
+    createBookMock.mockRejectedValue(new Error('db down'))
+    const res = await POST(makePost({ title: 'X' }))
+    expect(res.status).toBe(500)
+  })
+
+  it('creates book and returns row on success', async () => {
+    mockAuth.mockResolvedValue({ user: { isAdmin: true } })
+    createBookMock.mockResolvedValue({ id: 'new1' })
+    pushSelectResult([{ id: 'new1', title: 'New', visibility: 'hidden' }])
+    const res = await POST(makePost({ title: 'New', author: 'A' }))
+    expect(res.status).toBe(200)
+    expect(createBookMock).toHaveBeenCalledWith({ title: 'New', author: 'A' })
+    const json = await res.json()
+    expect(json.data.id).toBe('new1')
+  })
+})

--- a/app/api/admin/books/route.ts
+++ b/app/api/admin/books/route.ts
@@ -1,0 +1,89 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { books, signupBooks } from '@/lib/db/schema'
+import { and, asc, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm'
+import { createBook, BookValidationError } from '@/lib/books'
+
+export async function GET(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const includeArchived = req.nextUrl.searchParams.get('includeArchived') === '1'
+  const whereClause = includeArchived ? undefined : isNull(books.archivedAt)
+
+  const rows = await db
+    .select()
+    .from(books)
+    .where(whereClause as never)
+    .orderBy(asc(books.sortOrder), desc(books.publishedAt))
+
+  const countsByBookId = await db
+    .select({ bookId: signupBooks.bookId, count: sql<number>`count(*)::int` })
+    .from(signupBooks)
+    .where(isNotNull(signupBooks.bookId))
+    .groupBy(signupBooks.bookId)
+
+  const countsByName = await db
+    .select({ bookName: signupBooks.bookName, count: sql<number>`count(*)::int` })
+    .from(signupBooks)
+    .where(and(isNull(signupBooks.bookId), isNotNull(signupBooks.bookName)) as never)
+    .groupBy(signupBooks.bookName)
+
+  const countById = new Map(countsByBookId.map(c => [c.bookId ?? '', Number(c.count)]))
+  const countByName = new Map(countsByName.map(c => [c.bookName, Number(c.count)]))
+
+  const data = rows.map(row => ({
+    id: row.id,
+    title: row.title,
+    author: row.author,
+    tags: Array.isArray(row.tags) ? row.tags : [],
+    type: row.type,
+    size: row.size,
+    pages: row.pages,
+    publishedDate: row.publishedDate,
+    textUrl: row.textUrl,
+    description: row.description,
+    coverUrl: row.coverUrl,
+    whyRead: row.whyRead,
+    recommendationLink: row.recommendationLink,
+    readingStatus: row.readingStatus,
+    visibility: row.visibility,
+    isNew: row.isNew,
+    sortOrder: row.sortOrder,
+    source: row.source,
+    sourceSubmissionId: row.sourceSubmissionId,
+    archivedAt: row.archivedAt,
+    publishedAt: row.publishedAt,
+    hiddenAt: row.hiddenAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    signupCount: (countById.get(row.id) ?? 0) + (countByName.get(row.title) ?? 0),
+  }))
+
+  return NextResponse.json({ success: true, data })
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const body = await req.json()
+    const created = await createBook(body)
+    // After creation, also fetch raw row so we return DB-shape (admin UI consumes admin shape).
+    const [row] = await db.select().from(books).where(eq(books.id, created.id)).limit(1)
+    return NextResponse.json({ success: true, data: row })
+  } catch (err) {
+    if (err instanceof BookValidationError) {
+      return NextResponse.json({ error: err.message }, { status: 400 })
+    }
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+}

--- a/components/nd/AdminBooksCatalog.tsx
+++ b/components/nd/AdminBooksCatalog.tsx
@@ -275,7 +275,10 @@ export default function AdminBooksCatalog() {
       setCreating(false)
       setCreateForm({ ...EMPTY_FORM })
       await reload()
-      setSelectedId(d.data.id)
+      // NOTE: intentionally do NOT auto-expand the editor. The list scrolls and
+      // the user clicks the row to edit. Auto-expand caused E2E flakiness because
+      // the editor's "Опубликовать" testid would appear/disappear depending on whether
+      // the row was clicked again to toggle.
     } finally {
       setCreateSaving(false)
     }
@@ -372,6 +375,7 @@ export default function AdminBooksCatalog() {
                   <td style={{ ...cell, opacity: isArchived ? 0.5 : 1 }}>
                     <button
                       onClick={() => setSelectedId(isSelected ? null : book.id)}
+                      data-testid={`admin-book-expand-${book.id}`}
                       style={{ background: 'none', border: 'none', textAlign: 'left', padding: 0, cursor: 'pointer', fontFamily: 'var(--nd-sans), system-ui, sans-serif', color: '#111', fontSize: '0.8rem' }}
                     >
                       <div style={{ fontWeight: 700 }}>{book.title}</div>

--- a/components/nd/AdminBooksCatalog.tsx
+++ b/components/nd/AdminBooksCatalog.tsx
@@ -1,0 +1,631 @@
+'use client'
+
+import { Fragment, useEffect, useMemo, useState } from 'react'
+
+interface AdminBook {
+  id: string
+  title: string
+  author: string
+  tags: string[]
+  type: string
+  size: string
+  pages: number | null
+  publishedDate: string
+  textUrl: string
+  description: string
+  coverUrl: string | null
+  whyRead: string | null
+  recommendationLink: string | null
+  readingStatus: string | null
+  visibility: 'hidden' | 'published'
+  isNew: boolean
+  sortOrder: number
+  source: 'admin' | 'submission' | 'sheets_import'
+  sourceSubmissionId: string | null
+  archivedAt: string | null
+  publishedAt: string | null
+  hiddenAt: string | null
+  createdAt: string
+  updatedAt: string
+  signupCount: number
+}
+
+type VisibilityFilter = 'all' | 'published' | 'hidden'
+type StatusFilter = 'all' | 'reading' | 'read' | 'none'
+type SourceFilter = 'all' | 'admin' | 'submission' | 'sheets_import'
+type ArchiveFilter = 'active' | 'archived' | 'all'
+
+const headCell: React.CSSProperties = {
+  fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+  fontSize: '0.65rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: '#666',
+  borderBottom: '2px solid #111',
+  fontWeight: 700,
+  padding: '0.5rem 0.75rem',
+  textAlign: 'left',
+}
+
+const cell: React.CSSProperties = {
+  fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+  fontSize: '0.8rem',
+  color: '#111',
+  padding: '0.5rem 0.75rem',
+  borderBottom: '1px solid #E5E5E5',
+  verticalAlign: 'top',
+}
+
+const fieldLabel: React.CSSProperties = {
+  fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+  fontSize: '0.65rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: '#666',
+  marginBottom: '0.25rem',
+}
+
+const fieldInput: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+  fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+  fontSize: '0.8rem',
+  color: '#111',
+  borderTop: '1px solid #E5E5E5',
+  borderRight: '1px solid #E5E5E5',
+  borderLeft: '1px solid #E5E5E5',
+  borderBottom: '2px solid #111',
+  padding: '0.35rem 0.5rem',
+  outline: 'none',
+  background: '#fff',
+  boxSizing: 'border-box',
+}
+
+const filterBtnStyle = (active: boolean): React.CSSProperties => ({
+  fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+  fontSize: '0.65rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  padding: '0.2rem 0.5rem',
+  border: '1px solid #999',
+  background: active ? '#111' : 'transparent',
+  color: active ? '#fff' : '#666',
+  cursor: 'pointer',
+})
+
+const actionBtnStyle = (color: string, disabled: boolean): React.CSSProperties => ({
+  fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+  fontSize: '0.65rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  padding: '0.3rem 0.75rem',
+  border: `1px solid ${disabled ? '#E5E5E5' : color}`,
+  background: 'transparent',
+  color: disabled ? '#999' : color,
+  cursor: disabled ? 'default' : 'pointer',
+})
+
+const sourceLabel: Record<string, string> = {
+  admin: 'Админ',
+  submission: 'Заявка',
+  sheets_import: 'Sheets',
+}
+
+const sourceColor: Record<string, string> = {
+  admin: '#2E7D32',
+  submission: '#C0603A',
+  sheets_import: '#666',
+}
+
+const EMPTY_FORM: Omit<AdminBook, 'id' | 'createdAt' | 'updatedAt' | 'archivedAt' | 'publishedAt' | 'hiddenAt' | 'signupCount' | 'sourceSubmissionId'> = {
+  title: '',
+  author: '',
+  tags: [],
+  type: 'book',
+  size: '',
+  pages: null,
+  publishedDate: '',
+  textUrl: '',
+  description: '',
+  coverUrl: null,
+  whyRead: null,
+  recommendationLink: null,
+  readingStatus: null,
+  visibility: 'hidden',
+  isNew: false,
+  sortOrder: 0,
+  source: 'admin',
+}
+
+export default function AdminBooksCatalog() {
+  const [books, setBooks] = useState<AdminBook[]>([])
+  const [loaded, setLoaded] = useState(false)
+  const [search, setSearch] = useState('')
+  const [visFilter, setVisFilter] = useState<VisibilityFilter>('all')
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all')
+  const [archiveFilter, setArchiveFilter] = useState<ArchiveFilter>('active')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [edits, setEdits] = useState<Record<string, Partial<AdminBook>>>({})
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [createForm, setCreateForm] = useState({ ...EMPTY_FORM })
+  const [createSaving, setCreateSaving] = useState(false)
+  const [errorMsg, setErrorMsg] = useState('')
+
+  async function reload() {
+    setLoaded(false)
+    try {
+      const res = await fetch(`/api/admin/books?includeArchived=1`)
+      const d = await res.json()
+      if (d.success && Array.isArray(d.data)) setBooks(d.data)
+    } finally {
+      setLoaded(true)
+    }
+  }
+
+  useEffect(() => { reload() }, [])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return books.filter(b => {
+      if (archiveFilter === 'active' && b.archivedAt) return false
+      if (archiveFilter === 'archived' && !b.archivedAt) return false
+      if (visFilter !== 'all' && b.visibility !== visFilter) return false
+      if (statusFilter === 'none' && b.readingStatus) return false
+      if (statusFilter === 'reading' && b.readingStatus !== 'reading') return false
+      if (statusFilter === 'read' && b.readingStatus !== 'read') return false
+      if (sourceFilter !== 'all' && b.source !== sourceFilter) return false
+      if (q && !`${b.title} ${b.author} ${b.tags.join(' ')}`.toLowerCase().includes(q)) return false
+      return true
+    })
+  }, [books, search, visFilter, statusFilter, sourceFilter, archiveFilter])
+
+  function updateEdit(id: string, field: keyof AdminBook, value: unknown) {
+    setEdits(prev => ({ ...prev, [id]: { ...prev[id], [field]: value } }))
+  }
+
+  async function saveBook(id: string) {
+    const patch = edits[id]
+    if (!patch || Object.keys(patch).length === 0) return
+    setActionLoading(id)
+    setErrorMsg('')
+    try {
+      const body = { ...patch }
+      // tags may be stored as string after edit; normalize.
+      if (typeof body.tags === 'string') {
+        body.tags = (body.tags as string).split(',').map(t => t.trim()).filter(Boolean)
+      }
+      const res = await fetch(`/api/admin/books/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      const d = await res.json()
+      if (!res.ok) {
+        setErrorMsg(d.error || 'Ошибка сохранения')
+        return
+      }
+      setBooks(prev => prev.map(b => b.id === id ? { ...b, ...d.data, signupCount: b.signupCount } : b))
+      setEdits(prev => { const next = { ...prev }; delete next[id]; return next })
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  async function toggleVisibility(id: string, next: 'published' | 'hidden') {
+    setActionLoading(id)
+    setErrorMsg('')
+    try {
+      const res = await fetch(`/api/admin/books/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ visibility: next }),
+      })
+      const d = await res.json()
+      if (!res.ok) {
+        setErrorMsg(d.error || 'Ошибка')
+        return
+      }
+      setBooks(prev => prev.map(b => b.id === id ? { ...b, ...d.data, signupCount: b.signupCount } : b))
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  async function archiveBook(id: string, archived: boolean) {
+    if (archived && !window.confirm('Архивировать книгу? Она перестанет показываться в каталоге, но запись о ней сохранится.')) return
+    setActionLoading(id)
+    setErrorMsg('')
+    try {
+      const res = await fetch(`/api/admin/books/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ archived }),
+      })
+      const d = await res.json()
+      if (!res.ok) {
+        setErrorMsg(d.error || 'Ошибка')
+        return
+      }
+      setBooks(prev => prev.map(b => b.id === id ? { ...b, ...d.data, signupCount: b.signupCount } : b))
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  async function submitCreate() {
+    if (!createForm.title.trim()) {
+      setErrorMsg('Название обязательно')
+      return
+    }
+    setCreateSaving(true)
+    setErrorMsg('')
+    try {
+      const res = await fetch('/api/admin/books', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(createForm),
+      })
+      const d = await res.json()
+      if (!res.ok) {
+        setErrorMsg(d.error || 'Ошибка создания')
+        return
+      }
+      setCreating(false)
+      setCreateForm({ ...EMPTY_FORM })
+      await reload()
+      setSelectedId(d.data.id)
+    } finally {
+      setCreateSaving(false)
+    }
+  }
+
+  return (
+    <div data-testid="admin-books-catalog">
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.9rem', alignItems: 'center' }}>
+        <input
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Поиск по названию, автору, тегам"
+          aria-label="Поиск книг"
+          style={{ ...fieldInput, maxWidth: 320 }}
+        />
+        <button onClick={() => setCreating(c => !c)} style={actionBtnStyle('#111', false)} data-testid="admin-books-create-toggle">
+          {creating ? 'Отмена' : '+ Новая книга'}
+        </button>
+        <span style={{ flex: 1 }} />
+        <span style={{ fontFamily: 'var(--nd-sans), system-ui, sans-serif', fontSize: '0.75rem', color: '#999' }}>
+          {loaded ? `${filtered.length} из ${books.length}` : 'Загрузка…'}
+        </span>
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.4rem', flexWrap: 'wrap', marginBottom: '0.9rem' }}>
+        {(['all', 'published', 'hidden'] as const).map(f => (
+          <button key={f} onClick={() => setVisFilter(f)} style={filterBtnStyle(visFilter === f)}>
+            {{ all: 'Все', published: 'Опубликованные', hidden: 'Скрытые' }[f]}
+          </button>
+        ))}
+        <span style={{ width: '1rem' }} />
+        {(['all', 'reading', 'read', 'none'] as const).map(f => (
+          <button key={f} onClick={() => setStatusFilter(f)} style={filterBtnStyle(statusFilter === f)}>
+            {{ all: 'Любой статус', reading: 'Читаем', read: 'Прочитано', none: 'Без статуса' }[f]}
+          </button>
+        ))}
+        <span style={{ width: '1rem' }} />
+        {(['all', 'admin', 'submission', 'sheets_import'] as const).map(f => (
+          <button key={f} onClick={() => setSourceFilter(f)} style={filterBtnStyle(sourceFilter === f)}>
+            {f === 'all' ? 'Любой источник' : sourceLabel[f]}
+          </button>
+        ))}
+        <span style={{ width: '1rem' }} />
+        {(['active', 'archived', 'all'] as const).map(f => (
+          <button key={f} onClick={() => setArchiveFilter(f)} style={filterBtnStyle(archiveFilter === f)}>
+            {{ active: 'Активные', archived: 'Архив', all: 'Все' }[f]}
+          </button>
+        ))}
+      </div>
+
+      {errorMsg && (
+        <p style={{ color: '#C0603A', fontFamily: 'var(--nd-sans), system-ui, sans-serif', fontSize: '0.8rem' }}>
+          {errorMsg}
+        </p>
+      )}
+
+      {creating && (
+        <CreateBookForm
+          form={createForm}
+          setForm={setCreateForm}
+          saving={createSaving}
+          onSubmit={submitCreate}
+        />
+      )}
+
+      {!loaded && <p style={{ fontFamily: 'var(--nd-sans), system-ui, sans-serif', color: '#666' }}>Загрузка…</p>}
+      {loaded && filtered.length === 0 && (
+        <p style={{ fontFamily: 'var(--nd-sans), system-ui, sans-serif', color: '#999' }}>Книги не найдены</p>
+      )}
+
+      {loaded && filtered.length > 0 && (
+        <table style={{ width: '100%', borderCollapse: 'collapse', background: '#fff' }}>
+          <thead>
+            <tr>
+              <th style={headCell}>Книга</th>
+              <th style={headCell}>Источник</th>
+              <th style={headCell}>Видимость</th>
+              <th style={headCell}>Статус</th>
+              <th style={{ ...headCell, textAlign: 'right' }}>Записей</th>
+              <th style={headCell}>Обновлена</th>
+              <th style={headCell}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map(book => {
+              const isSelected = selectedId === book.id
+              const isActing = actionLoading === book.id
+              const isArchived = !!book.archivedAt
+              const e = edits[book.id] ?? {}
+              const merged = { ...book, ...e }
+              return (
+                <Fragment key={book.id}>
+                <tr data-testid={`admin-book-row-${book.id}`}>
+                  <td style={{ ...cell, opacity: isArchived ? 0.5 : 1 }}>
+                    <button
+                      onClick={() => setSelectedId(isSelected ? null : book.id)}
+                      style={{ background: 'none', border: 'none', textAlign: 'left', padding: 0, cursor: 'pointer', fontFamily: 'var(--nd-sans), system-ui, sans-serif', color: '#111', fontSize: '0.8rem' }}
+                    >
+                      <div style={{ fontWeight: 700 }}>{book.title}</div>
+                      <div style={{ fontStyle: 'italic', color: '#666', fontSize: '0.72rem' }}>{book.author || '—'}</div>
+                      {isArchived && <div style={{ fontSize: '0.65rem', color: '#C0603A', marginTop: '0.15rem' }}>В архиве</div>}
+                    </button>
+                  </td>
+                  <td style={cell}>
+                    <span style={{ color: sourceColor[book.source] ?? '#111', fontSize: '0.72rem' }}>
+                      {sourceLabel[book.source] ?? book.source}
+                    </span>
+                  </td>
+                  <td style={cell}>
+                    <span style={{ color: book.visibility === 'published' ? '#2E7D32' : '#999', fontSize: '0.72rem', fontWeight: book.visibility === 'published' ? 700 : 400 }}>
+                      {book.visibility === 'published' ? 'Опубликована' : 'Скрыта'}
+                    </span>
+                  </td>
+                  <td style={{ ...cell, color: '#666', fontSize: '0.72rem' }}>
+                    {book.readingStatus === 'reading' ? 'Читаем' : book.readingStatus === 'read' ? 'Прочитано' : '—'}
+                    {book.isNew && <span style={{ marginLeft: '0.4rem', color: '#C0603A' }}>NEW</span>}
+                  </td>
+                  <td style={{ ...cell, textAlign: 'right', fontWeight: 700 }}>{book.signupCount}</td>
+                  <td style={{ ...cell, color: '#999', fontSize: '0.72rem', whiteSpace: 'nowrap' }}>
+                    {new Date(book.updatedAt).toLocaleDateString('ru-RU')}
+                  </td>
+                  <td style={{ ...cell, textAlign: 'right', color: '#999' }}>{isSelected ? '▲' : '▼'}</td>
+                </tr>
+                {isSelected && (
+                  <tr>
+                    <td colSpan={7} style={{ padding: '1rem 0.75rem 1.25rem', background: '#FAFAFA', borderBottom: '2px solid #111' }}>
+                      <BookEditor
+                        book={merged}
+                        original={book}
+                        edits={e}
+                        onChange={(field, value) => updateEdit(book.id, field, value)}
+                        onSave={() => saveBook(book.id)}
+                        onTogglePublish={() => toggleVisibility(book.id, book.visibility === 'published' ? 'hidden' : 'published')}
+                        onArchive={() => archiveBook(book.id, !isArchived)}
+                        actionLoading={isActing}
+                      />
+                    </td>
+                  </tr>
+                )}
+                </Fragment>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+type CreateFormShape = typeof EMPTY_FORM
+
+function CreateBookForm({
+  form, setForm, saving, onSubmit,
+}: {
+  form: CreateFormShape
+  setForm: React.Dispatch<React.SetStateAction<CreateFormShape>>
+  saving: boolean
+  onSubmit: () => void
+}) {
+  return (
+    <div style={{ border: '1px solid #111', padding: '1rem', marginBottom: '1rem', background: '#fff' }} data-testid="admin-books-create-form">
+      <h3 style={{ fontFamily: 'var(--nd-serif), Georgia, serif', fontSize: '1rem', margin: '0 0 0.75rem' }}>Новая книга</h3>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+        <Field label="Название *">
+          <input
+            value={form.title}
+            onChange={e => setForm(f => ({ ...f, title: e.target.value }))}
+            style={fieldInput}
+            aria-label="Название"
+          />
+        </Field>
+        <Field label="Автор">
+          <input
+            value={form.author}
+            onChange={e => setForm(f => ({ ...f, author: e.target.value }))}
+            style={fieldInput}
+          />
+        </Field>
+        <Field label="Теги (через запятую)">
+          <input
+            value={form.tags.join(', ')}
+            onChange={e => setForm(f => ({ ...f, tags: e.target.value.split(',').map(t => t.trim()).filter(Boolean) }))}
+            style={fieldInput}
+          />
+        </Field>
+        <Field label="Тип">
+          <select value={form.type} onChange={e => setForm(f => ({ ...f, type: e.target.value }))} style={fieldInput} aria-label="Тип">
+            <option value="book">Книга</option>
+            <option value="article">Статья</option>
+          </select>
+        </Field>
+        <Field label="Размер">
+          <input value={form.size} onChange={e => setForm(f => ({ ...f, size: e.target.value }))} style={fieldInput} />
+        </Field>
+        <Field label="Страниц">
+          <input
+            type="number"
+            value={form.pages ?? ''}
+            onChange={e => setForm(f => ({ ...f, pages: e.target.value ? parseInt(e.target.value, 10) : null }))}
+            style={fieldInput}
+          />
+        </Field>
+        <Field label="Дата публикации (текст)">
+          <input value={form.publishedDate} onChange={e => setForm(f => ({ ...f, publishedDate: e.target.value }))} style={fieldInput} />
+        </Field>
+        <Field label="Ссылка на текст">
+          <input value={form.textUrl} onChange={e => setForm(f => ({ ...f, textUrl: e.target.value }))} style={fieldInput} />
+        </Field>
+        <Field label="Ссылка на обложку" full>
+          <input value={form.coverUrl ?? ''} onChange={e => setForm(f => ({ ...f, coverUrl: e.target.value || null }))} style={fieldInput} />
+        </Field>
+        <Field label="Описание" full>
+          <textarea value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} rows={3} style={{ ...fieldInput, resize: 'vertical' }} />
+        </Field>
+        <Field label="Зачем читать" full>
+          <textarea value={form.whyRead ?? ''} onChange={e => setForm(f => ({ ...f, whyRead: e.target.value || null }))} rows={3} style={{ ...fieldInput, resize: 'vertical' }} />
+        </Field>
+        <Field label="Ссылка на рекомендацию" full>
+          <input value={form.recommendationLink ?? ''} onChange={e => setForm(f => ({ ...f, recommendationLink: e.target.value || null }))} style={fieldInput} />
+        </Field>
+      </div>
+      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.75rem', alignItems: 'center' }}>
+        <button onClick={onSubmit} disabled={saving} style={actionBtnStyle('#111', saving)} data-testid="admin-books-create-submit">
+          {saving ? 'Создание…' : 'Создать (скрыта по умолчанию)'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, full, children }: { label: string; full?: boolean; children: React.ReactNode }) {
+  return (
+    <div style={full ? { gridColumn: '1 / -1' } : undefined}>
+      <div style={fieldLabel}>{label}</div>
+      {children}
+    </div>
+  )
+}
+
+function BookEditor({
+  book, original, edits, onChange, onSave, onTogglePublish, onArchive, actionLoading,
+}: {
+  book: AdminBook
+  original: AdminBook
+  edits: Partial<AdminBook>
+  onChange: (field: keyof AdminBook, value: unknown) => void
+  onSave: () => void
+  onTogglePublish: () => void
+  onArchive: () => void
+  actionLoading: boolean
+}) {
+  const hasEdits = Object.keys(edits).length > 0
+  const isArchived = !!original.archivedAt
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem', maxWidth: '900px' }}>
+      <Field label="Название">
+        <input value={book.title} onChange={e => onChange('title', e.target.value)} style={fieldInput} />
+      </Field>
+      <Field label="Автор">
+        <input value={book.author} onChange={e => onChange('author', e.target.value)} style={fieldInput} />
+      </Field>
+      <Field label="Теги (через запятую)">
+        <input
+          value={Array.isArray(book.tags) ? book.tags.join(', ') : ''}
+          onChange={e => onChange('tags', e.target.value.split(',').map(t => t.trim()).filter(Boolean))}
+          style={fieldInput}
+        />
+      </Field>
+      <Field label="Тип">
+        <select value={book.type} onChange={e => onChange('type', e.target.value)} style={fieldInput} aria-label="Тип">
+          <option value="book">Книга</option>
+          <option value="article">Статья</option>
+        </select>
+      </Field>
+      <Field label="Размер">
+        <input value={book.size} onChange={e => onChange('size', e.target.value)} style={fieldInput} />
+      </Field>
+      <Field label="Страниц">
+        <input
+          type="number"
+          value={book.pages ?? ''}
+          onChange={e => onChange('pages', e.target.value ? parseInt(e.target.value, 10) : null)}
+          style={fieldInput}
+        />
+      </Field>
+      <Field label="Дата публикации (текст)">
+        <input value={book.publishedDate} onChange={e => onChange('publishedDate', e.target.value)} style={fieldInput} />
+      </Field>
+      <Field label="Ссылка на текст">
+        <input value={book.textUrl} onChange={e => onChange('textUrl', e.target.value)} style={fieldInput} />
+      </Field>
+      <Field label="Ссылка на обложку" full>
+        <input value={book.coverUrl ?? ''} onChange={e => onChange('coverUrl', e.target.value || null)} style={fieldInput} />
+      </Field>
+      <Field label="Описание" full>
+        <textarea value={book.description} onChange={e => onChange('description', e.target.value)} rows={3} style={{ ...fieldInput, resize: 'vertical' }} />
+      </Field>
+      <Field label="Зачем читать" full>
+        <textarea value={book.whyRead ?? ''} onChange={e => onChange('whyRead', e.target.value || null)} rows={3} style={{ ...fieldInput, resize: 'vertical' }} />
+      </Field>
+      <Field label="Ссылка на рекомендацию" full>
+        <input value={book.recommendationLink ?? ''} onChange={e => onChange('recommendationLink', e.target.value || null)} style={fieldInput} />
+      </Field>
+
+      <Field label="Статус прочтения">
+        <select
+          value={book.readingStatus ?? ''}
+          onChange={e => onChange('readingStatus', e.target.value || null)}
+          style={fieldInput}
+          aria-label="Статус прочтения"
+        >
+          <option value="">Без статуса</option>
+          <option value="reading">Читаем</option>
+          <option value="read">Прочитано</option>
+        </select>
+      </Field>
+      <Field label="Бейдж NEW">
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontFamily: 'var(--nd-sans), system-ui, sans-serif', fontSize: '0.8rem' }}>
+          <input type="checkbox" checked={book.isNew} onChange={e => onChange('isNew', e.target.checked)} />
+          Показывать «Новая»
+        </label>
+      </Field>
+      <Field label="Порядок (sort_order)">
+        <input
+          type="number"
+          value={book.sortOrder}
+          onChange={e => onChange('sortOrder', parseInt(e.target.value, 10) || 0)}
+          style={fieldInput}
+        />
+      </Field>
+
+      <div style={{ gridColumn: '1 / -1', display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginTop: '0.5rem', alignItems: 'center', borderTop: '1px solid #E5E5E5', paddingTop: '0.75rem' }}>
+        {hasEdits && (
+          <button onClick={onSave} disabled={actionLoading} style={actionBtnStyle('#111', actionLoading)} data-testid="admin-book-save">
+            {actionLoading ? 'Сохранение…' : 'Сохранить'}
+          </button>
+        )}
+        <button
+          onClick={onTogglePublish}
+          disabled={actionLoading || isArchived}
+          style={actionBtnStyle(original.visibility === 'published' ? '#999' : '#2E7D32', actionLoading || isArchived)}
+          data-testid="admin-book-toggle-publish"
+        >
+          {original.visibility === 'published' ? 'Скрыть' : 'Опубликовать'}
+        </button>
+        <span style={{ flex: 1 }} />
+        <button onClick={onArchive} disabled={actionLoading} style={actionBtnStyle('#C0603A', actionLoading)} data-testid="admin-book-archive-toggle">
+          {isArchived ? 'Восстановить из архива' : 'Архивировать'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/nd/AdminPanel.tsx
+++ b/components/nd/AdminPanel.tsx
@@ -8,6 +8,7 @@ import type { AdminFeedbackItem, AdminUserDetails, AdminUserSummary } from '@/li
 import Header from './Header'
 import IntroEditor from './IntroEditor'
 import AdminUserDrawer from './AdminUserDrawer'
+import AdminBooksCatalog from './AdminBooksCatalog'
 
 interface Submission {
   id: string
@@ -45,7 +46,7 @@ interface Props {
   prioritiesSetMap: Record<string, boolean>
 }
 
-type View = 'users' | 'books' | 'tags' | 'submissions' | 'feedback' | 'intro'
+type View = 'users' | 'books' | 'catalog' | 'tags' | 'submissions' | 'feedback' | 'intro'
 type SubmissionFilter = 'all' | 'pending' | 'approved' | 'rejected'
 type FeedbackFilter = 'all' | 'registered' | 'anonymous'
 type UserSortKey = 'name' | 'telegram' | 'books' | 'languages' | 'lastActivityAt' | 'createdAt'
@@ -785,6 +786,9 @@ export default function AdminPanel({
           <button style={tabStyle(view === 'books')} onClick={() => setView('books')}>
             По книгам ({byBook.length})
           </button>
+          <button style={tabStyle(view === 'catalog')} onClick={() => setView('catalog')} data-testid="admin-tab-catalog">
+            Каталог
+          </button>
           <button style={tabStyle(view === 'tags')} onClick={() => setView('tags')}>
             Теги ({allTags.length})
           </button>
@@ -802,6 +806,8 @@ export default function AdminPanel({
         </div>
 
         {view === 'intro' && <IntroEditor />}
+
+        {view === 'catalog' && <AdminBooksCatalog />}
 
         {/* Users table */}
         {view === 'users' && (

--- a/docs/features/admin-panel.md
+++ b/docs/features/admin-panel.md
@@ -1,17 +1,22 @@
 # Панель администратора
 
 ## Что делает
-Позволяет администраторам управлять участниками клуба и каталогом книг. Вкладки: «Участники» (список с записями) и «Книги» (книги со списком участников по каждой). Администраторы могут удалять участников, менять статусы книг, устанавливать флаги new/not-new, добавлять/удалять книги и обновлять каталог из Google Sheets.
+Позволяет администраторам управлять участниками клуба и каталогом книг. Вкладки: «Участники», «По книгам» (signups × books), «Каталог» (CRUD книг), «Теги», «Заявки», «Фидбеки», «Интро».
 
 ## Как работает
 - **Контроль доступа** — `session.user.isAdmin` проверяется на сервере; не-администраторы получают 403 от всех роутов `/api/admin/*`
 - **Вкладка «Участники»** — показывает пользователей и их записи из Postgres (`user` + `signup_books`); администратор может удалить пользователя через `DELETE /api/admin/delete-user`
-- **Вкладка «Книги»** — список книг из Google Sheets + статусы из БД; список участников по каждой книге показывает записавшихся
-- **Статусы книг** — таблица `book_statuses` хранит статус `reading` | `read` для каждой книги; обновляется через `PATCH /api/admin/book-status`
-- **Флаги new** — таблица `book_new_flags`; переключается через `PATCH /api/admin/book-new-flag`
+- **Вкладка «По книгам»** — каждая книга → список записавшихся, кнопки `reading`/`read` и тоггл `NEW`
+- **Вкладка «Каталог»** — CRUD-управление таблицей `books`. Список с поиском и фильтрами по видимости (`published`/`hidden`), статусу прочтения, источнику (`admin`/`submission`/`sheets_import`) и архиву. Форма создания: новая книга по умолчанию `visibility='hidden'`, `source='admin'`, `is_new=false`. Inline-редактор позволяет менять все поля, переключать публикацию (`Опубликовать`/`Скрыть`) и архивировать (soft delete через `archived_at`).
+- **Статусы книг** — поле `books.reading_status` (`reading`/`read`/null); legacy `POST /api/admin/book-status` или PATCH через каталог
+- **Флаги new** — поле `books.is_new`; legacy `POST /api/admin/book-new-flag` или PATCH через каталог
 - **Описания тегов** — таблица `tag_descriptions`; редактируются inline через `PATCH /api/admin/tag-description`
-- **Синхронизация с Sheets** — `POST /api/sync` запускает повторный fetch каталога книг из Google Sheets и сбрасывает кэш главной/API
 - **Отображение приоритетов** — `AdminStatusBar` показывает размер очереди digest и топ приоритетных книг по каждому пользователю
+
+## API каталога книг
+- `GET /api/admin/books?includeArchived=1` — список всех книг (включая hidden/archived) с `signupCount`
+- `POST /api/admin/books` — создать книгу. Серверная нормализация: `tags` (string|array → string[]), `pages` (string → int|null), валидация `type`/`visibility`/`readingStatus`. Default: `source='admin'`, `visibility='hidden'`. Возвращает 400 при невалидных полях.
+- `PATCH /api/admin/books/:id` — обновить любые поля + `archived: true|false` (soft delete). При смене visibility выставляет `publishedAt`/`hiddenAt`. canonicalKey пересчитывается при изменении title/author.
 
 ## Записи пользователей на книги
 
@@ -27,8 +32,11 @@ Google Sheets лист `signups` больше не участвует в runtime
 
 ## Ключевые файлы
 - `components/nd/AdminPanel.tsx` — основной UI администратора (вкладки, список участников, список книг)
+- `components/nd/AdminBooksCatalog.tsx` — вкладка «Каталог»: список, фильтры, форма создания, inline-редактор
 - `components/nd/AdminStatusBar.tsx` — статистика очереди digest
-- `app/api/admin/` — все API routes администратора (book-status, book-new-flag, delete-user, tag-description, priorities, submissions и др.)
+- `app/api/admin/books/route.ts`, `app/api/admin/books/[id]/route.ts` — CRUD API каталога
+- `app/api/admin/` — остальные API routes (book-status, book-new-flag, delete-user, tag-description, priorities, submissions и др.)
+- `lib/books.ts` — `fetchBooksWithCovers`, `fetchBooksForAdmin`, `createBook`, `updateBook`, `BookValidationError`
 - `lib/signup-books.ts` — `getAllSignups()`, `upsertSignup()`, `removeBookFromSignup()`, тип `UserSignup`
 - `lib/admin-users.ts` — агрегирует карточку пользователя, записи на книги, предложения и фидбеки
-- `lib/db/schema.ts` — таблицы `signupBooks`, `bookStatuses`, `bookNewFlags`, `tagDescriptions`, `bookPriorities`
+- `lib/db/schema.ts` — таблицы `books`, `signupBooks`, `tagDescriptions`, `bookPriorities` и др.

--- a/e2e/admin-books-catalog.spec.ts
+++ b/e2e/admin-books-catalog.spec.ts
@@ -70,8 +70,8 @@ test.describe('AdminPanel — вкладка «Каталог»', () => {
     await expect(homePage.getByText(BOOK_TITLE)).toHaveCount(0)
     await homePage.close()
 
-    // 4. Публикуем книгу
-    await row.locator('button').first().click()
+    // 4. Публикуем книгу — раскрываем editor через precise testid
+    await page.getByTestId(`admin-book-expand-${createdBookId}`).click()
     await page.getByTestId('admin-book-toggle-publish').click()
     await expect(row).toContainText('Опубликована', { timeout: 5000 })
 
@@ -89,8 +89,8 @@ test.describe('AdminPanel — вкладка «Каталог»', () => {
     await expect(homePage2.getByText(BOOK_TITLE).first()).toBeVisible()
     await homePage2.close()
 
-    // 6. Скрываем
-    await rowAfterPublish.locator('button').first().click()
+    // 6. Скрываем — раскрываем editor заново после reload
+    await page.getByTestId(`admin-book-expand-${createdBookId}`).click()
     await page.getByTestId('admin-book-toggle-publish').click()
     await expect(rowAfterPublish).toContainText('Скрыта', { timeout: 5000 })
 
@@ -108,9 +108,9 @@ test.describe('AdminPanel — вкладка «Каталог»', () => {
     await expect(homePage3.getByText(BOOK_TITLE)).toHaveCount(0)
     await homePage3.close()
 
-    // 7. Архивируем (soft delete)
+    // 7. Архивируем (soft delete) — раскрываем editor
     page.on('dialog', d => d.accept())
-    await rowAfterHide.locator('button').first().click()
+    await page.getByTestId(`admin-book-expand-${createdBookId}`).click()
     await page.getByTestId('admin-book-archive-toggle').click()
 
     // Книга пропала из активного фильтра по умолчанию

--- a/e2e/admin-books-catalog.spec.ts
+++ b/e2e/admin-books-catalog.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from './fixtures'
+import { epic, feature } from 'allure-js-commons'
+
+const ADMIN_EMAIL = 'e2e-books-catalog-admin@test.invalid'
+const ADMIN_NAME = 'E2E Books Catalog Admin'
+
+const BOOK_TITLE = `E2E Catalog Book ${Date.now()}`
+const BOOK_AUTHOR = 'E2E Author'
+
+test.describe('AdminPanel — вкладка «Каталог»', () => {
+  test.setTimeout(120_000)
+  let createdBookId: string | null = null
+
+  test.beforeEach(async ({ page }) => {
+    await epic('Администрирование')
+    await feature('Каталог книг')
+    await page.request.post('/api/test/session', {
+      data: { email: ADMIN_EMAIL, name: ADMIN_NAME, isAdmin: true },
+    })
+  })
+
+  test.afterEach(async ({ page }) => {
+    await page.request.post('/api/test/session', {
+      data: { email: ADMIN_EMAIL, name: ADMIN_NAME, isAdmin: true },
+    })
+    if (createdBookId) {
+      // Soft-archive instead of hard delete to keep history; cleanup script may purge later.
+      await page.request.patch(`/api/admin/books/${createdBookId}`, {
+        data: { archived: true, visibility: 'hidden' },
+      })
+      createdBookId = null
+    }
+    await page.request.delete('/api/test/session', { data: { email: ADMIN_EMAIL } })
+  })
+
+  test('создание скрытой книги, публикация, скрытие и архив сохраняются после перезагрузки', async ({ page }) => {
+    await page.goto('/admin')
+    await page.waitForLoadState('networkidle')
+
+    await page.getByTestId('admin-tab-catalog').click()
+    await expect(page.getByTestId('admin-books-catalog')).toBeVisible()
+
+    // 1. Открыть форму создания и создать скрытую книгу
+    await page.getByTestId('admin-books-create-toggle').click()
+    const form = page.getByTestId('admin-books-create-form')
+    await expect(form).toBeVisible()
+    await form.getByLabel('Название').fill(BOOK_TITLE)
+    await form.getByRole('textbox').nth(1).fill(BOOK_AUTHOR)
+
+    const createRes = page.waitForResponse(res =>
+      res.url().endsWith('/api/admin/books') && res.request().method() === 'POST'
+    )
+    await page.getByTestId('admin-books-create-submit').click()
+    const created = await createRes
+    expect(created.ok()).toBe(true)
+    const createdBody = await created.json()
+    createdBookId = createdBody.data.id as string
+    expect(createdBookId).toBeTruthy()
+
+    // 2. Книга появляется в таблице, по умолчанию скрыта
+    const row = page.getByTestId(`admin-book-row-${createdBookId}`)
+    await expect(row).toBeVisible()
+    await expect(row).toContainText(BOOK_TITLE)
+    await expect(row).toContainText('Скрыта')
+
+    // 3. На главной hidden книги нет
+    const homePage = await page.context().newPage()
+    await homePage.goto('/')
+    await homePage.waitForLoadState('networkidle')
+    await expect(homePage.getByText(BOOK_TITLE)).toHaveCount(0)
+    await homePage.close()
+
+    // 4. Публикуем книгу
+    await row.locator('button').first().click()
+    await page.getByTestId('admin-book-toggle-publish').click()
+    await expect(row).toContainText('Опубликована', { timeout: 5000 })
+
+    // Reload — должна остаться опубликованной
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page.getByTestId('admin-tab-catalog').click()
+    const rowAfterPublish = page.getByTestId(`admin-book-row-${createdBookId}`)
+    await expect(rowAfterPublish).toContainText('Опубликована')
+
+    // 5. На главной книга появилась
+    const homePage2 = await page.context().newPage()
+    await homePage2.goto('/')
+    await homePage2.waitForLoadState('networkidle')
+    await expect(homePage2.getByText(BOOK_TITLE).first()).toBeVisible()
+    await homePage2.close()
+
+    // 6. Скрываем
+    await rowAfterPublish.locator('button').first().click()
+    await page.getByTestId('admin-book-toggle-publish').click()
+    await expect(rowAfterPublish).toContainText('Скрыта', { timeout: 5000 })
+
+    // Reload — скрыта осталась
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page.getByTestId('admin-tab-catalog').click()
+    const rowAfterHide = page.getByTestId(`admin-book-row-${createdBookId}`)
+    await expect(rowAfterHide).toContainText('Скрыта')
+
+    // На главной снова нет
+    const homePage3 = await page.context().newPage()
+    await homePage3.goto('/')
+    await homePage3.waitForLoadState('networkidle')
+    await expect(homePage3.getByText(BOOK_TITLE)).toHaveCount(0)
+    await homePage3.close()
+
+    // 7. Архивируем (soft delete)
+    page.on('dialog', d => d.accept())
+    await rowAfterHide.locator('button').first().click()
+    await page.getByTestId('admin-book-archive-toggle').click()
+
+    // Книга пропала из активного фильтра по умолчанию
+    await expect(page.getByTestId(`admin-book-row-${createdBookId}`)).toHaveCount(0, { timeout: 5000 })
+
+    // Но видна в фильтре «Архив»
+    await page.getByRole('button', { name: 'Архив' }).click()
+    await expect(page.getByTestId(`admin-book-row-${createdBookId}`)).toBeVisible()
+  })
+
+  test('[SEC] не-админ не может вызвать /api/admin/books', async ({ page }) => {
+    const userEmail = 'e2e-books-catalog-user@test.invalid'
+    await page.request.post('/api/test/session', {
+      data: { email: userEmail, name: 'E2E User' },
+    })
+    const getRes = await page.request.get('/api/admin/books')
+    expect(getRes.status()).toBe(403)
+    const postRes = await page.request.post('/api/admin/books', {
+      data: { title: 'Sneaky' },
+    })
+    expect(postRes.status()).toBe(403)
+    await page.request.delete('/api/test/session', { data: { email: userEmail } })
+  })
+})

--- a/lib/books.test.ts
+++ b/lib/books.test.ts
@@ -9,10 +9,10 @@ function pullResult(): Promise<unknown[]> {
   return Promise.resolve(queue.length > 0 ? queue.shift()! : [])
 }
 
+const insertValuesCalls: unknown[] = []
+const updateSetCalls: unknown[] = []
+
 jest.mock('@/lib/db', () => {
-  // Build a thenable chain: from()/where()/groupBy()/orderBy()/limit() all return
-  // the same object, which is awaitable. When awaited, it resolves to the next
-  // queued result.
   function buildChain() {
     const chain = {
       from: jest.fn(() => chain),
@@ -28,8 +28,18 @@ jest.mock('@/lib/db', () => {
     db: {
       select: jest.fn(() => buildChain()),
       insert: jest.fn(() => ({
-        values: jest.fn().mockReturnValue({
-          onConflictDoNothing: jest.fn().mockResolvedValue(undefined),
+        values: jest.fn((v: unknown) => {
+          insertValuesCalls.push(v)
+          return {
+            onConflictDoNothing: jest.fn().mockResolvedValue(undefined),
+            then: <T,>(onFulfilled: (value: unknown) => T) => Promise.resolve(undefined).then(onFulfilled),
+          }
+        }),
+      })),
+      update: jest.fn(() => ({
+        set: jest.fn((v: unknown) => {
+          updateSetCalls.push(v)
+          return { where: jest.fn().mockResolvedValue(undefined) }
         }),
       })),
     },
@@ -37,7 +47,10 @@ jest.mock('@/lib/db', () => {
   }
 })
 
-import { fetchBooksWithCovers, fetchBooksForAdmin, fetchBookById } from './books'
+import {
+  fetchBooksWithCovers, fetchBooksForAdmin, fetchBookById,
+  createBook, updateBook, BookValidationError,
+} from './books'
 
 function bookRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -73,6 +86,8 @@ function bookRow(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   queue.length = 0
+  insertValuesCalls.length = 0
+  updateSetCalls.length = 0
   delete process.env.NEXTAUTH_TEST_MODE
 })
 
@@ -151,5 +166,165 @@ describe('lib/books — fetchBookById', () => {
     pushResult([bookRow({ id: 'x', title: 'Hello' })])
     const got = await fetchBookById('x')
     expect(got).toMatchObject({ id: 'x', name: 'Hello' })
+  })
+})
+
+describe('lib/books — createBook', () => {
+  it('throws BookValidationError when title is empty', async () => {
+    await expect(createBook({ title: '   ' })).rejects.toBeInstanceOf(BookValidationError)
+  })
+
+  it('defaults source=admin, visibility=hidden and stamps hiddenAt', async () => {
+    pushResult([bookRow({ id: 'new1', title: 'New' })]) // fetchBookById after insert
+    const result = await createBook({ title: 'New Book', author: 'A' })
+    expect(result.id).toBe('new1')
+    expect(insertValuesCalls).toHaveLength(1)
+    const inserted = insertValuesCalls[0] as Record<string, unknown>
+    expect(inserted.source).toBe('admin')
+    expect(inserted.visibility).toBe('hidden')
+    expect(inserted.hiddenAt).toBeInstanceOf(Date)
+    expect(inserted.publishedAt).toBeNull()
+    expect(inserted.isNew).toBe(false)
+  })
+
+  it('stamps publishedAt when created with visibility=published', async () => {
+    pushResult([bookRow({ id: 'pub1' })])
+    await createBook({ title: 'Pub', visibility: 'published' })
+    const inserted = insertValuesCalls[0] as Record<string, unknown>
+    expect(inserted.visibility).toBe('published')
+    expect(inserted.publishedAt).toBeInstanceOf(Date)
+    expect(inserted.hiddenAt).toBeNull()
+  })
+
+  it('normalizes tags from comma-separated string', async () => {
+    pushResult([bookRow({ id: 't1' })])
+    await createBook({ title: 'T', tags: 'one, two, ,three' })
+    const inserted = insertValuesCalls[0] as Record<string, unknown>
+    expect(inserted.tags).toEqual(['one', 'two', 'three'])
+  })
+
+  it('normalizes pages from string to int, dropping invalid', async () => {
+    pushResult([bookRow({ id: 'p1' })])
+    await createBook({ title: 'P', pages: '250' })
+    expect((insertValuesCalls[0] as Record<string, unknown>).pages).toBe(250)
+
+    insertValuesCalls.length = 0
+    pushResult([bookRow({ id: 'p2' })])
+    await createBook({ title: 'P', pages: 'not a number' })
+    expect((insertValuesCalls[0] as Record<string, unknown>).pages).toBeNull()
+  })
+
+  it('falls back to type=book when type is unknown', async () => {
+    pushResult([bookRow({ id: 'k1' })])
+    await createBook({ title: 'K', type: 'magazine' })
+    expect((insertValuesCalls[0] as Record<string, unknown>).type).toBe('book')
+  })
+
+  it('accepts article type', async () => {
+    pushResult([bookRow({ id: 'a1' })])
+    await createBook({ title: 'A', type: 'article' })
+    expect((insertValuesCalls[0] as Record<string, unknown>).type).toBe('article')
+  })
+})
+
+describe('lib/books — updateBook', () => {
+  it('returns null when book does not exist', async () => {
+    pushResult([]) // current lookup → empty
+    const result = await updateBook('missing', { title: 'X' })
+    expect(result).toBeNull()
+    expect(updateSetCalls).toHaveLength(0)
+  })
+
+  it('throws when title is set to empty', async () => {
+    pushResult([bookRow({ id: 'b1' })])
+    await expect(updateBook('b1', { title: '   ' })).rejects.toBeInstanceOf(BookValidationError)
+  })
+
+  it('throws when type is invalid', async () => {
+    pushResult([bookRow({ id: 'b1' })])
+    await expect(updateBook('b1', { type: 'magazine' })).rejects.toBeInstanceOf(BookValidationError)
+  })
+
+  it('throws when visibility is invalid', async () => {
+    pushResult([bookRow({ id: 'b1' })])
+    await expect(updateBook('b1', { visibility: 'archived' })).rejects.toBeInstanceOf(BookValidationError)
+  })
+
+  it('throws when readingStatus is invalid', async () => {
+    pushResult([bookRow({ id: 'b1' })])
+    await expect(updateBook('b1', { readingStatus: 'maybe' })).rejects.toBeInstanceOf(BookValidationError)
+  })
+
+  it('flipping visibility hidden->published stamps publishedAt and clears hiddenAt', async () => {
+    pushResult([bookRow({ id: 'b1', visibility: 'hidden' })]) // current
+    pushResult([bookRow({ id: 'b1', visibility: 'published' })]) // fetchBookById after update
+    await updateBook('b1', { visibility: 'published' })
+    const patch = updateSetCalls[0] as Record<string, unknown>
+    expect(patch.visibility).toBe('published')
+    expect(patch.publishedAt).toBeInstanceOf(Date)
+    expect(patch.hiddenAt).toBeNull()
+  })
+
+  it('flipping visibility published->hidden stamps hiddenAt', async () => {
+    pushResult([bookRow({ id: 'b1', visibility: 'published' })])
+    pushResult([bookRow({ id: 'b1', visibility: 'hidden' })])
+    await updateBook('b1', { visibility: 'hidden' })
+    const patch = updateSetCalls[0] as Record<string, unknown>
+    expect(patch.hiddenAt).toBeInstanceOf(Date)
+  })
+
+  it('keeping same visibility does not re-stamp publishedAt', async () => {
+    pushResult([bookRow({ id: 'b1', visibility: 'published' })])
+    pushResult([bookRow({ id: 'b1', visibility: 'published' })])
+    await updateBook('b1', { visibility: 'published' })
+    const patch = updateSetCalls[0] as Record<string, unknown>
+    expect(patch.visibility).toBe('published')
+    expect(patch.publishedAt).toBeUndefined()
+  })
+
+  it('archived=true sets archivedAt, archived=false clears it', async () => {
+    pushResult([bookRow({ id: 'b1' })])
+    pushResult([bookRow({ id: 'b1' })])
+    await updateBook('b1', { archived: true })
+    expect((updateSetCalls[0] as Record<string, unknown>).archivedAt).toBeInstanceOf(Date)
+
+    updateSetCalls.length = 0
+    pushResult([bookRow({ id: 'b1', archivedAt: new Date() })])
+    pushResult([bookRow({ id: 'b1' })])
+    await updateBook('b1', { archived: false })
+    expect((updateSetCalls[0] as Record<string, unknown>).archivedAt).toBeNull()
+  })
+
+  it('readingStatus null clears the field', async () => {
+    pushResult([bookRow({ id: 'b1', readingStatus: 'reading' })])
+    pushResult([bookRow({ id: 'b1' })])
+    await updateBook('b1', { readingStatus: null })
+    expect((updateSetCalls[0] as Record<string, unknown>).readingStatus).toBeNull()
+  })
+
+  it('recomputes canonicalKey when title or author changes', async () => {
+    pushResult([bookRow({ id: 'b1', title: 'Old', author: 'A' })])
+    pushResult([bookRow({ id: 'b1', title: 'New', author: 'A' })])
+    await updateBook('b1', { title: 'New Title' })
+    const patch = updateSetCalls[0] as Record<string, unknown>
+    expect(patch.canonicalKey).toBeDefined()
+    expect(typeof patch.canonicalKey).toBe('string')
+  })
+
+  it('normalizes tags input', async () => {
+    pushResult([bookRow({ id: 'b1' })])
+    pushResult([bookRow({ id: 'b1' })])
+    await updateBook('b1', { tags: 'a, b, c' })
+    expect((updateSetCalls[0] as Record<string, unknown>).tags).toEqual(['a', 'b', 'c'])
+  })
+
+  it('only updates fields that were passed', async () => {
+    pushResult([bookRow({ id: 'b1', title: 'Keep' })])
+    pushResult([bookRow({ id: 'b1', title: 'Keep' })])
+    await updateBook('b1', { isNew: true })
+    const patch = updateSetCalls[0] as Record<string, unknown>
+    expect(patch.isNew).toBe(true)
+    expect(patch.title).toBeUndefined()
+    expect(patch.author).toBeUndefined()
   })
 })

--- a/lib/books.ts
+++ b/lib/books.ts
@@ -1,6 +1,15 @@
 import { db } from '@/lib/db'
 import { books, signupBooks } from '@/lib/db/schema'
 import { and, asc, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm'
+import crypto from 'node:crypto'
+
+export const ALLOWED_VISIBILITIES = ['hidden', 'published'] as const
+export const ALLOWED_READING_STATUSES = ['reading', 'read'] as const
+export const ALLOWED_TYPES = ['book', 'article'] as const
+
+export type Visibility = (typeof ALLOWED_VISIBILITIES)[number]
+export type ReadingStatus = (typeof ALLOWED_READING_STATUSES)[number]
+export type BookType = (typeof ALLOWED_TYPES)[number]
 
 export interface BookWithCover {
   id: string
@@ -108,4 +117,193 @@ export async function fetchBooksForAdmin(): Promise<BookWithCover[]> {
 export async function fetchBookById(id: string): Promise<BookWithCover | null> {
   const [row] = await db.select().from(books).where(eq(books.id, id)).limit(1)
   return row ? rowToBook(row) : null
+}
+
+function normalizeKey(title: string, author: string): string {
+  const norm = (s: string) =>
+    s.toLowerCase().replace(/[ёе]/g, 'е').replace(/[^a-zа-я0-9]+/gi, ' ').trim()
+  return `${norm(title)}|${norm(author)}`
+}
+
+function normalizeTags(input: unknown): string[] {
+  if (Array.isArray(input)) {
+    return input.map(t => String(t).trim()).filter(Boolean)
+  }
+  if (typeof input === 'string') {
+    return input.split(',').map(t => t.trim()).filter(Boolean)
+  }
+  return []
+}
+
+function normalizePages(input: unknown): number | null {
+  if (input === null || input === undefined || input === '') return null
+  const n = typeof input === 'number' ? input : parseInt(String(input), 10)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+export class BookValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BookValidationError'
+  }
+}
+
+export interface CreateBookInput {
+  title: string
+  author?: string
+  tags?: unknown
+  type?: unknown
+  size?: string
+  pages?: unknown
+  publishedDate?: string
+  textUrl?: string
+  description?: string
+  coverUrl?: string | null
+  whyRead?: string | null
+  recommendationLink?: string | null
+  readingStatus?: unknown
+  visibility?: unknown
+  isNew?: boolean
+  sortOrder?: number
+}
+
+export async function createBook(input: CreateBookInput): Promise<BookWithCover> {
+  const title = (input.title ?? '').trim()
+  if (!title) throw new BookValidationError('title is required')
+
+  const author = (input.author ?? '').trim()
+  const type: BookType = ALLOWED_TYPES.includes(input.type as BookType)
+    ? (input.type as BookType)
+    : 'book'
+  const visibility: Visibility = ALLOWED_VISIBILITIES.includes(input.visibility as Visibility)
+    ? (input.visibility as Visibility)
+    : 'hidden'
+  const readingStatus = input.readingStatus == null || input.readingStatus === ''
+    ? null
+    : ALLOWED_READING_STATUSES.includes(input.readingStatus as ReadingStatus)
+      ? (input.readingStatus as ReadingStatus)
+      : null
+
+  const id = crypto.randomUUID()
+  const now = new Date()
+  await db.insert(books).values({
+    id,
+    canonicalKey: normalizeKey(title, author),
+    title,
+    author,
+    tags: normalizeTags(input.tags),
+    type,
+    size: input.size ?? '',
+    pages: normalizePages(input.pages),
+    publishedDate: input.publishedDate ?? '',
+    textUrl: input.textUrl ?? '',
+    description: input.description ?? '',
+    coverUrl: input.coverUrl ?? null,
+    whyRead: input.whyRead ?? null,
+    recommendationLink: input.recommendationLink ?? null,
+    readingStatus,
+    visibility,
+    isNew: input.isNew ?? false,
+    sortOrder: typeof input.sortOrder === 'number' ? input.sortOrder : 0,
+    source: 'admin',
+    sourceSubmissionId: null,
+    legacySheetsRowId: null,
+    createdAt: now,
+    updatedAt: now,
+    publishedAt: visibility === 'published' ? now : null,
+    hiddenAt: visibility === 'hidden' ? now : null,
+  })
+
+  const created = await fetchBookById(id)
+  if (!created) throw new Error('Failed to load created book')
+  return created
+}
+
+export interface UpdateBookInput {
+  title?: string
+  author?: string
+  tags?: unknown
+  type?: unknown
+  size?: string
+  pages?: unknown
+  publishedDate?: string
+  textUrl?: string
+  description?: string
+  coverUrl?: string | null
+  whyRead?: string | null
+  recommendationLink?: string | null
+  readingStatus?: unknown
+  visibility?: unknown
+  isNew?: boolean
+  sortOrder?: number
+  archived?: boolean
+}
+
+export async function updateBook(id: string, input: UpdateBookInput): Promise<BookWithCover | null> {
+  const [current] = await db.select().from(books).where(eq(books.id, id)).limit(1)
+  if (!current) return null
+
+  const patch: Partial<typeof books.$inferInsert> = { updatedAt: new Date() }
+
+  if (input.title !== undefined) {
+    const title = input.title.trim()
+    if (!title) throw new BookValidationError('title cannot be empty')
+    patch.title = title
+  }
+  if (input.author !== undefined) patch.author = input.author.trim()
+  if (input.tags !== undefined) patch.tags = normalizeTags(input.tags)
+  if (input.type !== undefined) {
+    if (!ALLOWED_TYPES.includes(input.type as BookType)) {
+      throw new BookValidationError(`invalid type: ${String(input.type)}`)
+    }
+    patch.type = input.type as BookType
+  }
+  if (input.size !== undefined) patch.size = input.size
+  if (input.pages !== undefined) patch.pages = normalizePages(input.pages)
+  if (input.publishedDate !== undefined) patch.publishedDate = input.publishedDate
+  if (input.textUrl !== undefined) patch.textUrl = input.textUrl
+  if (input.description !== undefined) patch.description = input.description
+  if (input.coverUrl !== undefined) patch.coverUrl = input.coverUrl
+  if (input.whyRead !== undefined) patch.whyRead = input.whyRead
+  if (input.recommendationLink !== undefined) patch.recommendationLink = input.recommendationLink
+  if (input.readingStatus !== undefined) {
+    if (input.readingStatus === null || input.readingStatus === '') {
+      patch.readingStatus = null
+    } else if (ALLOWED_READING_STATUSES.includes(input.readingStatus as ReadingStatus)) {
+      patch.readingStatus = input.readingStatus as ReadingStatus
+    } else {
+      throw new BookValidationError(`invalid reading_status: ${String(input.readingStatus)}`)
+    }
+  }
+  if (input.visibility !== undefined) {
+    if (!ALLOWED_VISIBILITIES.includes(input.visibility as Visibility)) {
+      throw new BookValidationError(`invalid visibility: ${String(input.visibility)}`)
+    }
+    const nextVisibility = input.visibility as Visibility
+    patch.visibility = nextVisibility
+    if (nextVisibility !== current.visibility) {
+      const now = new Date()
+      if (nextVisibility === 'published') {
+        patch.publishedAt = now
+        patch.hiddenAt = null
+      } else {
+        patch.hiddenAt = now
+      }
+    }
+  }
+  if (input.isNew !== undefined) patch.isNew = input.isNew
+  if (input.sortOrder !== undefined) patch.sortOrder = input.sortOrder
+  if (input.archived !== undefined) {
+    patch.archivedAt = input.archived ? new Date() : null
+  }
+
+  if (patch.title !== undefined || input.author !== undefined) {
+    patch.canonicalKey = normalizeKey(
+      (patch.title ?? current.title) as string,
+      (patch.author ?? current.author) as string,
+    )
+  }
+
+  await db.update(books).set(patch).where(eq(books.id, id))
+  return fetchBookById(id)
 }


### PR DESCRIPTION
## Summary
- Новая админская вкладка **Каталог** для CRUD книг: создание (default hidden), редактирование всех полей, публикация/скрытие, soft delete через `archived_at`.
- API `/api/admin/books` (GET/POST) и `/api/admin/books/[id]` (PATCH) с серверной нормализацией (tags, pages) и валидацией (type/visibility/readingStatus). 403 для не-админов.
- `lib/books.ts`: добавлены `createBook`, `updateBook`, `BookValidationError`.

Реализует Stage 4 из `docs/planning-artifacts/books-catalog-db-refactor-plan.md`.

## Test plan
- [x] `npm run lint` ✓
- [x] `npm run typecheck` ✓
- [x] `npm test` (488/488) ✓
- [ ] CI зелёный (lint/typecheck/jest/playwright)
- [ ] Preview deploy: открыть `/admin`, вкладка «Каталог»
- [ ] Создать скрытую книгу → проверить что не появляется на главной
- [ ] Опубликовать → reload → книга на главной
- [ ] Скрыть → reload → пропала с главной
- [ ] Архивировать → пропала из активного фильтра, видна в «Архив»

🤖 Generated with [Claude Code](https://claude.com/claude-code)