### PR TITLE
docs: enforce_admins=true, обновить emergency процедуру

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,13 +36,32 @@ gh pr merge --auto --squash --delete-branch
 - Vercel preview каждой feature-ветки публикуется на уникальном URL (виден в PR).
 
 ### Emergency push
-Если **нужно срочно** обойти gate (например, прод лежит и фикс должен уйти за 30 секунд):
+`enforce_admins: true` — gate работает **и для админа**. `git push origin main` отказывается даже у владельца репо. Это намеренно: «можно обойти» = «когда-нибудь обойдётся случайно».
+
+Если прод реально лежит и фикс должен уйти срочно:
 ```bash
-gh api repos/bon2362/book-club/branches/main/protection -X DELETE   # снять защиту
-git push origin main                                                 # прямой push
-# применить защиту обратно через gh api ... -X PUT (см. шаблон в коммит-истории)
+# 1. Снять защиту (~5 секунд)
+gh api repos/bon2362/book-club/branches/main/protection -X DELETE
+
+# 2. Сделать прямой push с фиксом
+git push origin main
+
+# 3. ВЕРНУТЬ защиту обратно — иначе следующий случайный коммит уйдёт без CI
+gh api repos/bon2362/book-club/branches/main/protection -X PUT --input - <<'JSON'
+{
+  "required_status_checks": {"strict": false, "checks": [{"context": "ci"}]},
+  "enforce_admins": true,
+  "required_pull_request_reviews": {"required_approving_review_count": 0, "dismiss_stale_reviews": false, "require_code_owner_reviews": false},
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false,
+  "required_linear_history": false
+}
+JSON
 ```
-Использовать только когда не остаётся другого выхода.
+
+Шаг 3 ВАЖЕН. Поставь напоминание сразу после шага 1.
 
 ## Деплой (через PR-merge)
 - После merge PR в `main` Vercel автоматически деплоит в production. Это не меняется.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,11 +70,12 @@ export default defineConfig({
   // retries: 1 — страховка от редких flaky-моментов (overload
   // dev-сервера, медленный Neon-compute, networkidle промахи).
   retries: 1,
-  // workers: 4 — каждая спека создаёт свои книги/секции через фикстуры
-  // (createTestBook, createIntroSection), параллельные спеки не дерутся.
-  // Если поднимешь выше — упрётся в bandwidth dev-сервера и Neon-compute
-  // (0.25 vCPU на free tier).
-  workers: 4,
+  // workers: локально 4 — спеки изолированы через createTestBook/
+  // createIntroSection, не дерутся за общие данные. На CI снижаем до 2:
+  // GitHub Actions runner делит 4 vCPU с системой, плюс Neon free tier
+  // (0.25 vCPU) — при 4 параллельных Playwright contexts admin-страница
+  // не успевает гидратироваться за 120s, тесты флачат с timeout.
+  workers: process.env.CI ? 2 : 4,
   reporter: process.env.CI
     ? [['list'], ['allure-playwright', { outputFolder: 'allure-results', suiteTitle: false }]]
     : 'list',


### PR DESCRIPTION
При первом тесте PR flow выяснилось: enforce_admins=false означает
"админ может обойти gate простым git push" (GitHub просто пишет
"Bypassed rule violations" в выводе). Это противоречит самой идее
CI-gate — если можно обойти случайно, рано или поздно обойдётся.

Изменил enforce_admins=true. Теперь даже владелец репо не может
push'нуть в main напрямую. Emergency-процедура теперь требует трёх
шагов: снять защиту, push, ВЕРНУТЬ защиту. С предупреждением.

(test-коммит 60ccca75 "test: should be rejected by branch protection"
остался в истории как evidence что bypass раньше работал. Удалять не
буду — он пустой, ничего не сломал.)
