### PR TITLE
Make Claude Code hooks cross-platform

### DIFF
--- a/.claude/hooks/block-secrets-in-issues.sh
+++ b/.claude/hooks/block-secrets-in-issues.sh
@@ -36,7 +36,7 @@ check "eyJ[A-Za-z0-9_-]{20,}\." "JWT токен"
 check "npg_[A-Za-z0-9]{10,}" "Neon postgres пароль (npg_...)"
 
 # Проверяем наличие значений из .env.local напрямую
-if [ -f /workspace/.env.local ]; then
+if [ -f ${CLAUDE_PROJECT_DIR:-$(pwd)}/.env.local ]; then
   while IFS='=' read -r key value; do
     # Пропускаем комментарии, пустые строки и публичные значения
     [[ "$key" =~ ^# ]] && continue
@@ -47,7 +47,7 @@ if [ -f /workspace/.env.local ]; then
     if [ -n "$value" ] && echo "$CMD" | grep -qF "$value"; then
       FOUND="$FOUND\n  ⚠ Значение переменной $key из .env.local"
     fi
-  done < /workspace/.env.local
+  done < ${CLAUDE_PROJECT_DIR:-$(pwd)}/.env.local
 fi
 
 if [ -n "$FOUND" ]; then

--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -7,6 +7,6 @@ FILE=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); prin
 case "$FILE" in
   *.ts|*.tsx)
     echo "=== ESLint ==="
-    cd /workspace && npx eslint "$FILE" --max-warnings 0 2>&1
+    cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" && npx eslint "$FILE" --max-warnings 0 2>&1
     ;;
 esac

--- a/.claude/hooks/post-git-push-ci.sh
+++ b/.claude/hooks/post-git-push-ci.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# PostToolUse hook: after git push — wait for CI and print result
+# PostToolUse hook: after git push — wait for CI and print result.
+# Works in both the devcontainer (project root = /workspace) and on a
+# host machine via ${CLAUDE_PROJECT_DIR} (the project directory Claude
+# Code injects for every hook invocation).
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('command',''))" 2>/dev/null)
@@ -8,13 +11,15 @@ if ! echo "$COMMAND" | grep -q "git push"; then
   exit 0
 fi
 
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
 # Load GH_TOKEN if not set
-if [ -z "$GH_TOKEN" ] && [ -f /workspace/.env.local ]; then
-  export GH_TOKEN=$(grep '^GH_TOKEN=' /workspace/.env.local | cut -d= -f2)
+if [ -z "$GH_TOKEN" ] && [ -f "$PROJECT_DIR/.env.local" ]; then
+  export GH_TOKEN=$(grep '^GH_TOKEN=' "$PROJECT_DIR/.env.local" | cut -d= -f2)
 fi
 
 # Get the SHA we just pushed
-PUSHED_SHA=$(git -C /workspace rev-parse HEAD 2>/dev/null)
+PUSHED_SHA=$(git -C "$PROJECT_DIR" rev-parse HEAD 2>/dev/null)
 
 # Wait for GitHub to register the run
 sleep 5

--- a/.claude/hooks/typecheck-on-edit.sh
+++ b/.claude/hooks/typecheck-on-edit.sh
@@ -7,6 +7,6 @@ FILE=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); prin
 case "$FILE" in
   *.ts|*.tsx)
     echo "=== TypeCheck ==="
-    cd /workspace && npx tsc --noEmit --skipLibCheck 2>&1 | head -20
+    cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" && npx tsc --noEmit --skipLibCheck 2>&1 | head -20
     ;;
 esac

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/workspace/.claude/hooks/block-env-local.sh"
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-env-local.sh"
           }
         ]
       },
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/workspace/.claude/hooks/block-secrets-in-issues.sh"
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-secrets-in-issues.sh"
           }
         ]
       }
@@ -72,7 +72,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/workspace/.claude/hooks/post-git-push-ci.sh"
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/post-git-push-ci.sh"
           }
         ]
       },
@@ -81,11 +81,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/workspace/.claude/hooks/typecheck-on-edit.sh"
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/typecheck-on-edit.sh"
           },
           {
             "type": "command",
-            "command": "/workspace/.claude/hooks/lint-on-edit.sh"
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/lint-on-edit.sh"
           }
         ]
       }
@@ -95,7 +95,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "touch /workspace/.claude-session-done"
+            "command": "touch ${CLAUDE_PROJECT_DIR}/.claude-session-done"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Хуки в \`.claude/hooks/\` и пути в \`.claude/settings.local.json\` были захардкожены на \`/workspace/...\` — это работает только внутри devcontainer. На хост-машине (мак) этот путь не существует, поэтому Claude Code молча игнорирует все хуки, включая \`post-git-push-ci\`.

Заменил абсолютные пути на \`\${CLAUDE_PROJECT_DIR}\` — стандартную переменную, которую Claude Code инжектит во все хуки. Работает в обоих окружениях.

## Что починено
- \`settings.local.json\`: все 5 хуков + Stop-marker
- \`post-git-push-ci.sh\`: \`.env.local\` lookup и \`git -C\`
- \`typecheck-on-edit.sh\`, \`lint-on-edit.sh\`: \`cd\` substitution
- \`block-secrets-in-issues.sh\`: \`.env.local\` lookup

## Проверка
Локально запустил вручную:
\`\`\`bash
echo '{"tool_input":{"command":"git push"}}' | CLAUDE_PROJECT_DIR=\$(pwd) .claude/hooks/post-git-push-ci.sh
\`\`\`
→ хук дотягивается до \`gh run list\` и корректно отчитывается о статусе CI.

## Test plan
- [x] Хук работает на хосте (вручную)
- [ ] CI зелёный (изменения только в \`.claude/\`, runtime не затронут)
- [ ] После мержа: следующий \`git push\` должен показать "✓ CI passed" или "✗ CI FAILED" в этом чате

**E2E**: не нужен — затронуты только tooling-скрипты Claude Code, не runtime приложения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)