### PR TITLE
feat: Story 2-5 — scenarios section with tier colors and book detail modal

### DIFF
--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -3,10 +3,12 @@ export const dynamic = 'force-dynamic'
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { db } from '@/lib/db'
-import { matchingSessions, matchingSessionParticipants, users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { matchingSessions, matchingSessionParticipants, users, signupBooks, bookPriorities, books } from '@/lib/db/schema'
+import { eq, inArray, and } from 'drizzle-orm'
 import { fetchPersonalList } from '@/lib/matching/personal-list'
+import { generateScenarios } from '@/lib/matching/scenarios'
 import MatchingPersonalList from '@/components/nd/MatchingPersonalList'
+import MatchingScenarios from '@/components/nd/MatchingScenarios'
 
 function DeadlineCountdown({ deadlineAt }: { deadlineAt: Date }) {
   const now = Date.now()
@@ -22,9 +24,8 @@ function DeadlineCountdown({ deadlineAt }: { deadlineAt: Date }) {
 
 export default async function MatchingPage() {
   const session = await auth()
-  if (!session?.user?.isAdmin) redirect('/')
+  if (!session?.user?.id) redirect('/')
 
-  // Load active session
   const [activeSession] = await db
     .select()
     .from(matchingSessions)
@@ -40,7 +41,6 @@ export default async function MatchingPage() {
     )
   }
 
-  // Load participants and personal list in parallel
   const [participants, personalBooks] = await Promise.all([
     db
       .select({
@@ -57,6 +57,23 @@ export default async function MatchingPage() {
   ])
 
   const isAdmin = session.user.isAdmin
+  const participantUserIds = participants.map(p => p.userId)
+
+  // Fetch scenario data only when enough participants
+  const scenarios =
+    participantUserIds.length >= activeSession.targetGroupSize
+      ? await fetchAndGenerateScenarios(participantUserIds, activeSession.targetGroupSize)
+      : []
+
+  // Fetch book details for scenario cards
+  const scenarioBookIds = Array.from(new Set(scenarios.map(s => s.bookId)))
+  const scenarioBooks =
+    scenarioBookIds.length > 0
+      ? await db.select({ id: books.id, title: books.title, author: books.author, coverUrl: books.coverUrl })
+          .from(books)
+          .where(inArray(books.id, scenarioBookIds))
+      : []
+  const bookById = new Map(scenarioBooks.map(b => [b.id, b]))
 
   return (
     <main style={{ fontFamily: 'var(--nd-mono), monospace', padding: '2rem', maxWidth: 720, margin: '0 auto' }}>
@@ -113,7 +130,17 @@ export default async function MatchingPage() {
         <h2 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.75rem' }}>
           Мой список
         </h2>
-        <MatchingPersonalList books={personalBooks} />
+        <MatchingPersonalList
+          books={personalBooks}
+          frozen={activeSession.status === 'frozen'}
+        />
+      </section>
+
+      <section style={{ marginTop: '2rem' }}>
+        <h2 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.75rem' }}>
+          Сценарии групп
+        </h2>
+        <MatchingScenarios scenarios={scenarios} bookById={bookById} />
       </section>
 
       {isAdmin && (
@@ -126,4 +153,36 @@ export default async function MatchingPage() {
       )}
     </main>
   )
+}
+
+async function fetchAndGenerateScenarios(participantUserIds: string[], targetGroupSize: number) {
+  const [allSignups, allRanks, allBooks] = await Promise.all([
+    db.select({ userId: signupBooks.userId, bookId: signupBooks.bookId })
+      .from(signupBooks)
+      .where(inArray(signupBooks.userId, participantUserIds)),
+    db.select({ userId: bookPriorities.userId, bookId: bookPriorities.bookId, rank: bookPriorities.rank })
+      .from(bookPriorities)
+      .where(inArray(bookPriorities.userId, participantUserIds)),
+    db.select({ id: books.id, readingStatus: books.readingStatus })
+      .from(books)
+      .where(and(eq(books.visibility, 'published'))),
+  ])
+
+  // Only include books that are signed up by at least one session participant
+  const signedUpBookIds = new Set(allSignups.map(s => s.bookId))
+  const sessionBooks = allBooks
+    .filter(b => signedUpBookIds.has(b.id))
+    .map(b => ({ bookId: b.id, readingStatus: b.readingStatus ?? null }))
+
+  // Build participant list from userIds (pseudonyms not needed for engine)
+  const scenarioParticipants = participantUserIds.map(userId => ({ userId, pseudonym: userId }))
+
+  return generateScenarios({
+    participants: scenarioParticipants,
+    books: sessionBooks,
+    signups: allSignups.map(s => ({ userId: s.userId, bookId: s.bookId })),
+    ranks: allRanks.map(r => ({ userId: r.userId, bookId: r.bookId, rank: r.rank })),
+    targetGroupSize,
+    maxResults: 10,
+  })
 }

--- a/components/nd/MatchingScenarios.tsx
+++ b/components/nd/MatchingScenarios.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import type { ScenarioCard } from '@/lib/matching/scenarios'
+import CoverImage from './CoverImage'
+
+interface BookInfo {
+  id: string
+  title: string
+  author: string
+  coverUrl: string | null
+}
+
+interface Props {
+  scenarios: ScenarioCard[]
+  bookById: Map<string, BookInfo>
+}
+
+const tierStyle = (tier: ScenarioCard['tier']): React.CSSProperties => {
+  if (tier === 'leader') return { background: '#f0faf0', border: '1px solid #b2d8b2' }
+  if (tier === 'max-coverage') return { background: '#f5f8ff', border: '1px solid #c0cff0' }
+  return { background: '#fafaf8', border: '1px solid #e8e8e4' }
+}
+
+const tierLabel = (tier: ScenarioCard['tier']): string | null => {
+  if (tier === 'leader') return 'лидер'
+  if (tier === 'max-coverage') return 'макс. покрытие'
+  return null
+}
+
+const tierLabelColor = (tier: ScenarioCard['tier']): string => {
+  if (tier === 'leader') return '#4a7'
+  return '#6699cc'
+}
+
+const interestChipStyle = (interest: string): React.CSSProperties => {
+  if (interest === 'хочу читать') return { background: '#e8f5e8', color: '#4a7', border: '1px solid #b2d8b2' }
+  if (interest === 'готов(а)') return { background: '#f0f0f0', color: '#888', border: '1px solid #ddd' }
+  return { background: '#f9f9f9', color: '#bbb', border: '1px solid #eee' }
+}
+
+interface BookModalProps {
+  book: BookInfo
+  onClose: () => void
+}
+
+function BookModal({ book, onClose }: BookModalProps) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  return (
+    <div
+      role="presentation"
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.35)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={book.title}
+        onClick={e => e.stopPropagation()}
+        style={{
+          background: '#fff', borderRadius: 6, padding: '1.5rem',
+          maxWidth: 380, width: '90%', fontFamily: 'var(--nd-mono), monospace',
+          boxShadow: '0 4px 24px rgba(0,0,0,0.12)',
+        }}
+      >
+        <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
+          <div style={{ width: 56, height: 80, flexShrink: 0 }}>
+            <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
+          </div>
+          <div>
+            <div style={{ fontWeight: 600, fontSize: '0.9rem', marginBottom: '0.25rem' }}>{book.title}</div>
+            <div style={{ fontSize: '0.78rem', color: '#666' }}>{book.author}</div>
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            marginTop: '0.5rem', fontSize: '0.78rem', color: '#999',
+            background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+          }}
+        >
+          Закрыть (Esc)
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default function MatchingScenarios({ scenarios, bookById }: Props) {
+  const [modalBook, setModalBook] = useState<BookInfo | null>(null)
+  const openModal = useCallback((book: BookInfo) => setModalBook(book), [])
+  const closeModal = useCallback(() => setModalBook(null), [])
+
+  if (scenarios.length === 0) {
+    return (
+      <p style={{ color: '#999', fontSize: '0.8rem' }}>
+        Недостаточно участников или сигнапов для формирования сценариев.
+      </p>
+    )
+  }
+
+  return (
+    <>
+      {modalBook && <BookModal book={modalBook} onClose={closeModal} />}
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        {scenarios.map((card) => {
+          const book = bookById.get(card.bookId)
+          const label = tierLabel(card.tier)
+          return (
+            <li
+              key={card.bookId}
+              style={{
+                borderRadius: 5,
+                padding: '0.75rem',
+                ...tierStyle(card.tier),
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.75rem' }}>
+                {book && (
+                  <div style={{ width: 36, height: 52, flexShrink: 0 }}>
+                    <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
+                  </div>
+                )}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.3rem' }}>
+                    <button
+                      onClick={() => book && openModal(book)}
+                      style={{
+                        background: 'none', border: 'none', padding: 0,
+                        fontFamily: 'var(--nd-mono), monospace',
+                        fontSize: '0.82rem', fontWeight: 600,
+                        cursor: book ? 'pointer' : 'default',
+                        textAlign: 'left',
+                        textDecoration: book ? 'underline' : 'none',
+                        color: '#222',
+                      }}
+                    >
+                      {book?.title ?? card.bookId}
+                    </button>
+                    {label && (
+                      <span
+                        style={{
+                          fontSize: '0.65rem',
+                          color: tierLabelColor(card.tier),
+                          border: `1px solid ${tierLabelColor(card.tier)}`,
+                          borderRadius: 3,
+                          padding: '1px 5px',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {label}
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem' }}>
+                    {card.members.map(m => (
+                      <span
+                        key={m.userId}
+                        style={{ display: 'flex', alignItems: 'center', gap: '0.3rem' }}
+                      >
+                        <span style={{ fontSize: '0.78rem', color: '#555' }}>{m.pseudonym}</span>
+                        <span
+                          style={{
+                            fontSize: '0.6rem',
+                            padding: '1px 4px',
+                            borderRadius: 3,
+                            ...interestChipStyle(m.interest),
+                          }}
+                        >
+                          {m.interest}
+                        </span>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Auth gate changed from isAdmin → any authenticated user (scenarios are for all participants)
- Fetches signups, ranks, and book metadata for all session participants in parallel
- Calls `generateScenarios()` from Story 2-4 and renders up to 10 cards
- `MatchingScenarios` client component: tier-coloured cards (green=leader, blue=max-coverage, beige=sub-max), tier badge, participant pseudonyms + interest chips
- Book title click opens `role="dialog"` modal with cover, title, author; closes on Escape or backdrop click

## Test plan
- [ ] Scenarios section visible on /matching with active session
- [ ] Leader card has green background + "лидер" badge
- [ ] max-coverage cards have blue background
- [ ] sub-max cards are neutral beige
- [ ] Clicking book title opens modal; Escape closes it
- [ ] Empty state shown when not enough participants/signups

🤖 Generated with [Claude Code](https://claude.com/claude-code)