### PR TITLE
feat: Story 3-1 — SSE endpoint with heartbeat and in-memory broadcast hub

### DIFF
--- a/app/api/matching/stream/route.ts
+++ b/app/api/matching/stream/route.ts
@@ -1,0 +1,110 @@
+export const dynamic = 'force-dynamic'
+
+import { type NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { matchingSessions, matchingSessionParticipants } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import {
+  addSubscriber,
+  removeSubscriber,
+  canSubscribe,
+  heartbeat,
+} from '@/lib/matching/realtime/hub'
+
+const HEARTBEAT_INTERVAL_MS = 25_000
+const MAX_STREAM_DURATION_MS = 5 * 60 * 1000
+
+export async function GET(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sessionIdParam = req.nextUrl.searchParams.get('session')
+  if (!sessionIdParam) {
+    return NextResponse.json({ error: 'session param required' }, { status: 400 })
+  }
+
+  const sessionId: string = sessionIdParam
+
+  // Verify session exists
+  const [matchSession] = await db
+    .select({ id: matchingSessions.id })
+    .from(matchingSessions)
+    .where(eq(matchingSessions.id, sessionId))
+    .limit(1)
+
+  if (!matchSession) {
+    return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+  }
+
+  // Verify user is a participant or admin
+  const userId = session.user.id
+  const isAdmin = session.user.isAdmin
+
+  if (!isAdmin) {
+    const [participant] = await db
+      .select({ userId: matchingSessionParticipants.userId })
+      .from(matchingSessionParticipants)
+      .where(
+        and(
+          eq(matchingSessionParticipants.sessionId, sessionId),
+          eq(matchingSessionParticipants.userId, userId),
+        ),
+      )
+      .limit(1)
+
+    if (!participant) {
+      return NextResponse.json({ error: 'Not a participant' }, { status: 403 })
+    }
+  }
+
+  if (!canSubscribe(sessionId)) {
+    return NextResponse.json({ error: 'Too many subscribers' }, { status: 503 })
+  }
+
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  let closeTimer: ReturnType<typeof setTimeout> | null = null
+  const sub = { controller: null as unknown as ReadableStreamDefaultController, userId }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      sub.controller = controller
+      addSubscriber(sessionId, sub)
+
+      // Heartbeat every 25s
+      heartbeatTimer = setInterval(() => {
+        try {
+          controller.enqueue(heartbeat())
+        } catch {
+          cleanup()
+        }
+      }, HEARTBEAT_INTERVAL_MS)
+
+      // Auto-close after 5 minutes
+      closeTimer = setTimeout(() => {
+        cleanup()
+        controller.close()
+      }, MAX_STREAM_DURATION_MS)
+    },
+    cancel() {
+      cleanup()
+    },
+  })
+
+  function cleanup() {
+    if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null }
+    if (closeTimer) { clearTimeout(closeTimer); closeTimer = null }
+    removeSubscriber(sessionId, sub)
+  }
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/lib/matching/realtime/__tests__/hub.test.ts
+++ b/lib/matching/realtime/__tests__/hub.test.ts
@@ -1,0 +1,101 @@
+import {
+  broadcast,
+  addSubscriber,
+  removeSubscriber,
+  canSubscribe,
+  subscriberCount,
+  encodeEvent,
+  heartbeat,
+} from '../hub'
+
+function makeMockController() {
+  const enqueued: Uint8Array[] = []
+  return {
+    enqueue: jest.fn((chunk: Uint8Array) => enqueued.push(chunk)),
+    close: jest.fn(),
+    enqueued,
+  }
+}
+
+describe('hub', () => {
+  const sessionId = 'test-session-hub'
+
+  afterEach(() => {
+    // Clean up subscribers for the test session
+    const count = subscriberCount(sessionId)
+    if (count > 0) {
+      // No direct reset, just remove individually is not easy; rely on test isolation
+    }
+  })
+
+  it('subscriberCount starts at 0 for unknown session', () => {
+    expect(subscriberCount('no-session')).toBe(0)
+  })
+
+  it('canSubscribe returns true below limit', () => {
+    expect(canSubscribe('empty-session')).toBe(true)
+  })
+
+  it('addSubscriber and removeSubscriber track count', () => {
+    const sid = 'count-test'
+    const ctrl = makeMockController()
+    const sub = { controller: ctrl as unknown as ReadableStreamDefaultController, userId: 'u1' }
+    addSubscriber(sid, sub)
+    expect(subscriberCount(sid)).toBe(1)
+    removeSubscriber(sid, sub)
+    expect(subscriberCount(sid)).toBe(0)
+  })
+
+  it('broadcast delivers encoded event to subscriber', () => {
+    const sid = 'broadcast-test'
+    const ctrl = makeMockController()
+    const sub = { controller: ctrl as unknown as ReadableStreamDefaultController, userId: 'u1' }
+    addSubscriber(sid, sub)
+    const event = broadcast(sid, 'test_event', { foo: 'bar' })
+    removeSubscriber(sid, sub)
+
+    expect(event.type).toBe('test_event')
+    expect(event.event_id).toBeGreaterThan(0)
+    expect(ctrl.enqueue).toHaveBeenCalledTimes(1)
+
+    const text = new TextDecoder().decode(ctrl.enqueued[0])
+    expect(text).toContain('event: test_event')
+    expect(text).toContain('"foo":"bar"')
+  })
+
+  it('broadcast increments event_id monotonically', () => {
+    const sid = 'monotonic-test'
+    const ctrl = makeMockController()
+    const sub = { controller: ctrl as unknown as ReadableStreamDefaultController, userId: 'u1' }
+    addSubscriber(sid, sub)
+    const e1 = broadcast(sid, 'a', {})
+    const e2 = broadcast(sid, 'b', {})
+    const e3 = broadcast(sid, 'c', {})
+    removeSubscriber(sid, sub)
+    expect(e2.event_id).toBeGreaterThan(e1.event_id)
+    expect(e3.event_id).toBeGreaterThan(e2.event_id)
+  })
+
+  it('broadcast handles controller errors gracefully', () => {
+    const sid = 'error-test'
+    const ctrl = {
+      enqueue: jest.fn().mockImplementation(() => { throw new Error('closed') }),
+    }
+    const sub = { controller: ctrl as unknown as ReadableStreamDefaultController, userId: 'u1' }
+    addSubscriber(sid, sub)
+    expect(() => broadcast(sid, 'evt', {})).not.toThrow()
+    removeSubscriber(sid, sub)
+  })
+
+  it('encodeEvent produces valid SSE format', () => {
+    const encoded = encodeEvent({ type: 'foo', event_id: 42, payload: { x: 1 } })
+    const text = new TextDecoder().decode(encoded)
+    expect(text).toBe('event: foo\ndata: {"type":"foo","event_id":42,"payload":{"x":1}}\n\n')
+  })
+
+  it('heartbeat produces SSE comment format', () => {
+    const hb = heartbeat()
+    const text = new TextDecoder().decode(hb)
+    expect(text).toBe(': ping\n\n')
+  })
+})

--- a/lib/matching/realtime/hub.ts
+++ b/lib/matching/realtime/hub.ts
@@ -1,0 +1,76 @@
+export interface HubEvent {
+  type: string
+  event_id: number
+  payload: unknown
+}
+
+type Subscriber = {
+  controller: ReadableStreamDefaultController
+  userId: string
+}
+
+const MAX_SUBSCRIBERS_PER_SESSION = 50
+
+// Per-session map of subscribers
+const subscribers = new Map<string, Set<Subscriber>>()
+// Per-session monotonic event ID counter
+const eventCounters = new Map<string, number>()
+
+function nextEventId(sessionId: string): number {
+  const n = (eventCounters.get(sessionId) ?? 0) + 1
+  eventCounters.set(sessionId, n)
+  return n
+}
+
+export function subscriberCount(sessionId: string): number {
+  return subscribers.get(sessionId)?.size ?? 0
+}
+
+export function canSubscribe(sessionId: string): boolean {
+  return subscriberCount(sessionId) < MAX_SUBSCRIBERS_PER_SESSION
+}
+
+export function addSubscriber(sessionId: string, sub: Subscriber): void {
+  let set = subscribers.get(sessionId)
+  if (!set) {
+    set = new Set()
+    subscribers.set(sessionId, set)
+  }
+  set.add(sub)
+}
+
+export function removeSubscriber(sessionId: string, sub: Subscriber): void {
+  const set = subscribers.get(sessionId)
+  if (!set) return
+  set.delete(sub)
+  if (set.size === 0) subscribers.delete(sessionId)
+}
+
+export function broadcast(sessionId: string, type: string, payload: unknown): HubEvent {
+  const event_id = nextEventId(sessionId)
+  const event: HubEvent = { type, event_id, payload }
+  const msg = encodeEvent(event)
+  const set = subscribers.get(sessionId)
+  if (set) {
+    for (const sub of Array.from(set)) {
+      try {
+        sub.controller.enqueue(msg)
+      } catch {
+        // controller closed; will be cleaned up by cancel callback
+      }
+    }
+  }
+  return event
+}
+
+export function encodeEvent(event: HubEvent): Uint8Array {
+  const text = `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`
+  return new TextEncoder().encode(text)
+}
+
+export function heartbeat(): Uint8Array {
+  return new TextEncoder().encode(': ping\n\n')
+}
+
+// Exported for testing
+export const hub = { broadcast, addSubscriber, removeSubscriber, canSubscribe, subscriberCount }


### PR DESCRIPTION
## Summary
- `lib/matching/realtime/hub.ts` — in-memory broadcast hub: per-session subscriber sets, monotonic event_id counters, SSE encoding helpers, 50-subscriber limit
- `GET /api/matching/stream?session=<id>` — SSE endpoint with ReadableStream; heartbeat every 25s; auto-close after 5 minutes; 401/403/404/503 guards
- 8 unit tests for hub module (subscriber tracking, broadcast, event_id monotonicity, SSE format, heartbeat format)

## Test plan
- [ ] 8 unit tests pass (`npm test -- --testPathPattern="realtime.*hub"`)
- [ ] SSE connection stays open, heartbeat arrives every 25s
- [ ] 51st subscriber gets 503
- [ ] Non-participant/non-admin gets 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)