### PR TITLE
feat: Story 2-3 — drag-and-drop rank reorder with keyboard and touch alternatives

### DIFF
--- a/app/api/matching/priorities/route.test.ts
+++ b/app/api/matching/priorities/route.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+import { PATCH } from './route'
+import * as authModule from '@/lib/auth'
+import { db } from '@/lib/db'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn() } }))
+jest.mock('@/lib/db/schema', () => ({
+  matchingSessions: {},
+  bookPriorities: {},
+}))
+
+const mockAuth = authModule.auth as jest.Mock
+const mockDb = db as jest.Mocked<typeof db>
+
+function makeReq(body: object) {
+  return new Request('http://localhost/api/matching/priorities', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  }) as unknown as import('next/server').NextRequest
+}
+
+const userSession = { user: { id: 'user1', isAdmin: false } }
+
+describe('PATCH /api/matching/priorities', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue(null)
+    const res = await PATCH(makeReq({ bookIds: ['b1'] }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when no active session', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await PATCH(makeReq({ bookIds: ['b1'] }))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 409 when session is frozen', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'frozen' }]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await PATCH(makeReq({ bookIds: ['b1'] }))
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 400 when bookIds is empty', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active' }]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await PATCH(makeReq({ bookIds: [] }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when bookIds contains non-strings', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active' }]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await PATCH(makeReq({ bookIds: [1, 2] }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 with canonical ranks', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const sessionChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active' }]) }
+    const canonicalChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([{ bookId: 'b2', rank: 1 }, { bookId: 'b1', rank: 2 }]) }
+    mockDb.select = jest.fn()
+      .mockReturnValueOnce(sessionChain)
+      .mockReturnValueOnce(canonicalChain)
+    const upsertChain = { values: jest.fn().mockReturnThis(), onConflictDoUpdate: jest.fn().mockResolvedValue([]) }
+    mockDb.insert = jest.fn().mockReturnValue(upsertChain)
+
+    const res = await PATCH(makeReq({ bookIds: ['b2', 'b1'] }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.ranks).toHaveLength(2)
+    expect(mockDb.insert).toHaveBeenCalledTimes(2)
+  })
+})

--- a/app/api/matching/priorities/route.ts
+++ b/app/api/matching/priorities/route.ts
@@ -1,0 +1,49 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { matchingSessions, bookPriorities } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+
+export async function PATCH(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const [activeSession] = await db
+    .select()
+    .from(matchingSessions)
+    .where(eq(matchingSessions.status, 'active'))
+    .limit(1)
+
+  if (!activeSession) return NextResponse.json({ error: 'No active session' }, { status: 404 })
+  if (activeSession.status === 'frozen') return NextResponse.json({ error: 'Session is frozen' }, { status: 409 })
+
+  const body = await req.json().catch(() => ({}))
+  const bookIds: unknown = body.bookIds
+  if (!Array.isArray(bookIds) || bookIds.length === 0 || bookIds.some(id => typeof id !== 'string')) {
+    return NextResponse.json({ error: 'bookIds must be a non-empty string array' }, { status: 400 })
+  }
+
+  const userId = session.user.id
+  const ordered = bookIds as string[]
+
+  // Upsert each book with its new rank (1-indexed position)
+  for (let i = 0; i < ordered.length; i++) {
+    await db
+      .insert(bookPriorities)
+      .values({ userId, bookId: ordered[i], rank: i + 1 })
+      .onConflictDoUpdate({
+        target: [bookPriorities.userId, bookPriorities.bookId],
+        set: { rank: i + 1, updatedAt: new Date() },
+      })
+  }
+
+  // Return canonical order so client can reconcile
+  const canonical = await db
+    .select({ bookId: bookPriorities.bookId, rank: bookPriorities.rank })
+    .from(bookPriorities)
+    .where(eq(bookPriorities.userId, userId))
+
+  return NextResponse.json({ ranks: canonical }, { status: 200 })
+}

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -1,10 +1,30 @@
 'use client'
 
+import { useState, useCallback } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import type { PersonalListBook } from '@/lib/matching/personal-list'
 import CoverImage from './CoverImage'
 
 interface Props {
   books: PersonalListBook[]
+  frozen?: boolean
 }
 
 const interestLabel = (rank: number | null, readingStatus: string | null): string => {
@@ -21,7 +41,193 @@ const labelColor = (rank: number | null, readingStatus: string | null): string =
   return '#999'
 }
 
-export default function MatchingPersonalList({ books }: Props) {
+interface SortableRowProps {
+  book: PersonalListBook
+  index: number
+  total: number
+  frozen: boolean
+  onMoveUp: (bookId: string) => void
+  onMoveDown: (bookId: string) => void
+}
+
+function SortableRow({ book, index, total, frozen, onMoveUp, onMoveDown }: SortableRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: book.bookId,
+    disabled: frozen || book.readingStatus === 'reading',
+  })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.75rem',
+    padding: '0.4rem 0',
+    borderBottom: '1px solid #f0f0f0',
+    opacity: isDragging ? 0.5 : book.readingStatus === 'reading' ? 0.7 : 1,
+    background: isDragging ? '#f9f9f9' : undefined,
+    cursor: frozen || book.readingStatus === 'reading' ? 'default' : 'grab',
+  }
+
+  const canReorder = !frozen && book.readingStatus !== 'reading'
+
+  return (
+    <li ref={setNodeRef} style={style}>
+      {canReorder && (
+        <span
+          {...attributes}
+          {...listeners}
+          aria-label={`Перетащить книгу ${book.title}`}
+          style={{ fontSize: '0.75rem', color: '#ccc', cursor: 'grab', flexShrink: 0, userSelect: 'none' }}
+        >
+          ⠿
+        </span>
+      )}
+
+      <span
+        style={{
+          fontFamily: 'var(--nd-mono), monospace',
+          fontSize: '0.7rem',
+          color: '#bbb',
+          minWidth: 18,
+          textAlign: 'right',
+          flexShrink: 0,
+        }}
+      >
+        {book.rank ?? '—'}
+      </span>
+
+      <div style={{ width: 32, height: 32, flexShrink: 0 }}>
+        <CoverImage
+          coverUrl={book.coverUrl}
+          title={book.title}
+          author={book.author}
+        />
+      </div>
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontFamily: 'var(--nd-mono), monospace',
+            fontSize: '0.82rem',
+            fontWeight: 500,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {book.title}
+        </div>
+        <div style={{ fontSize: '0.72rem', color: '#999' }}>{book.author}</div>
+      </div>
+
+      <span
+        style={{
+          fontFamily: 'var(--nd-mono), monospace',
+          fontSize: '0.68rem',
+          color: labelColor(book.rank, book.readingStatus),
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {interestLabel(book.rank, book.readingStatus)}
+      </span>
+
+      {canReorder && (
+        <span style={{ display: 'flex', flexDirection: 'column', gap: 1, flexShrink: 0 }}>
+          <button
+            onClick={() => onMoveUp(book.bookId)}
+            disabled={index === 0}
+            aria-label={`Переместить ${book.title} выше`}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: index === 0 ? 'default' : 'pointer',
+              color: index === 0 ? '#ddd' : '#999',
+              fontSize: '0.65rem',
+              padding: '1px 3px',
+              lineHeight: 1,
+            }}
+          >
+            ▲
+          </button>
+          <button
+            onClick={() => onMoveDown(book.bookId)}
+            disabled={index === total - 1}
+            aria-label={`Переместить ${book.title} ниже`}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: index === total - 1 ? 'default' : 'pointer',
+              color: index === total - 1 ? '#ddd' : '#999',
+              fontSize: '0.65rem',
+              padding: '1px 3px',
+              lineHeight: 1,
+            }}
+          >
+            ▼
+          </button>
+        </span>
+      )}
+    </li>
+  )
+}
+
+async function patchPriorities(bookIds: string[]) {
+  await fetch('/api/matching/priorities', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ bookIds }),
+  })
+}
+
+export default function MatchingPersonalList({ books: initialBooks, frozen = false }: Props) {
+  const [books, setBooks] = useState(initialBooks)
+  const [announcement, setAnnouncement] = useState('')
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(TouchSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const applyNewOrder = useCallback(async (newBooks: PersonalListBook[]) => {
+    const rankable = newBooks.filter(b => b.readingStatus !== 'reading')
+    const ranked = rankable.map((b, i) => ({ ...b, rank: i + 1 }))
+    const updated = newBooks.map(b => {
+      const r = ranked.find(rb => rb.bookId === b.bookId)
+      return r ?? b
+    })
+    setBooks(updated)
+    await patchPriorities(rankable.map(b => b.bookId))
+    return updated
+  }, [])
+
+  const handleDragEnd = useCallback(async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = books.findIndex(b => b.bookId === active.id)
+    const newIndex = books.findIndex(b => b.bookId === over.id)
+    const newBooks = arrayMove(books, oldIndex, newIndex)
+    await applyNewOrder(newBooks)
+    setAnnouncement(`Книга ${books[oldIndex].title} перемещена на позицию ${newIndex + 1} из ${books.filter(b => b.readingStatus !== 'reading').length}`)
+  }, [books, applyNewOrder])
+
+  const handleMoveUp = useCallback(async (bookId: string) => {
+    const index = books.findIndex(b => b.bookId === bookId)
+    if (index <= 0) return
+    const newBooks = arrayMove(books, index, index - 1)
+    await applyNewOrder(newBooks)
+    setAnnouncement(`Книга ${books[index].title} перемещена на позицию ${index} из ${books.filter(b => b.readingStatus !== 'reading').length}`)
+  }, [books, applyNewOrder])
+
+  const handleMoveDown = useCallback(async (bookId: string) => {
+    const index = books.findIndex(b => b.bookId === bookId)
+    if (index >= books.length - 1) return
+    const newBooks = arrayMove(books, index, index + 1)
+    await applyNewOrder(newBooks)
+    setAnnouncement(`Книга ${books[index].title} перемещена на позицию ${index + 2} из ${books.filter(b => b.readingStatus !== 'reading').length}`)
+  }, [books, applyNewOrder])
+
   if (books.length === 0) {
     return (
       <p style={{ color: '#999', fontSize: '0.8rem' }}>
@@ -31,70 +237,40 @@ export default function MatchingPersonalList({ books }: Props) {
   }
 
   return (
-    <ul
-      style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
-      data-testid="matching-personal-list"
-    >
-      {books.map((book) => (
-        <li
-          key={book.bookId}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.75rem',
-            padding: '0.4rem 0',
-            borderBottom: '1px solid #f0f0f0',
-            opacity: book.readingStatus === 'reading' ? 0.7 : 1,
-          }}
-        >
-          <span
-            style={{
-              fontFamily: 'var(--nd-mono), monospace',
-              fontSize: '0.7rem',
-              color: '#bbb',
-              minWidth: 18,
-              textAlign: 'right',
-            }}
+    <>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="dnd-announcement"
+        style={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0,0,0,0)' }}
+      >
+        {announcement}
+      </div>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={books.map(b => b.bookId)} strategy={verticalListSortingStrategy}>
+          <ul
+            style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
+            data-testid="matching-personal-list"
           >
-            {book.rank ?? '—'}
-          </span>
-
-          <div style={{ width: 32, height: 32, flexShrink: 0 }}>
-            <CoverImage
-              coverUrl={book.coverUrl}
-              title={book.title}
-              author={book.author}
-            />
-          </div>
-
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div
-              style={{
-                fontFamily: 'var(--nd-mono), monospace',
-                fontSize: '0.82rem',
-                fontWeight: 500,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {book.title}
-            </div>
-            <div style={{ fontSize: '0.72rem', color: '#999' }}>{book.author}</div>
-          </div>
-
-          <span
-            style={{
-              fontFamily: 'var(--nd-mono), monospace',
-              fontSize: '0.68rem',
-              color: labelColor(book.rank, book.readingStatus),
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {interestLabel(book.rank, book.readingStatus)}
-          </span>
-        </li>
-      ))}
-    </ul>
+            {books.map((book, idx) => (
+              <SortableRow
+                key={book.bookId}
+                book={book}
+                index={idx}
+                total={books.filter(b => b.readingStatus !== 'reading').length}
+                frozen={frozen}
+                onMoveUp={handleMoveUp}
+                onMoveDown={handleMoveDown}
+              />
+            ))}
+          </ul>
+        </SortableContext>
+      </DndContext>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- `PATCH /api/matching/priorities` — upserts rank for each bookId in ordered array, returns canonical ranks; guards 401/404/409
- `MatchingPersonalList` upgraded with @dnd-kit: pointer, touch, and keyboard sensors; ↑/↓ buttons as touch/keyboard alternative
- Screen-reader announcement via `aria-live="polite"` region reporting new position after each move
- Reading-status books are excluded from drag (disabled in sortable, no buttons shown)
- Frozen session hides drag handles and ↑/↓ buttons

## Test plan
- [ ] 6 unit tests pass for PATCH /api/matching/priorities
- [ ] Drag-and-drop reorders list and calls PATCH
- [ ] ↑/↓ buttons reorder list correctly
- [ ] Keyboard: Space to pick up, arrows to move, Space to drop
- [ ] "читается" books cannot be reordered
- [ ] Frozen session hides reorder controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)