### PR TITLE
feat: Story 2-8 — admin freeze session, capture leader, frozen badge

### DIFF
--- a/app/api/matching/sessions/[id]/freeze/route.test.ts
+++ b/app/api/matching/sessions/[id]/freeze/route.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from './route'
+import * as authModule from '@/lib/auth'
+import { db } from '@/lib/db'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), update: jest.fn() } }))
+jest.mock('@/lib/db/schema', () => ({
+  matchingSessions: {},
+  matchingSessionParticipants: {},
+  signupBooks: {},
+  bookPriorities: {},
+  books: {},
+}))
+jest.mock('@/lib/matching/scenarios', () => ({
+  generateScenarios: jest.fn().mockReturnValue([]),
+}))
+
+const mockAuth = authModule.auth as jest.Mock
+const mockDb = db as jest.Mocked<typeof db>
+
+function makeReq(id: string) {
+  return new Request(`http://localhost/api/matching/sessions/${id}/freeze`, {
+    method: 'POST',
+  }) as unknown as import('next/server').NextRequest
+}
+
+const adminSession = { user: { id: 'admin1', isAdmin: true } }
+
+describe('POST /api/matching/sessions/[id]/freeze', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns 403 for non-admin', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u1', isAdmin: false } })
+    const res = await POST(makeReq('s1'), { params: { id: 's1' } })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 404 when session not found', async () => {
+    mockAuth.mockResolvedValue(adminSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await POST(makeReq('bad'), { params: { id: 'bad' } })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 409 when already frozen', async () => {
+    mockAuth.mockResolvedValue(adminSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'frozen', targetGroupSize: 3, createdAt: new Date() }]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await POST(makeReq('s1'), { params: { id: 's1' } })
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 422 when no participants', async () => {
+    mockAuth.mockResolvedValue(adminSession)
+    const sessionChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active', targetGroupSize: 3, createdAt: new Date() }]) }
+    const emptyChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) }
+    mockDb.select = jest.fn()
+      .mockReturnValueOnce(sessionChain)
+      .mockReturnValue(emptyChain)
+    const res = await POST(makeReq('s1'), { params: { id: 's1' } })
+    expect(res.status).toBe(422)
+  })
+
+  it('returns 200 and updates session on success', async () => {
+    mockAuth.mockResolvedValue(adminSession)
+    let selectCallCount = 0
+    mockDb.select = jest.fn().mockImplementation(() => {
+      const instance = {
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockImplementation(() => {
+          selectCallCount++
+          if (selectCallCount === 1) return Promise.resolve([{ id: 's1', status: 'active', targetGroupSize: 3, createdAt: new Date() }])
+          return Promise.resolve([{ userId: 'u1' }])
+        }),
+      }
+      // For queries without .limit (signups, ranks, books)
+      instance.where = jest.fn().mockReturnValue({
+        ...instance,
+        then: (resolve: (v: unknown[]) => void) => Promise.resolve([]).then(resolve),
+        limit: instance.limit,
+      })
+      return instance
+    })
+    // Override for Promise.all queries
+    mockDb.select = jest.fn()
+      .mockReturnValueOnce({ from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active', targetGroupSize: 3, createdAt: new Date() }]) })
+      .mockReturnValueOnce({ from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([{ userId: 'u1' }]) })
+      .mockReturnValueOnce({ from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) })
+      .mockReturnValueOnce({ from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) })
+      .mockReturnValueOnce({ from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) })
+
+    const updateChain = { set: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) }
+    mockDb.update = jest.fn().mockReturnValue(updateChain)
+
+    const res = await POST(makeReq('s1'), { params: { id: 's1' } })
+    expect(res.status).toBe(200)
+    expect(mockDb.update).toHaveBeenCalled()
+  })
+})

--- a/app/api/matching/sessions/[id]/freeze/route.ts
+++ b/app/api/matching/sessions/[id]/freeze/route.ts
@@ -1,0 +1,96 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import {
+  matchingSessions,
+  matchingSessionParticipants,
+  signupBooks,
+  bookPriorities,
+  books,
+} from '@/lib/db/schema'
+import { eq, inArray, and } from 'drizzle-orm'
+import { generateScenarios } from '@/lib/matching/scenarios'
+
+type Params = { params: { id: string } }
+
+export async function POST(_req: NextRequest, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const [matchSession] = await db
+    .select()
+    .from(matchingSessions)
+    .where(eq(matchingSessions.id, params.id))
+    .limit(1)
+
+  if (!matchSession) return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+  if (matchSession.status === 'frozen') return NextResponse.json({ error: 'Already frozen' }, { status: 409 })
+
+  // Fetch participants and data for scenario generation
+  const participants = await db
+    .select({ userId: matchingSessionParticipants.userId })
+    .from(matchingSessionParticipants)
+    .where(eq(matchingSessionParticipants.sessionId, params.id))
+
+  const participantUserIds = participants.map(p => p.userId)
+  if (participantUserIds.length === 0) {
+    return NextResponse.json({ error: 'No participants' }, { status: 422 })
+  }
+
+  const [allSignups, allRanks, allBooks] = await Promise.all([
+    db.select({ userId: signupBooks.userId, bookId: signupBooks.bookId })
+      .from(signupBooks)
+      .where(inArray(signupBooks.userId, participantUserIds)),
+    db.select({ userId: bookPriorities.userId, bookId: bookPriorities.bookId, rank: bookPriorities.rank })
+      .from(bookPriorities)
+      .where(inArray(bookPriorities.userId, participantUserIds)),
+    db.select({ id: books.id, readingStatus: books.readingStatus })
+      .from(books)
+      .where(and(eq(books.visibility, 'published'))),
+  ])
+
+  const signedUpBookIds = new Set(allSignups.map(s => s.bookId))
+  const sessionBooks = allBooks
+    .filter(b => signedUpBookIds.has(b.id))
+    .map(b => ({ bookId: b.id, readingStatus: b.readingStatus ?? null }))
+
+  const scenarios = generateScenarios({
+    participants: participantUserIds.map(uid => ({ userId: uid, pseudonym: uid })),
+    books: sessionBooks,
+    signups: allSignups,
+    ranks: allRanks,
+    targetGroupSize: matchSession.targetGroupSize,
+    maxResults: 10,
+  })
+
+  const leader = scenarios[0] ?? null
+
+  // Compute metrics
+  const frozenAt = new Date()
+  const metricGroupsCount = scenarios.length
+  const metricCoverage = scenarios.reduce((sum, s) => sum + s.members.length, 0)
+  const metricTimeToFreezeSeconds = Math.floor(
+    (frozenAt.getTime() - matchSession.createdAt.getTime()) / 1000,
+  )
+  const metricTop3HitRate = leader
+    ? leader.wantsCount / matchSession.targetGroupSize
+    : 0
+
+  await db
+    .update(matchingSessions)
+    .set({
+      status: 'frozen',
+      frozenAt,
+      frozenScenarioJson: leader ?? null,
+      metricGroupsCount,
+      metricCoverage,
+      metricTimeToFreezeSeconds,
+      metricTimeSinceLastMutationSeconds: null,
+      metricTop3HitRate,
+    })
+    .where(eq(matchingSessions.id, params.id))
+
+  return NextResponse.json({ ok: true, frozen_at: frozenAt.toISOString(), leader }, { status: 200 })
+}

--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -92,7 +92,13 @@ export default async function MatchingPage() {
               Дедлайн: <DeadlineCountdown deadlineAt={new Date(activeSession.deadlineAt)} />
             </span>
           )}
-          <span style={{ color: '#4a7' }}>● активна</span>
+          {activeSession.status === 'frozen' ? (
+            <span style={{ color: '#888', background: '#f0f0f0', padding: '1px 8px', borderRadius: 3, fontSize: '0.72rem' }}>
+              Зафиксирована
+            </span>
+          ) : (
+            <span style={{ color: '#4a7' }}>● активна</span>
+          )}
         </div>
       </header>
 

--- a/components/nd/AdminMatchingSession.tsx
+++ b/components/nd/AdminMatchingSession.tsx
@@ -63,6 +63,25 @@ export default function AdminMatchingSession() {
   useEffect(() => { load() }, [load])
 
   const activeSession = sessions.find(s => s.status === 'active')
+  const [freezing, setFreezing] = useState(false)
+  const [freezeError, setFreezeError] = useState<string | null>(null)
+
+  async function handleFreeze() {
+    if (!activeSession) return
+    if (!window.confirm(`Зафиксировать сессию «${activeSession.name}»? Это действие необратимо.`)) return
+    setFreezing(true)
+    setFreezeError(null)
+    try {
+      const res = await fetch(`/api/matching/sessions/${activeSession.id}/freeze`, { method: 'POST' })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error ?? 'Ошибка заморозки')
+      await load()
+    } catch (e) {
+      setFreezeError(e instanceof Error ? e.message : 'Неизвестная ошибка')
+    } finally {
+      setFreezing(false)
+    }
+  }
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault()
@@ -108,14 +127,23 @@ export default function AdminMatchingSession() {
           {activeSession.deadlineAt && (
             <div>Дедлайн: {new Date(activeSession.deadlineAt).toLocaleString('ru-RU')}</div>
           )}
-          <div style={{ marginTop: 8 }}>
+          <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
             <a
               href="/matching"
               style={{ color: '#333', textDecoration: 'underline', fontSize: '0.78rem' }}
             >
               Открыть страницу матчинга →
             </a>
+            <button
+              onClick={handleFreeze}
+              disabled={freezing}
+              style={{ ...btn, borderColor: '#c00', color: '#c00' }}
+              data-testid="admin-freeze-session"
+            >
+              {freezing ? 'Фиксирую…' : 'Зафиксировать'}
+            </button>
           </div>
+          {freezeError && <p style={{ color: '#c00', fontSize: '0.75rem', marginTop: 4 }}>{freezeError}</p>}
         </div>
       )}
 

--- a/drizzle/0030_matching_freeze_metrics.sql
+++ b/drizzle/0030_matching_freeze_metrics.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "matching_sessions"
+  ADD COLUMN "metric_groups_count" integer,
+  ADD COLUMN "metric_coverage" integer,
+  ADD COLUMN "metric_time_to_freeze_seconds" integer,
+  ADD COLUMN "metric_time_since_last_mutation_seconds" integer,
+  ADD COLUMN "metric_top3_hit_rate" real;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm'
 import {
-  pgTable, text, timestamp, integer, boolean, primaryKey, index, uniqueIndex, jsonb,
+  pgTable, text, timestamp, integer, boolean, primaryKey, index, uniqueIndex, jsonb, real,
 } from 'drizzle-orm/pg-core'
 
 export const users = pgTable('user', {
@@ -190,8 +190,13 @@ export const matchingSessions = pgTable('matching_sessions', {
   deadlineAt:         timestamp('deadline_at', { mode: 'date' }),
   status:             text('status').notNull().default('active'), // 'active' | 'frozen'
   targetGroupSize:    integer('target_group_size').notNull().default(3),
-  frozenAt:           timestamp('frozen_at', { mode: 'date' }),
-  frozenScenarioJson: jsonb('frozen_scenario_json'),
+  frozenAt:                        timestamp('frozen_at', { mode: 'date' }),
+  frozenScenarioJson:              jsonb('frozen_scenario_json'),
+  metricGroupsCount:               integer('metric_groups_count'),
+  metricCoverage:                  integer('metric_coverage'),
+  metricTimeToFreezeSeconds:       integer('metric_time_to_freeze_seconds'),
+  metricTimeSinceLastMutationSeconds: integer('metric_time_since_last_mutation_seconds'),
+  metricTop3HitRate:               real('metric_top3_hit_rate'),
 }, (t) => ({
   // Enforces at most one active session at a time
   singleActiveIdx: uniqueIndex('matching_sessions_single_active_idx')


### PR DESCRIPTION
## Summary
- DB migration `0030_matching_freeze_metrics.sql` adds 5 metric columns to matching_sessions
- `POST /api/matching/sessions/:id/freeze` — admin-only; sets status='frozen', frozenScenarioJson, and metric columns
- Admin panel "Зафиксировать" button with confirmation dialog; shows freeze error inline
- /matching page shows "Зафиксирована" badge for frozen sessions; MatchingPersonalList already passes frozen=true to disable drag

## Test plan
- [ ] 5 unit tests pass for freeze endpoint (403, 404, 409, 422, 200)
- [ ] Admin sees "Зафиксировать" button in admin panel for active session
- [ ] Confirm dialog appears; confirm freezes the session
- [ ] /matching page shows frozen badge after freeze
- [ ] All matching API mutations return 409 when session frozen (covered by earlier stories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)