### PR TITLE
feat: Story 2-4 — pure scenario engine with sorting and tier classification

### DIFF
--- a/lib/matching/__tests__/scenarios.test.ts
+++ b/lib/matching/__tests__/scenarios.test.ts
@@ -1,0 +1,201 @@
+import { generateScenarios } from '../scenarios'
+
+// Helpers to build test fixtures
+function makeParticipants(n: number) {
+  return Array.from({ length: n }, (_, i) => ({ userId: `u${i + 1}`, pseudonym: `Участник${i + 1}` }))
+}
+
+function makeBook(bookId: string, readingStatus: string | null = null) {
+  return { bookId, readingStatus }
+}
+
+function allSignedUp(userIds: string[], bookId: string) {
+  return userIds.map(userId => ({ userId, bookId }))
+}
+
+function rankAll(userIds: string[], bookId: string, rank: number) {
+  return userIds.map(userId => ({ userId, bookId, rank }))
+}
+
+describe('generateScenarios', () => {
+  const participants = makeParticipants(6)
+  const userIds = participants.map(p => p.userId)
+
+  it('returns empty array when no books', () => {
+    const result = generateScenarios({
+      participants,
+      books: [],
+      signups: [],
+      ranks: [],
+      targetGroupSize: 3,
+    })
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array when no signups', () => {
+    const result = generateScenarios({
+      participants,
+      books: [makeBook('b1')],
+      signups: [],
+      ranks: [],
+      targetGroupSize: 3,
+    })
+    expect(result).toEqual([])
+  })
+
+  it('excludes books with reading_status=reading', () => {
+    const result = generateScenarios({
+      participants,
+      books: [makeBook('b1', 'reading')],
+      signups: allSignedUp(userIds, 'b1'),
+      ranks: rankAll(userIds, 'b1', 1),
+      targetGroupSize: 3,
+    })
+    expect(result).toEqual([])
+  })
+
+  it('excludes books without enough signups', () => {
+    const result = generateScenarios({
+      participants: makeParticipants(2),
+      books: [makeBook('b1')],
+      signups: allSignedUp(['u1', 'u2'], 'b1'),
+      ranks: [],
+      targetGroupSize: 3,
+    })
+    expect(result).toEqual([])
+  })
+
+  it('groups have exactly targetGroupSize members', () => {
+    const result = generateScenarios({
+      participants,
+      books: [makeBook('b1')],
+      signups: allSignedUp(userIds, 'b1'),
+      ranks: rankAll(userIds, 'b1', 2),
+      targetGroupSize: 3,
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].members).toHaveLength(3)
+  })
+
+  it('no participant repeats across selected groups', () => {
+    // 6 participants, 2 books each with 6 signups → should produce 2 groups, 3+3=6 unique
+    const result = generateScenarios({
+      participants,
+      books: [makeBook('b1'), makeBook('b2')],
+      signups: [
+        ...allSignedUp(userIds, 'b1'),
+        ...allSignedUp(userIds, 'b2'),
+      ],
+      ranks: [
+        ...rankAll(userIds, 'b1', 2),
+        ...rankAll(userIds, 'b2', 2),
+      ],
+      targetGroupSize: 3,
+    })
+    expect(result).toHaveLength(2)
+    const allMemberIds = result.flatMap(c => c.members.map(m => m.userId))
+    const unique = new Set(allMemberIds)
+    expect(unique.size).toBe(allMemberIds.length)
+  })
+
+  it('tier leader is assigned to top card only', () => {
+    const result = generateScenarios({
+      participants,
+      books: [makeBook('b1'), makeBook('b2')],
+      signups: [
+        ...allSignedUp(userIds.slice(0, 3), 'b1'),
+        ...allSignedUp(userIds.slice(3, 6), 'b2'),
+      ],
+      ranks: [
+        ...rankAll(userIds.slice(0, 3), 'b1', 1),
+        ...rankAll(userIds.slice(3, 6), 'b2', 5),
+      ],
+      targetGroupSize: 3,
+    })
+    const leaders = result.filter(c => c.tier === 'leader')
+    expect(leaders).toHaveLength(1)
+    expect(leaders[0].bookId).toBe('b1')
+  })
+
+  it('tier max-coverage assigned to all cards with same wantsCount as leader', () => {
+    // 3 books, each with 3 signups and rank=1 → all tied → all max-coverage (except leader)
+    const p3 = makeParticipants(9)
+    const books = [makeBook('b1'), makeBook('b2'), makeBook('b3')]
+    const signups = [
+      ...allSignedUp(p3.slice(0, 3).map(p => p.userId), 'b1'),
+      ...allSignedUp(p3.slice(3, 6).map(p => p.userId), 'b2'),
+      ...allSignedUp(p3.slice(6, 9).map(p => p.userId), 'b3'),
+    ]
+    const ranks = [
+      ...rankAll(p3.slice(0, 3).map(p => p.userId), 'b1', 1),
+      ...rankAll(p3.slice(3, 6).map(p => p.userId), 'b2', 1),
+      ...rankAll(p3.slice(6, 9).map(p => p.userId), 'b3', 1),
+    ]
+    const result = generateScenarios({ participants: p3, books, signups, ranks, targetGroupSize: 3 })
+    expect(result).toHaveLength(3)
+    expect(result.filter(c => c.tier === 'leader')).toHaveLength(1)
+    expect(result.filter(c => c.tier === 'max-coverage')).toHaveLength(2)
+    expect(result.filter(c => c.tier === 'sub-max')).toHaveLength(0)
+  })
+
+  it('tier sub-max assigned when wantsCount is less than leader', () => {
+    const p6 = makeParticipants(6)
+    const books = [makeBook('b1'), makeBook('b2')]
+    const signups = [
+      ...allSignedUp(p6.slice(0, 3).map(p => p.userId), 'b1'),
+      ...allSignedUp(p6.slice(3, 6).map(p => p.userId), 'b2'),
+    ]
+    const ranks = [
+      ...rankAll(p6.slice(0, 3).map(p => p.userId), 'b1', 1),  // wantsCount=3
+      ...rankAll(p6.slice(3, 6).map(p => p.userId), 'b2', 5),  // wantsCount=0
+    ]
+    const result = generateScenarios({ participants: p6, books, signups, ranks, targetGroupSize: 3 })
+    expect(result).toHaveLength(2)
+    expect(result.find(c => c.bookId === 'b1')?.tier).toBe('leader')
+    expect(result.find(c => c.bookId === 'b2')?.tier).toBe('sub-max')
+  })
+
+  it('respects maxResults', () => {
+    const p = makeParticipants(30)
+    const books = Array.from({ length: 10 }, (_, i) => makeBook(`b${i}`))
+    const signups = books.flatMap(b => allSignedUp(p.slice(0, 5).map(x => x.userId), b.bookId))
+    const result = generateScenarios({ participants: p, books, signups, ranks: [], targetGroupSize: 3, maxResults: 3 })
+    expect(result.length).toBeLessThanOrEqual(3)
+  })
+
+  it('handles null ranks (unranked participants)', () => {
+    const result = generateScenarios({
+      participants,
+      books: [makeBook('b1')],
+      signups: allSignedUp(userIds, 'b1'),
+      ranks: [],
+      targetGroupSize: 3,
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].unrankedCount).toBe(3)
+    expect(result[0].wantsCount).toBe(0)
+  })
+
+  it('perf: N=30 participants, M=50 books median < 200ms', () => {
+    const p = makeParticipants(30)
+    const books = Array.from({ length: 50 }, (_, i) => makeBook(`book${i}`))
+    const signups = books.flatMap(b =>
+      p.slice(0, 10).map(x => ({ userId: x.userId, bookId: b.bookId }))
+    )
+    const ranks = books.flatMap(b =>
+      p.slice(0, 10).map((x, i) => ({ userId: x.userId, bookId: b.bookId, rank: (i % 7) + 1 }))
+    )
+
+    const times: number[] = []
+    for (let run = 0; run < 11; run++) {
+      const start = Date.now()
+      generateScenarios({ participants: p, books, signups, ranks, targetGroupSize: 3 })
+      times.push(Date.now() - start)
+    }
+    times.sort((a, b) => a - b)
+    const median = times[Math.floor(times.length / 2)]
+    const p95 = times[Math.floor(times.length * 0.95)]
+    expect(median).toBeLessThan(200)
+    expect(p95).toBeLessThan(400)
+  })
+})

--- a/lib/matching/scenarios.ts
+++ b/lib/matching/scenarios.ts
@@ -1,0 +1,254 @@
+export interface ScenarioParticipant {
+  userId: string
+  pseudonym: string
+}
+
+export interface ScenarioBook {
+  bookId: string
+  readingStatus: string | null
+}
+
+export interface ScenarioSignup {
+  userId: string
+  bookId: string
+}
+
+export interface ScenarioRank {
+  userId: string
+  bookId: string
+  rank: number | null
+}
+
+export interface GroupMember {
+  userId: string
+  pseudonym: string
+  rank: number | null
+  interest: 'хочу читать' | 'готов(а)' | 'без ранга'
+}
+
+export interface ScenarioCard {
+  bookId: string
+  tier: 'leader' | 'max-coverage' | 'sub-max'
+  members: GroupMember[]
+  wantsCount: number
+  avgRank: number | null
+  worstRank: number | null
+  unrankedCount: number
+}
+
+export interface GenerateScenariosInput {
+  participants: ScenarioParticipant[]
+  books: ScenarioBook[]
+  signups: ScenarioSignup[]
+  ranks: ScenarioRank[]
+  targetGroupSize: number
+  maxResults?: number
+}
+
+function interest(rank: number | null): GroupMember['interest'] {
+  if (rank === null) return 'без ранга'
+  if (rank <= 3) return 'хочу читать'
+  return 'готов(а)'
+}
+
+function scoreCandidates(members: GroupMember[]): {
+  wantsCount: number
+  avgRank: number | null
+  worstRank: number | null
+  unrankedCount: number
+} {
+  const ranked = members.filter(m => m.rank !== null)
+  const unrankedCount = members.length - ranked.length
+  const wantsCount = members.filter(m => m.rank !== null && m.rank <= 3).length
+  const avgRank = ranked.length > 0 ? ranked.reduce((s, m) => s + m.rank!, 0) / ranked.length : null
+  const worstRank = ranked.length > 0 ? Math.max(...ranked.map(m => m.rank!)) : null
+  return { wantsCount, avgRank, worstRank, unrankedCount }
+}
+
+// Compare two cards: higher is better
+// Returns negative if a < b (b is better), positive if a > b (a is better)
+function compareScore(
+  a: { wantsCount: number; avgRank: number | null; worstRank: number | null; unrankedCount: number },
+  b: { wantsCount: number; avgRank: number | null; worstRank: number | null; unrankedCount: number },
+): number {
+  if (b.wantsCount !== a.wantsCount) return a.wantsCount - b.wantsCount
+  // Lower avgRank is better; null ranks are worst
+  const aAvg = a.avgRank ?? Infinity
+  const bAvg = b.avgRank ?? Infinity
+  if (aAvg !== bAvg) return bAvg - aAvg
+  const aWorst = a.worstRank ?? Infinity
+  const bWorst = b.worstRank ?? Infinity
+  if (aWorst !== bWorst) return bWorst - aWorst
+  return b.unrankedCount - a.unrankedCount
+}
+
+// Pick the best combination of targetGroupSize members from candidates.
+// Sorts by rank (null = worst) and picks the top group using exhaustive search
+// for small targetGroupSize (<=5 typical).
+function pickBestGroup(
+  candidates: GroupMember[],
+  targetGroupSize: number,
+): GroupMember[] | null {
+  if (candidates.length < targetGroupSize) return null
+  if (candidates.length === targetGroupSize) return candidates
+
+  // Sort: want most хочу читать, then lowest rank, then null last
+  const sorted = [...candidates].sort((a, b) => {
+    const wa = a.rank !== null && a.rank <= 3 ? 0 : 1
+    const wb = b.rank !== null && b.rank <= 3 ? 0 : 1
+    if (wa !== wb) return wa - wb
+    const ra = a.rank ?? Infinity
+    const rb = b.rank ?? Infinity
+    return ra - rb
+  })
+
+  // For small targetGroupSize, brute-force best combination
+  if (targetGroupSize <= 5 && candidates.length <= 30) {
+    let best: GroupMember[] | null = null
+    let bestScore: ReturnType<typeof scoreCandidates> | null = null
+
+    const combine = (start: number, current: GroupMember[]) => {
+      if (current.length === targetGroupSize) {
+        const s = scoreCandidates(current)
+        if (bestScore === null || compareScore(s, bestScore) > 0) {
+          best = [...current]
+          bestScore = s
+        }
+        return
+      }
+      const remaining = candidates.length - start
+      if (remaining < targetGroupSize - current.length) return
+      for (let i = start; i < candidates.length; i++) {
+        current.push(candidates[i])
+        combine(i + 1, current)
+        current.pop()
+      }
+    }
+    combine(0, [])
+    return best
+  }
+
+  // Greedy fallback for large inputs
+  return sorted.slice(0, targetGroupSize)
+}
+
+export function generateScenarios(input: GenerateScenariosInput): ScenarioCard[] {
+  const {
+    participants,
+    books,
+    signups,
+    ranks,
+    targetGroupSize,
+    maxResults = 10,
+  } = input
+
+  const pseudonymMap = new Map(participants.map(p => [p.userId, p.pseudonym]))
+
+  // Build rank lookup: (userId, bookId) → rank
+  const rankMap = new Map<string, number | null>()
+  for (const r of ranks) {
+    rankMap.set(`${r.userId}:${r.bookId}`, r.rank)
+  }
+
+  // Build signups per book
+  const signupsByBook = new Map<string, string[]>()
+  for (const s of signups) {
+    const arr = signupsByBook.get(s.bookId) ?? []
+    arr.push(s.userId)
+    signupsByBook.set(s.bookId, arr)
+  }
+
+  // Candidate books: not reading, have ≥ targetGroupSize signups
+  const candidateBookIds = books
+    .filter(b => b.readingStatus !== 'reading')
+    .map(b => b.bookId)
+    .filter(bookId => (signupsByBook.get(bookId)?.length ?? 0) >= targetGroupSize)
+
+  // For each candidate book, find best group and score it
+  interface Candidate {
+    bookId: string
+    members: GroupMember[]
+    wantsCount: number
+    avgRank: number | null
+    worstRank: number | null
+    unrankedCount: number
+  }
+
+  const scored: Candidate[] = []
+
+  for (const bookId of candidateBookIds) {
+    const userIds = signupsByBook.get(bookId) ?? []
+    const memberCandidates: GroupMember[] = userIds.map(userId => ({
+      userId,
+      pseudonym: pseudonymMap.get(userId) ?? userId,
+      rank: rankMap.get(`${userId}:${bookId}`) ?? null,
+      interest: interest(rankMap.get(`${userId}:${bookId}`) ?? null),
+    }))
+
+    const group = pickBestGroup(memberCandidates, targetGroupSize)
+    if (!group) continue
+
+    const s = scoreCandidates(group)
+    scored.push({ bookId, members: group, ...s })
+  }
+
+  // Sort by score descending
+  scored.sort((a, b) => compareScore(b, a))
+
+  // Build full member candidate lists for re-picking when initial group overlaps
+  const memberCandidatesByBook = new Map<string, GroupMember[]>()
+  for (const bookId of candidateBookIds) {
+    const userIds2 = signupsByBook.get(bookId) ?? []
+    memberCandidatesByBook.set(bookId, userIds2.map(userId => ({
+      userId,
+      pseudonym: pseudonymMap.get(userId) ?? userId,
+      rank: rankMap.get(`${userId}:${bookId}`) ?? null,
+      interest: interest(rankMap.get(`${userId}:${bookId}`) ?? null),
+    })))
+  }
+
+  // Greedily select non-overlapping groups to maximize coverage
+  const selectedUserIds = new Set<string>()
+  const selected: Candidate[] = []
+
+  for (const candidate of scored) {
+    const overlaps = candidate.members.some(m => selectedUserIds.has(m.userId))
+    if (!overlaps) {
+      for (const m of candidate.members) selectedUserIds.add(m.userId)
+      selected.push(candidate)
+      if (selected.length >= maxResults) break
+    } else {
+      // Try re-picking from remaining participants
+      const allCandidates = memberCandidatesByBook.get(candidate.bookId) ?? []
+      const remaining = allCandidates.filter(m => !selectedUserIds.has(m.userId))
+      const altGroup = pickBestGroup(remaining, targetGroupSize)
+      if (altGroup) {
+        const s = scoreCandidates(altGroup)
+        for (const m of altGroup) selectedUserIds.add(m.userId)
+        selected.push({ bookId: candidate.bookId, members: altGroup, ...s })
+        if (selected.length >= maxResults) break
+      }
+    }
+  }
+
+  // Assign tiers
+  if (selected.length === 0) return []
+
+  const topWantsCount = selected[0].wantsCount
+  return selected.map((c, i): ScenarioCard => {
+    let tier: ScenarioCard['tier']
+    if (i === 0) tier = 'leader'
+    else if (c.wantsCount === topWantsCount) tier = 'max-coverage'
+    else tier = 'sub-max'
+
+    return {
+      bookId: c.bookId,
+      tier,
+      members: c.members,
+      wantsCount: c.wantsCount,
+      avgRank: c.avgRank,
+      worstRank: c.worstRank,
+      unrankedCount: c.unrankedCount,
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- `lib/matching/scenarios.ts` exports `generateScenarios()` and all related types
- Filters out reading-status books and books with fewer than targetGroupSize signups
- Brute-force best group selection for targetGroupSize≤5/signups≤30; greedy fallback otherwise
- Greedy non-overlapping group selection; re-picks from remaining participants when initial group overlaps
- Tier assignment: `leader` = top-1 by score, `max-coverage` = tied wantsCount with leader, `sub-max` = rest
- Sort order: wantsCount DESC → avgRank ASC → worstRank ASC → unrankedCount ASC

## Test plan
- [ ] 12 unit tests pass (empty inputs, reading exclusion, group size, no participant repeats, tier classification, perf N=30 M=50 <200ms median)

🤖 Generated with [Claude Code](https://claude.com/claude-code)