### PR TITLE
docs: branch protection strict: true + правило про Update branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ gh pr merge --auto --squash --delete-branch
 - Прод **не задеплоится**, если упали: lint, secret scan, typecheck, unit-tests, E2E, build.
 - `gh pr merge --auto` — мерж происходит автоматически в момент когда CI станет зелёным; не надо сидеть и кликать.
 - Vercel preview каждой feature-ветки публикуется на уникальном URL (виден в PR).
+- **`strict: true`** в branch protection: PR обязан быть up-to-date с main перед мержем. Если другой PR смержился раньше — GitHub потребует `gh pr update-branch`, CI перезапустится на актуальной комбинации. Это закрывает дыру «два PR от одного base, оба зелёные по отдельности, но сломанные вместе». Особенно важно при параллельной работе нескольких агентов.
 
 ### Emergency push
 `enforce_admins: true` — gate работает **и для админа**. `git push origin main` отказывается даже у владельца репо. Это намеренно: «можно обойти» = «когда-нибудь обойдётся случайно».
@@ -80,6 +81,14 @@ JSON
 6. **`--no-verify` запрещён.** Husky pre-commit (lint + secretlint) — твоя проверка качества. CI secret scan ловит то же самое позже, но коммит уже в истории git — секрет утёк, даже если поймали.
 
 7. **Проверь осиротевшие ветки в начале сессии.** Пользователь работает то с Claude, то с Codex — другой агент мог оставить незакрытый PR. Перед началом: `gh pr list` и `git branch --remote | grep -v main`. Если есть feature-ветки без открытого PR или зависший PR — спроси у пользователя, что с ним делать (продолжить, домержить, закрыть).
+
+8. **PR заблокирован «out of date with base branch» — подтяни main, не создавай новый PR.** Branch protection требует `strict: true`: PR должен быть up-to-date с main перед мержем. Если другой агент смержился раньше тебя, GitHub откажется мержить твой PR, пока не подтянешь свежий main. Делается одной командой:
+   ```bash
+   gh pr update-branch <pr-number>      # GitHub сделает merge main → твоя ветка
+   # или вручную:
+   # git fetch origin main && git rebase origin/main && git push --force-with-lease
+   ```
+   После этого CI перезапустится на актуальной комбинации (свежий main + твой diff). Когда зелёный — auto-merge сработает. Это нормальный путь параллельной работы нескольких агентов, не баг.
 
 ## Деплой (через PR-merge)
 - После merge PR в `main` Vercel автоматически деплоит в production. Это не меняется.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -66,8 +66,9 @@ interface E2EHelpers {
    * Create a per-test book through /api/test/books. The book is deleted
    * in teardown (cascade removes associated signups/priorities).
    *
-   * Each test gets a unique id (`__e2e_book_<testId>_<index>__`) so
-   * parallel specs do not collide.
+   * Each test gets a unique id (`__e2e_book_<testId+random>_<index>__`)
+   * so parallel specs do not collide — and so two concurrent CI runs
+   * against the same e2e DB do not race on the same primary key.
    *
    * Does NOT require an admin session.
    */
@@ -154,8 +155,12 @@ export const test = base.extend<E2EHelpers>({
 
   createTestBook: async ({ page }, use, testInfo) => {
     const created: string[] = []
-    // Stable short suffix per test, plus an index per book within the test
-    const seed = testInfo.testId.slice(0, 8)
+    // Suffix должен быть уникален per-test И per-run. testInfo.testId сам
+    // по себе детерминирован (один и тот же для теста между запусками),
+    // поэтому два параллельных CI run одного теста против одной e2e ветки
+    // конфликтуют по primary key `books.id`. Добавляем случайный compо-
+    // нент, чтобы это исключить.
+    const seed = `${testInfo.testId.slice(0, 6)}${Math.random().toString(36).slice(2, 8)}`
 
     const create: E2EHelpers['createTestBook'] = async (overrides) => {
       const index = created.length


### PR DESCRIPTION
Пользователь работает над проектом параллельно с Claude и Codex,
файлы пересекаются. Без strict mode была дыра:

  T=0  оба агента создают PR от main@X
  T=1  оба CI зелёные (каждый проверил X + свой diff)
  T=2  агент A мержит → main@X+1
  T=3  агент B мержит → main@X+2 (= X+1 + diff B, никем не проверено)

При пересечении логики (даже без git conflict) typecheck/тесты
могли упасть уже на проде. Vercel auto-deploy запускается параллельно
с CI, к моменту падения main-CI прод уже сломан.

Включил strict: true через `gh api ... -X PUT`:
  required_status_checks.strict = true

Теперь GitHub блокирует merge PR, если main двинулся → надо
подтянуть свежий main → CI перезапускается на актуальной
комбинации → только тогда auto-merge срабатывает.

Документация:
- AGENTS.md → правило 8: «PR заблокирован "out of date" — подтяни
  main через gh pr update-branch <num>, не создавай новый PR»
- Раздел «Что гарантирует CI-gate» дополнен про strict mode

Этот PR — первый тест strict mode. Так как открывается от текущего
main и других PR в полёте нет, должен пройти без необходимости
update-branch.
