### PR TITLE
Clean up E2E catalog books in teardown

### DIFF
--- a/app/api/test/seed-books/route.ts
+++ b/app/api/test/seed-books/route.ts
@@ -49,7 +49,11 @@ export async function DELETE() {
   const autoSignupBooks = await db
     .select({ id: books.id })
     .from(books)
-    .where(sql`${books.title} ILIKE 'E2E Auto Signup %' AND ${books.author} = 'E2E Автор'`)
+    .where(sql`
+      (${books.title} ILIKE 'E2E Auto Signup %' AND ${books.author} = 'E2E Автор')
+      OR ${books.title} ILIKE 'E2E Catalog Book %'
+      OR ${books.title} ILIKE 'UI Layout Book %'
+    `)
   const autoSignupBookIds = autoSignupBooks.map(book => book.id)
   const cleanupBookIds = [...TEST_FIXTURE_BOOK_IDS, ...autoSignupBookIds]
 
@@ -58,5 +62,5 @@ export async function DELETE() {
   await db.delete(books).where(inArray(books.id, cleanupBookIds))
   await db.delete(bookSubmissions).where(sql`${bookSubmissions.title} ILIKE 'E2E Auto Signup %' AND ${bookSubmissions.author} = 'E2E Автор'`)
 
-  return NextResponse.json({ ok: true, deletedAutoSignupBooks: autoSignupBookIds.length })
+  return NextResponse.json({ ok: true, deletedE2EBooks: autoSignupBookIds.length })
 }


### PR DESCRIPTION
## Summary
- extend the test seed DELETE endpoint to remove catalog and UI layout E2E books
- keep production DB clean after Playwright specs that create temporary book rows

## Checks
- npm run lint
- npm run typecheck
- npx playwright test e2e/admin-books-catalog.spec.ts e2e/ui-states.spec.ts --workers=1

E2E: нужен — это правка test lifecycle; проверен реальный cleanup для specs, создающих временные книги.