### PR TITLE
feat: Story 2-2 — add and remove books in matching mode

### DIFF
--- a/app/api/matching/books/[bookId]/route.test.ts
+++ b/app/api/matching/books/[bookId]/route.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment node
+ */
+import { DELETE } from './route'
+import * as authModule from '@/lib/auth'
+import { db } from '@/lib/db'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), delete: jest.fn(), update: jest.fn() } }))
+jest.mock('@/lib/db/schema', () => ({
+  matchingSessions: {},
+  signupBooks: {},
+  bookPriorities: {},
+}))
+
+const mockAuth = authModule.auth as jest.Mock
+const mockDb = db as jest.Mocked<typeof db>
+
+function makeReq(bookId: string) {
+  return new Request(`http://localhost/api/matching/books/${bookId}`, {
+    method: 'DELETE',
+  }) as unknown as import('next/server').NextRequest
+}
+
+const userSession = { user: { id: 'user1', isAdmin: false } }
+
+describe('DELETE /api/matching/books/[bookId]', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue(null)
+    const res = await DELETE(makeReq('b1'), { params: { bookId: 'b1' } })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when no active session', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await DELETE(makeReq('b1'), { params: { bookId: 'b1' } })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 409 when session is frozen', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'frozen' }]) }
+    mockDb.select = jest.fn().mockReturnThis()
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await DELETE(makeReq('b1'), { params: { bookId: 'b1' } })
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 200, deletes signup and priority, normalizes ranks', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const sessionChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active' }]) }
+    const remainingChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), orderBy: jest.fn().mockResolvedValue([{ bookId: 'b2' }, { bookId: 'b3' }]) }
+    mockDb.select = jest.fn()
+      .mockReturnValueOnce(sessionChain)
+      .mockReturnValueOnce(remainingChain)
+    const deleteChain = { where: jest.fn().mockResolvedValue([]) }
+    mockDb.delete = jest.fn().mockReturnValue(deleteChain)
+    const updateChain = { set: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) }
+    mockDb.update = jest.fn().mockReturnValue(updateChain)
+
+    const res = await DELETE(makeReq('b1'), { params: { bookId: 'b1' } })
+    expect(res.status).toBe(200)
+    expect(mockDb.delete).toHaveBeenCalledTimes(2)
+    expect(mockDb.update).toHaveBeenCalledTimes(2)
+  })
+})

--- a/app/api/matching/books/[bookId]/route.ts
+++ b/app/api/matching/books/[bookId]/route.ts
@@ -1,0 +1,49 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { matchingSessions, signupBooks, bookPriorities } from '@/lib/db/schema'
+import { eq, and, asc } from 'drizzle-orm'
+
+type Params = { params: { bookId: string } }
+
+export async function DELETE(_req: NextRequest, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const [activeSession] = await db
+    .select()
+    .from(matchingSessions)
+    .where(eq(matchingSessions.status, 'active'))
+    .limit(1)
+
+  if (!activeSession) return NextResponse.json({ error: 'No active session' }, { status: 404 })
+  if (activeSession.status === 'frozen') return NextResponse.json({ error: 'Session is frozen' }, { status: 409 })
+
+  const userId = session.user.id
+  const { bookId } = params
+
+  await db.delete(signupBooks).where(
+    and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId))
+  )
+  await db.delete(bookPriorities).where(
+    and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, bookId))
+  )
+
+  // Normalize ranks for remaining books
+  const remaining = await db
+    .select({ bookId: bookPriorities.bookId })
+    .from(bookPriorities)
+    .where(eq(bookPriorities.userId, userId))
+    .orderBy(asc(bookPriorities.rank))
+
+  for (let i = 0; i < remaining.length; i++) {
+    await db
+      .update(bookPriorities)
+      .set({ rank: i + 1 })
+      .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, remaining[i].bookId)))
+  }
+
+  return NextResponse.json({ ok: true }, { status: 200 })
+}

--- a/app/api/matching/books/route.test.ts
+++ b/app/api/matching/books/route.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from './route'
+import * as authModule from '@/lib/auth'
+import { db } from '@/lib/db'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn() } }))
+jest.mock('@/lib/db/schema', () => ({
+  matchingSessions: {},
+  signupBooks: {},
+}))
+
+const mockAuth = authModule.auth as jest.Mock
+const mockDb = db as jest.Mocked<typeof db>
+
+function makeReq(body: object) {
+  return new Request('http://localhost/api/matching/books', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  }) as unknown as import('next/server').NextRequest
+}
+
+const userSession = { user: { id: 'user1', isAdmin: false } }
+
+describe('POST /api/matching/books', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue(null)
+    const res = await POST(makeReq({ bookId: 'b1' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when no active session', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await POST(makeReq({ bookId: 'b1' }))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 409 when session is frozen', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'frozen' }]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await POST(makeReq({ bookId: 'b1' }))
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 400 when bookId missing', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active' }]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await POST(makeReq({}))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 and inserts book', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active' }]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const insertChain = { values: jest.fn().mockReturnThis(), onConflictDoNothing: jest.fn().mockResolvedValue([]) }
+    mockDb.insert = jest.fn().mockReturnValue(insertChain)
+    const res = await POST(makeReq({ bookId: 'b1' }))
+    expect(res.status).toBe(200)
+    expect(mockDb.insert).toHaveBeenCalled()
+  })
+})

--- a/app/api/matching/books/route.ts
+++ b/app/api/matching/books/route.ts
@@ -1,0 +1,32 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { matchingSessions, signupBooks } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+
+export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const [activeSession] = await db
+    .select()
+    .from(matchingSessions)
+    .where(eq(matchingSessions.status, 'active'))
+    .limit(1)
+
+  if (!activeSession) return NextResponse.json({ error: 'No active session' }, { status: 404 })
+  if (activeSession.status === 'frozen') return NextResponse.json({ error: 'Session is frozen' }, { status: 409 })
+
+  const body = await req.json().catch(() => ({}))
+  const bookId = typeof body.bookId === 'string' ? body.bookId.trim() : ''
+  if (!bookId) return NextResponse.json({ error: 'bookId required' }, { status: 400 })
+
+  await db
+    .insert(signupBooks)
+    .values({ userId: session.user.id, bookId })
+    .onConflictDoNothing()
+
+  return NextResponse.json({ ok: true }, { status: 200 })
+}


### PR DESCRIPTION
## Summary
- `POST /api/matching/books` — adds a book to signup_books (idempotent via onConflictDoNothing), guards frozen sessions with 409
- `DELETE /api/matching/books/:bookId` — removes from signup_books and book_priorities, then normalizes remaining ranks to 1..N-1
- Both endpoints return 401 without auth, 404 without active session, 409 if session frozen

## Test plan
- [ ] 9 unit tests pass (`npm test -- --testPathPattern="matching/books"`)
- [ ] POST creates signup_books row; book appears in Мой список without rank
- [ ] DELETE removes book from list; remaining ranks normalize sequentially
- [ ] Frozen session blocks both operations with 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)