### PR TITLE
ci: concurrency group — отменять устаревшие CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,14 @@ on:
   pull_request:
     branches: [main]
 
+# Если PR обновился (новый push или gh pr update-branch после strict-mode
+# конфликта), старый CI run отменяется — auto-merge ждёт run на актуальном
+# SHA, неактуальный результат никому не нужен. Экономит ~5 минут CI-времени
+# на каждое обновление PR.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Когда PR обновляется (новый push, или gh pr update-branch после
strict-mode конфликта), старый CI run на устаревшем SHA продолжает
гоняться до конца. Его результат никому не нужен — auto-merge
ждёт run на актуальном SHA. Чистая трата ~5 минут CI на каждое
обновление PR.

Реальный кейс из истории: при создании PR 165 одновременно крутились
два CI run — #409 (opened event на старом SHA) и #410 (synchronize
event после gh pr update-branch на новом SHA). #409 был useless.

concurrency group по github.ref (для PR = refs/pull/<num>/merge,
один на весь PR независимо от события) + cancel-in-progress=true
отменяет старый run в момент старта нового.

На неизменных PR (один push, не апдейтился) ничего не меняется.
