### PR TITLE
feat: Story 2-7 — rank nudge banner for unranked participants

### DIFF
--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -11,6 +11,7 @@ import { fetchMyMoves } from '@/lib/matching/my-moves'
 import MatchingPersonalList from '@/components/nd/MatchingPersonalList'
 import MatchingScenarios from '@/components/nd/MatchingScenarios'
 import MatchingMyMoves from '@/components/nd/MatchingMyMoves'
+import MatchingRankNudge from '@/components/nd/MatchingRankNudge'
 
 function DeadlineCountdown({ deadlineAt }: { deadlineAt: Date }) {
   const now = Date.now()
@@ -133,6 +134,9 @@ export default async function MatchingPage() {
         <h2 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.75rem' }}>
           Мой список
         </h2>
+        <MatchingRankNudge
+          show={personalBooks.length > 0 && personalBooks.every(b => b.rank === null)}
+        />
         <MatchingPersonalList
           books={personalBooks}
           frozen={activeSession.status === 'frozen'}

--- a/components/nd/MatchingRankNudge.tsx
+++ b/components/nd/MatchingRankNudge.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+const STORAGE_KEY = 'matching-rank-nudge-dismissed'
+
+interface Props {
+  show: boolean
+}
+
+export default function MatchingRankNudge({ show }: Props) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!show) return
+    try {
+      const dismissed = sessionStorage.getItem(STORAGE_KEY)
+      if (!dismissed) setVisible(true)
+    } catch {
+      setVisible(true)
+    }
+  }, [show])
+
+  const dismiss = useCallback(() => {
+    setVisible(false)
+    try {
+      sessionStorage.setItem(STORAGE_KEY, '1')
+    } catch {
+      // ignore storage errors
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!visible) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') dismiss()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [visible, dismiss])
+
+  if (!visible) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '0.75rem',
+        padding: '0.6rem 0.75rem',
+        marginBottom: '0.75rem',
+        borderRadius: 4,
+        background: '#fffbe6',
+        border: '1px solid #f5d35e',
+        fontSize: '0.78rem',
+        fontFamily: 'var(--nd-mono), monospace',
+        color: '#7a6000',
+      }}
+    >
+      <span>
+        Расставь ранги, чтобы улучшить выбор сценариев
+      </span>
+      <button
+        onClick={dismiss}
+        aria-label="Закрыть подсказку"
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          color: '#7a6000',
+          fontSize: '0.9rem',
+          lineHeight: 1,
+          padding: '0 2px',
+          flexShrink: 0,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- `MatchingRankNudge` client component: shown when user has signups but all ranks are null
- Dismissible via × button or Escape; dismissal state persisted in sessionStorage (per-session, not permanent)
- Renders inline above the book list, does not block interaction

## Test plan
- [ ] Banner appears when user has books but none ranked
- [ ] Banner absent when at least one book is ranked
- [ ] × button dismisses banner
- [ ] Escape dismisses banner
- [ ] Banner stays dismissed after dismiss (sessionStorage key set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)