### PR TITLE
ci: drop push:main trigger — squash-merge уже проверен PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
+  # Только pull_request. Прямой push в main запрещён branch protection
+  # (enforce_admins: true), значит push в main = squash-merge от PR,
+  # который CI уже проверил. Дублирующий run на main-SHA только тратит
+  # CI-время и шумит в UI.
+  # Если когда-нибудь нужен emergency push (см. AGENTS.md), CI на него
+  # не запустится — это норма, emergency edits идут без gate по определению.
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
CI крутился дважды на каждый merge:
1. pull_request event на feature-ветке — это gate, ждёт auto-merge
2. push event на main после squash-merge — дубликат, тот же diff

После включения branch protection (enforce_admins: true) push в main
возможен ТОЛЬКО как squash-merge от PR, который CI только что
проверил. Дублирующий run не находит ничего нового — просто тратит
~5 минут CI-времени и шумит в UI.

Edge case — emergency push (когда временно снимают branch protection
в случае ЧП). После этой правки CI на emergency push не запустится.
Это норма — emergency edits идут без gate по определению.
