### PR TITLE
docs(wiki): синхронизация с новым CI/CD workflow

### DIFF
--- a/docs/wiki/Hosting-Deployment-and-Domains.md
+++ b/docs/wiki/Hosting-Deployment-and-Domains.md
@@ -1,6 +1,6 @@
 # Хостинг, деплой и домены
 
-Проект хостится на Vercel. Код живет в GitHub. Push в `main` запускает проверки и production-деплой.
+Проект хостится на Vercel. Код живет в GitHub. Изменения идут через Pull Request — прямой push в `main` запрещён branch protection. После merge PR в `main` Vercel автоматически деплоит в production.
 
 ## Ресурсы
 
@@ -18,14 +18,24 @@
 
 ```mermaid
 flowchart LR
-    Commit["git commit"] --> Push["git push main"]
-    Push --> CI["GitHub Actions CI"]
-    CI --> Tests["lint + typecheck + Jest + Playwright"]
-    Tests --> Vercel["Vercel build/deploy"]
+    Branch["git checkout -b fix/x"] --> Commit["git commit"]
+    Commit --> Push["git push -u origin fix/x"]
+    Push --> PR["gh pr create + gh pr merge --auto"]
+    PR --> CI["GitHub Actions CI<br/>lint + secret scan + typecheck<br/>Jest + Playwright + build"]
+    CI --> Merge["squash-merge в main<br/>auto-merge ждал зелёного CI"]
+    Merge --> Vercel["Vercel build/deploy"]
     Vercel --> Domain["www.slowreading.club"]
-    Tests --> Allure["Allure report on gh-pages"]
-    Tests --> Codecov["Codecov coverage"]
+    CI --> Allure["Allure report on gh-pages"]
+    CI --> Codecov["Codecov coverage"]
 ```
+
+Branch protection на `main`:
+- Прямой push запрещён даже для admin (`enforce_admins: true`).
+- PR обязателен, status check `ci` должен пройти до мержа.
+- `gh pr merge --auto --squash --delete-branch` — стандартный путь.
+- Feature-ветка удаляется автоматически после мержа.
+
+Если прод лежит и надо обойти gate — см. [Operations Runbook](Operations-Runbook.md) → «Прод лежит, срочный фикс минуя CI».
 
 ## Домены и DNS
 

--- a/docs/wiki/Operations-Runbook.md
+++ b/docs/wiki/Operations-Runbook.md
@@ -88,6 +88,37 @@
 - `NEXT_PUBLIC_POSTHOG_HOST`;
 - права API key.
 
+## Прод лежит, срочный фикс минуя CI
+
+В нормальном цикле любой коммит в `main` идёт через PR и ждёт зелёного CI (~5 минут). Когда прод реально лежит и пять минут — много, можно временно снять branch protection, push'нуть прямо, **вернуть защиту**:
+
+```bash
+# 1. Снять защиту (мгновенно)
+gh api repos/bon2362/book-club/branches/main/protection -X DELETE
+
+# 2. Сделать прямой push
+git push origin main
+
+# 3. ВЕРНУТЬ защиту обратно — это критично, иначе следующий
+#    случайный коммит уйдёт без проверок и без CI gate
+gh api repos/bon2362/book-club/branches/main/protection -X PUT --input - <<'JSON'
+{
+  "required_status_checks": {"strict": false, "checks": [{"context": "ci"}]},
+  "enforce_admins": true,
+  "required_pull_request_reviews": {"required_approving_review_count": 0, "dismiss_stale_reviews": false, "require_code_owner_reviews": false},
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false,
+  "required_linear_history": false
+}
+JSON
+```
+
+Шаг 3 обязателен. Поставьте напоминание сразу после шага 1.
+
+**Не использовать** для удобства разработки — только когда нет другого выхода. Каждый emergency push минует все проверки: ESLint, secretlint, typecheck, unit-тесты, e2e, build. Это и есть его суть, но и его риск.
+
 ## Что не делать без отдельного плана
 
 - Не менять структуру `user.id` и identity без миграционного плана.


### PR DESCRIPTION
Две страницы вводили в заблуждение или не давали критичной инфы:

1. Hosting-Deployment-and-Domains
   - Текст "Push в main запускает проверки и production-деплой" неверный
     после включения branch protection (прямой push отказывается с GH006).
   - Mermaid-диаграмма показывала старый flow (commit → push → CI → deploy).
   - Обновил на PR-flow с явным указанием auto-merge и branch protection.

2. Operations-Runbook
   - Не было сценария "прод лежит, нужен срочный фикс минуя CI".
   - В стрессовой ситуации владелец проекта пойдёт сюда, не в AGENTS.md
     (AGENTS.md — для агентов, runbook — для человека).
   - Добавил emergency-процедуру с обязательным шагом 3 "вернуть защиту"
     и предупреждением, что emergency push минует все проверки.

Не трогал:
- Quality-CI-Allure-and-Codecov — раздел про изоляцию e2e уже добавлен
  раньше. Secret scan в списке шагов CI можно не упоминать —
  это деталь механики, владельцу не критично.
- Glossary / External-Services / Data-and-Database — реальных дыр нет,
  добавление терминов "branch protection" / "PR-flow" — nice-to-have,
  не блокер.
