### PR TITLE
feat: Story 2-1 — personal list with signups and ranks on /matching page

### DIFF
--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -5,6 +5,8 @@ import { redirect } from 'next/navigation'
 import { db } from '@/lib/db'
 import { matchingSessions, matchingSessionParticipants, users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { fetchPersonalList } from '@/lib/matching/personal-list'
+import MatchingPersonalList from '@/components/nd/MatchingPersonalList'
 
 function DeadlineCountdown({ deadlineAt }: { deadlineAt: Date }) {
   const now = Date.now()
@@ -38,18 +40,21 @@ export default async function MatchingPage() {
     )
   }
 
-  // Load participants with user info
-  const participants = await db
-    .select({
-      userId: matchingSessionParticipants.userId,
-      pseudonym: matchingSessionParticipants.pseudonym,
-      joinedAt: matchingSessionParticipants.joinedAt,
-      name: users.name,
-    })
-    .from(matchingSessionParticipants)
-    .leftJoin(users, eq(matchingSessionParticipants.userId, users.id))
-    .where(eq(matchingSessionParticipants.sessionId, activeSession.id))
-    .orderBy(matchingSessionParticipants.joinedAt)
+  // Load participants and personal list in parallel
+  const [participants, personalBooks] = await Promise.all([
+    db
+      .select({
+        userId: matchingSessionParticipants.userId,
+        pseudonym: matchingSessionParticipants.pseudonym,
+        joinedAt: matchingSessionParticipants.joinedAt,
+        name: users.name,
+      })
+      .from(matchingSessionParticipants)
+      .leftJoin(users, eq(matchingSessionParticipants.userId, users.id))
+      .where(eq(matchingSessionParticipants.sessionId, activeSession.id))
+      .orderBy(matchingSessionParticipants.joinedAt),
+    fetchPersonalList(session.user.id!),
+  ])
 
   const isAdmin = session.user.isAdmin
 
@@ -102,6 +107,13 @@ export default async function MatchingPage() {
             ))}
           </ul>
         )}
+      </section>
+
+      <section style={{ marginTop: '2rem' }}>
+        <h2 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.75rem' }}>
+          Мой список
+        </h2>
+        <MatchingPersonalList books={personalBooks} />
       </section>
 
       {isAdmin && (

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import type { PersonalListBook } from '@/lib/matching/personal-list'
+import CoverImage from './CoverImage'
+
+interface Props {
+  books: PersonalListBook[]
+}
+
+const interestLabel = (rank: number | null, readingStatus: string | null): string => {
+  if (readingStatus === 'reading') return 'читается'
+  if (rank === null) return 'без ранга'
+  if (rank <= 3) return 'хочу читать'
+  return 'готов(а)'
+}
+
+const labelColor = (rank: number | null, readingStatus: string | null): string => {
+  if (readingStatus === 'reading') return '#888'
+  if (rank === null) return '#bbb'
+  if (rank <= 3) return '#4a7'
+  return '#999'
+}
+
+export default function MatchingPersonalList({ books }: Props) {
+  if (books.length === 0) {
+    return (
+      <p style={{ color: '#999', fontSize: '0.8rem' }}>
+        Вы ещё не добавили книги. Перейдите в каталог, чтобы выбрать книги для чтения.
+      </p>
+    )
+  }
+
+  return (
+    <ul
+      style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
+      data-testid="matching-personal-list"
+    >
+      {books.map((book) => (
+        <li
+          key={book.bookId}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.75rem',
+            padding: '0.4rem 0',
+            borderBottom: '1px solid #f0f0f0',
+            opacity: book.readingStatus === 'reading' ? 0.7 : 1,
+          }}
+        >
+          <span
+            style={{
+              fontFamily: 'var(--nd-mono), monospace',
+              fontSize: '0.7rem',
+              color: '#bbb',
+              minWidth: 18,
+              textAlign: 'right',
+            }}
+          >
+            {book.rank ?? '—'}
+          </span>
+
+          <div style={{ width: 32, height: 32, flexShrink: 0 }}>
+            <CoverImage
+              coverUrl={book.coverUrl}
+              title={book.title}
+              author={book.author}
+            />
+          </div>
+
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                fontFamily: 'var(--nd-mono), monospace',
+                fontSize: '0.82rem',
+                fontWeight: 500,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {book.title}
+            </div>
+            <div style={{ fontSize: '0.72rem', color: '#999' }}>{book.author}</div>
+          </div>
+
+          <span
+            style={{
+              fontFamily: 'var(--nd-mono), monospace',
+              fontSize: '0.68rem',
+              color: labelColor(book.rank, book.readingStatus),
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {interestLabel(book.rank, book.readingStatus)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/lib/matching/__tests__/personal-list.test.ts
+++ b/lib/matching/__tests__/personal-list.test.ts
@@ -1,0 +1,55 @@
+import { fetchPersonalList } from '../personal-list'
+import { db } from '@/lib/db'
+
+jest.mock('@/lib/db', () => ({
+  db: { select: jest.fn() },
+}))
+jest.mock('@/lib/db/schema', () => ({
+  signupBooks: {},
+  bookPriorities: {},
+  books: {},
+}))
+
+const mockDb = db as jest.Mocked<typeof db>
+
+function makeChain(result: unknown[]) {
+  return {
+    from: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockResolvedValue(result),
+  }
+}
+
+describe('fetchPersonalList', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns empty array when user has no signups', async () => {
+    mockDb.select = jest.fn().mockReturnValue(makeChain([]))
+    const result = await fetchPersonalList('u1')
+    expect(result).toEqual([])
+  })
+
+  it('returns books sorted by rank then title', async () => {
+    const rows = [
+      { bookId: 'b1', title: 'Книга А', author: 'Автор', coverUrl: null, readingStatus: null, rank: 1 },
+      { bookId: 'b2', title: 'Книга Б', author: 'Автор', coverUrl: null, readingStatus: null, rank: 2 },
+      { bookId: 'b3', title: 'Книга В', author: 'Автор', coverUrl: null, readingStatus: 'reading', rank: null },
+    ]
+    mockDb.select = jest.fn().mockReturnValue(makeChain(rows))
+    const result = await fetchPersonalList('u1')
+    expect(result).toHaveLength(3)
+    expect(result[0].bookId).toBe('b1')
+    expect(result[2].readingStatus).toBe('reading')
+  })
+
+  it('includes reading books in the list', async () => {
+    const rows = [
+      { bookId: 'b1', title: 'Читаемая', author: 'Автор', coverUrl: null, readingStatus: 'reading', rank: null },
+    ]
+    mockDb.select = jest.fn().mockReturnValue(makeChain(rows))
+    const result = await fetchPersonalList('u1')
+    expect(result[0].readingStatus).toBe('reading')
+  })
+})

--- a/lib/matching/personal-list.ts
+++ b/lib/matching/personal-list.ts
@@ -1,0 +1,45 @@
+import { db } from '@/lib/db'
+import { signupBooks, bookPriorities, books } from '@/lib/db/schema'
+import { eq, and, asc, sql } from 'drizzle-orm'
+
+export interface PersonalListBook {
+  bookId: string
+  title: string
+  author: string
+  coverUrl: string | null
+  readingStatus: string | null
+  rank: number | null
+}
+
+export async function fetchPersonalList(userId: string): Promise<PersonalListBook[]> {
+  const rows = await db
+    .select({
+      bookId: signupBooks.bookId,
+      title: books.title,
+      author: books.author,
+      coverUrl: books.coverUrl,
+      readingStatus: books.readingStatus,
+      rank: bookPriorities.rank,
+    })
+    .from(signupBooks)
+    .innerJoin(books, eq(books.id, signupBooks.bookId))
+    .leftJoin(
+      bookPriorities,
+      and(
+        eq(bookPriorities.userId, signupBooks.userId),
+        eq(bookPriorities.bookId, signupBooks.bookId),
+      ),
+    )
+    .where(
+      and(
+        eq(signupBooks.userId, userId),
+        eq(books.visibility, 'published'),
+      ),
+    )
+    .orderBy(
+      sql`${bookPriorities.rank} ASC NULLS LAST`,
+      asc(books.title),
+    )
+
+  return rows
+}


### PR DESCRIPTION
## Summary
- Adds `fetchPersonalList(userId)` joining signup_books + books + book_priorities, sorted by rank ASC NULLS LAST
- Adds `MatchingPersonalList` client component showing rank, cover thumbnail, title/author, interest label
- Renders "Мой список" section on /matching page below the participants list

## Test plan
- [ ] `npm test -- --testPathPattern=personal-list` passes (3 unit tests)
- [ ] `/matching` page renders personal book list for authenticated users
- [ ] Books without rank show "без ранга", rank ≤3 show "хочу читать", others "готов(а)", currently-reading show "читается"

🤖 Generated with [Claude Code](https://claude.com/claude-code)