### PR TITLE
feat: Story 3-2 — broadcast state_changed on mutations + GET /api/matching/state

### DIFF
--- a/app/api/matching/books/[bookId]/route.ts
+++ b/app/api/matching/books/[bookId]/route.ts
@@ -5,6 +5,7 @@ import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { matchingSessions, signupBooks, bookPriorities } from '@/lib/db/schema'
 import { eq, and, asc } from 'drizzle-orm'
+import { broadcast } from '@/lib/matching/realtime/hub'
 
 type Params = { params: { bookId: string } }
 
@@ -44,6 +45,8 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
       .set({ rank: i + 1 })
       .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, remaining[i].bookId)))
   }
+
+  broadcast(activeSession.id, 'state_changed', { userId, kind: 'book_removed', bookId })
 
   return NextResponse.json({ ok: true }, { status: 200 })
 }

--- a/app/api/matching/books/route.ts
+++ b/app/api/matching/books/route.ts
@@ -5,6 +5,7 @@ import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { matchingSessions, signupBooks } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { broadcast } from '@/lib/matching/realtime/hub'
 
 export async function POST(req: NextRequest) {
   const session = await auth()
@@ -27,6 +28,8 @@ export async function POST(req: NextRequest) {
     .insert(signupBooks)
     .values({ userId: session.user.id, bookId })
     .onConflictDoNothing()
+
+  broadcast(activeSession.id, 'state_changed', { userId: session.user.id, kind: 'book_added', bookId })
 
   return NextResponse.json({ ok: true }, { status: 200 })
 }

--- a/app/api/matching/priorities/route.ts
+++ b/app/api/matching/priorities/route.ts
@@ -5,6 +5,7 @@ import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { matchingSessions, bookPriorities } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { broadcast } from '@/lib/matching/realtime/hub'
 
 export async function PATCH(req: NextRequest) {
   const session = await auth()
@@ -44,6 +45,8 @@ export async function PATCH(req: NextRequest) {
     .select({ bookId: bookPriorities.bookId, rank: bookPriorities.rank })
     .from(bookPriorities)
     .where(eq(bookPriorities.userId, userId))
+
+  broadcast(activeSession.id, 'state_changed', { userId, kind: 'ranks_updated' })
 
   return NextResponse.json({ ranks: canonical }, { status: 200 })
 }

--- a/app/api/matching/sessions/[id]/freeze/route.ts
+++ b/app/api/matching/sessions/[id]/freeze/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/db/schema'
 import { eq, inArray, and } from 'drizzle-orm'
 import { generateScenarios } from '@/lib/matching/scenarios'
+import { broadcast } from '@/lib/matching/realtime/hub'
 
 type Params = { params: { id: string } }
 
@@ -91,6 +92,8 @@ export async function POST(_req: NextRequest, { params }: Params) {
       metricTop3HitRate,
     })
     .where(eq(matchingSessions.id, params.id))
+
+  broadcast(params.id, 'session_frozen', { frozen_at: frozenAt.toISOString(), frozen_scenario: leader })
 
   return NextResponse.json({ ok: true, frozen_at: frozenAt.toISOString(), leader }, { status: 200 })
 }

--- a/app/api/matching/sessions/[id]/join/route.ts
+++ b/app/api/matching/sessions/[id]/join/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { matchingSessions, matchingSessionParticipants } from '@/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { assignPseudonym } from '@/lib/matching/pseudonyms'
+import { broadcast } from '@/lib/matching/realtime/hub'
 
 interface Params { params: { id: string } }
 
@@ -61,6 +62,8 @@ export async function POST(_req: NextRequest, { params }: Params) {
     userId,
     pseudonym,
   })
+
+  broadcast(sessionId, 'state_changed', { userId, kind: 'participant_joined' })
 
   return NextResponse.json({ success: true, pseudonym }, { status: 201 })
 }

--- a/app/api/matching/state/route.test.ts
+++ b/app/api/matching/state/route.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from './route'
+import * as authModule from '@/lib/auth'
+import { db } from '@/lib/db'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn() } }))
+jest.mock('@/lib/db/schema', () => ({
+  matchingSessions: {},
+  matchingSessionParticipants: {},
+  signupBooks: {},
+  bookPriorities: {},
+  books: {},
+}))
+jest.mock('@/lib/matching/personal-list', () => ({
+  fetchPersonalList: jest.fn().mockResolvedValue([]),
+}))
+jest.mock('@/lib/matching/my-moves', () => ({
+  fetchMyMoves: jest.fn().mockResolvedValue([]),
+}))
+jest.mock('@/lib/matching/scenarios', () => ({
+  generateScenarios: jest.fn().mockReturnValue([]),
+}))
+
+const mockAuth = authModule.auth as jest.Mock
+const mockDb = db as jest.Mocked<typeof db>
+
+function makeReq(sessionId: string, asParam?: string) {
+  const urlStr = `http://localhost/api/matching/state?session=${sessionId}${asParam ? `&as=${asParam}` : ''}`
+  const url = new URL(urlStr)
+  const req = new Request(urlStr) as unknown as import('next/server').NextRequest
+  ;(req as unknown as { nextUrl: URL }).nextUrl = url
+  return req
+}
+
+const userSession = { user: { id: 'u1', isAdmin: false } }
+
+describe('GET /api/matching/state', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns 401 when not authenticated', async () => {
+    mockAuth.mockResolvedValue(null)
+    const res = await GET(makeReq('s1'))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when session param missing', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const url = new URL('http://localhost/api/matching/state')
+    const req = new Request('http://localhost/api/matching/state') as unknown as import('next/server').NextRequest
+    ;(req as unknown as { nextUrl: URL }).nextUrl = url
+    const res = await GET(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when session not found', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const chain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([]) }
+    mockDb.select = jest.fn().mockReturnValue(chain)
+    const res = await GET(makeReq('bad-id'))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 200 with state for authenticated user', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const sessionChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active', targetGroupSize: 3 }]) }
+    const participantsChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) }
+    mockDb.select = jest.fn()
+      .mockReturnValueOnce(sessionChain)
+      .mockReturnValue(participantsChain)
+    const res = await GET(makeReq('s1'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toHaveProperty('personalBooks')
+    expect(json).toHaveProperty('scenarios')
+    expect(json).toHaveProperty('myMoves')
+    expect(json).toHaveProperty('sessionStatus')
+  })
+})

--- a/app/api/matching/state/route.ts
+++ b/app/api/matching/state/route.ts
@@ -1,0 +1,76 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { matchingSessions, matchingSessionParticipants, signupBooks, bookPriorities, books } from '@/lib/db/schema'
+import { eq, inArray, and } from 'drizzle-orm'
+import { fetchPersonalList } from '@/lib/matching/personal-list'
+import { fetchMyMoves } from '@/lib/matching/my-moves'
+import { generateScenarios } from '@/lib/matching/scenarios'
+
+export async function GET(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const sessionId = req.nextUrl.searchParams.get('session')
+  if (!sessionId) return NextResponse.json({ error: 'session param required' }, { status: 400 })
+
+  const [matchSession] = await db
+    .select()
+    .from(matchingSessions)
+    .where(eq(matchingSessions.id, sessionId))
+    .limit(1)
+
+  if (!matchSession) return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+
+  // Support ?as= for admin impersonation (Epic 4) — userId used for personal data
+  const asParam = req.nextUrl.searchParams.get('as')
+  const isAdmin = session.user.isAdmin
+  const effectiveUserId = (isAdmin && asParam) ? asParam : session.user.id
+
+  const participants = await db
+    .select({ userId: matchingSessionParticipants.userId })
+    .from(matchingSessionParticipants)
+    .where(eq(matchingSessionParticipants.sessionId, sessionId))
+
+  const participantUserIds = participants.map(p => p.userId)
+
+  const [personalBooks, myMoves] = await Promise.all([
+    fetchPersonalList(effectiveUserId),
+    fetchMyMoves(effectiveUserId, sessionId, matchSession.targetGroupSize),
+  ])
+
+  // Scenario generation
+  let scenarios: ReturnType<typeof generateScenarios> = []
+  if (participantUserIds.length >= matchSession.targetGroupSize) {
+    const [allSignups, allRanks, allBooks] = await Promise.all([
+      db.select({ userId: signupBooks.userId, bookId: signupBooks.bookId })
+        .from(signupBooks)
+        .where(inArray(signupBooks.userId, participantUserIds)),
+      db.select({ userId: bookPriorities.userId, bookId: bookPriorities.bookId, rank: bookPriorities.rank })
+        .from(bookPriorities)
+        .where(inArray(bookPriorities.userId, participantUserIds)),
+      db.select({ id: books.id, readingStatus: books.readingStatus })
+        .from(books)
+        .where(and(eq(books.visibility, 'published'))),
+    ])
+    const signedUpBookIds = new Set(allSignups.map(s => s.bookId))
+    const sessionBooks = allBooks.filter(b => signedUpBookIds.has(b.id)).map(b => ({ bookId: b.id, readingStatus: b.readingStatus ?? null }))
+    scenarios = generateScenarios({
+      participants: participantUserIds.map(uid => ({ userId: uid, pseudonym: uid })),
+      books: sessionBooks,
+      signups: allSignups,
+      ranks: allRanks,
+      targetGroupSize: matchSession.targetGroupSize,
+      maxResults: 10,
+    })
+  }
+
+  return NextResponse.json({
+    personalBooks,
+    myMoves,
+    scenarios,
+    sessionStatus: matchSession.status,
+  })
+}


### PR DESCRIPTION
## Summary
- `GET /api/matching/state?session=<id>` returns personalBooks, myMoves, scenarios, sessionStatus; supports ?as= for admin impersonation
- Broadcast `state_changed` added to: POST /sessions/:id/join, POST /books, DELETE /books/:bookId, PATCH /priorities
- Broadcast `session_frozen` added to POST /sessions/:id/freeze
- 4 unit tests for state endpoint (401, 400, 404, 200)

## Test plan
- [ ] 4 unit tests pass for /api/matching/state
- [ ] On mutation, connected SSE clients receive state_changed event
- [ ] Freeze broadcasts session_frozen to all session subscribers

🤖 Generated with [Claude Code](https://claude.com/claude-code)