### PR TITLE
feat: Stories 3-3 through 3-7 — presence, SSE client, polling fallback, feed, frozen broadcast

### DIFF
--- a/app/api/matching/sessions/[id]/heartbeat/route.ts
+++ b/app/api/matching/sessions/[id]/heartbeat/route.ts
@@ -1,0 +1,48 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { matchingSessions, matchingSessionParticipants } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { touch, getOnline } from '@/lib/matching/realtime/presence'
+import { broadcast } from '@/lib/matching/realtime/hub'
+
+type Params = { params: { id: string } }
+
+export async function POST(_req: NextRequest, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const [participant] = await db
+    .select({ pseudonym: matchingSessionParticipants.pseudonym })
+    .from(matchingSessionParticipants)
+    .where(
+      and(
+        eq(matchingSessionParticipants.sessionId, params.id),
+        eq(matchingSessionParticipants.userId, session.user.id),
+      ),
+    )
+    .limit(1)
+
+  // Validate session exists
+  const [matchSession] = await db
+    .select({ id: matchingSessions.id })
+    .from(matchingSessions)
+    .where(eq(matchingSessions.id, params.id))
+    .limit(1)
+
+  if (!matchSession) return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+
+  // Only session participants get presence tracking (not impersonating admins)
+  if (participant) {
+    const prevOnline = getOnline(params.id)
+    touch(params.id, session.user.id, participant.pseudonym)
+    const newOnline = getOnline(params.id)
+    if (JSON.stringify(prevOnline.sort()) !== JSON.stringify(newOnline.sort())) {
+      broadcast(params.id, 'presence', { online: newOnline })
+    }
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/components/nd/MatchingRealtimeClient.tsx
+++ b/components/nd/MatchingRealtimeClient.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+
+interface Props {
+  sessionId: string
+  onStateChange: (data: unknown) => void
+  onPresence?: (online: string[]) => void
+  onFrozen?: (payload: unknown) => void
+}
+
+const POLL_INTERVAL_MS = 3_000
+const HEARTBEAT_INTERVAL_MS = 25_000
+const MAX_SSE_ERRORS = 3
+const SSE_BACKOFF_LIMIT_MS = 30_000
+
+export default function MatchingRealtimeClient({ sessionId, onStateChange, onPresence, onFrozen }: Props) {
+  const [mode, setMode] = useState<'sse' | 'polling'>('sse')
+  const lastEventIdRef = useRef(0)
+  const sseErrorsRef = useRef(0)
+  const sseRef = useRef<EventSource | null>(null)
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const backoffMsRef = useRef(1_000)
+
+  const fetchState = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/matching/state?session=${sessionId}`)
+      if (res.ok) {
+        const data = await res.json()
+        onStateChange(data)
+      }
+    } catch {
+      // ignore network errors on poll
+    }
+  }, [sessionId, onStateChange])
+
+  const sendHeartbeat = useCallback(async () => {
+    try {
+      await fetch(`/api/matching/sessions/${sessionId}/heartbeat`, { method: 'POST' })
+    } catch {
+      // ignore
+    }
+  }, [sessionId])
+
+  const startPolling = useCallback(() => {
+    setMode('polling')
+    if (pollTimerRef.current) clearInterval(pollTimerRef.current)
+    pollTimerRef.current = setInterval(fetchState, POLL_INTERVAL_MS)
+  }, [fetchState])
+
+  const handleSseMessage = useCallback((event: MessageEvent) => {
+    sseErrorsRef.current = 0
+    backoffMsRef.current = 1_000
+    try {
+      const data = JSON.parse(event.data) as { type: string; event_id: number; payload: unknown }
+      if (data.event_id <= lastEventIdRef.current) return
+      lastEventIdRef.current = data.event_id
+
+      if (data.type === 'state_changed') {
+        fetchState()
+      } else if (data.type === 'presence' && onPresence) {
+        onPresence(data.payload as string[])
+      } else if (data.type === 'session_frozen' && onFrozen) {
+        onFrozen(data.payload)
+      }
+    } catch {
+      // malformed event
+    }
+  }, [fetchState, onPresence, onFrozen])
+
+  const connectSSE = useCallback(() => {
+    if (sseRef.current) {
+      sseRef.current.close()
+      sseRef.current = null
+    }
+
+    const es = new EventSource(`/api/matching/stream?session=${sessionId}`)
+    sseRef.current = es
+
+    es.addEventListener('state_changed', handleSseMessage)
+    es.addEventListener('presence', handleSseMessage)
+    es.addEventListener('session_frozen', handleSseMessage)
+
+    es.onerror = () => {
+      sseErrorsRef.current++
+      if (sseErrorsRef.current >= MAX_SSE_ERRORS && backoffMsRef.current >= SSE_BACKOFF_LIMIT_MS) {
+        es.close()
+        sseRef.current = null
+        startPolling()
+      } else {
+        // exponential backoff reconnect handled by browser's EventSource
+        backoffMsRef.current = Math.min(backoffMsRef.current * 2, SSE_BACKOFF_LIMIT_MS)
+      }
+    }
+  }, [sessionId, handleSseMessage, startPolling])
+
+  useEffect(() => {
+    connectSSE()
+    fetchState()
+
+    heartbeatTimerRef.current = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS)
+    sendHeartbeat()
+
+    return () => {
+      if (sseRef.current) { sseRef.current.close(); sseRef.current = null }
+      if (pollTimerRef.current) { clearInterval(pollTimerRef.current); pollTimerRef.current = null }
+      if (heartbeatTimerRef.current) { clearInterval(heartbeatTimerRef.current); heartbeatTimerRef.current = null }
+    }
+  }, [connectSSE, fetchState, sendHeartbeat])
+
+  return (
+    <div
+      data-testid="matching-realtime-indicator"
+      aria-live="polite"
+      style={{
+        position: 'fixed',
+        bottom: 8,
+        right: 8,
+        fontSize: '0.6rem',
+        color: mode === 'sse' ? '#4a7' : '#999',
+        fontFamily: 'var(--nd-mono), monospace',
+        opacity: 0.6,
+        userSelect: 'none',
+      }}
+    >
+      {mode === 'polling' ? '⟳ синхр.' : '●'}
+    </div>
+  )
+}

--- a/lib/matching/realtime/__tests__/presence.test.ts
+++ b/lib/matching/realtime/__tests__/presence.test.ts
@@ -1,0 +1,42 @@
+import { touch, remove, getOnline } from '../presence'
+
+jest.mock('../hub', () => ({
+  broadcast: jest.fn(),
+}))
+
+describe('presence', () => {
+  const sid = 'presence-test-session'
+
+  beforeEach(() => {
+    // Clear state by removing all users
+    // Since we can't reset the module, each test uses a unique session
+  })
+
+  it('touch adds user to online set', () => {
+    const s = `${sid}-1`
+    touch(s, 'u1', 'Барсук')
+    expect(getOnline(s)).toContain('Барсук')
+  })
+
+  it('remove takes user off online set', () => {
+    const s = `${sid}-2`
+    touch(s, 'u1', 'Выдра')
+    remove(s, 'u1')
+    expect(getOnline(s)).not.toContain('Выдра')
+  })
+
+  it('multiple users all online', () => {
+    const s = `${sid}-3`
+    touch(s, 'u1', 'Лис')
+    touch(s, 'u2', 'Волк')
+    touch(s, 'u3', 'Рысь')
+    const online = getOnline(s)
+    expect(online).toContain('Лис')
+    expect(online).toContain('Волк')
+    expect(online).toContain('Рысь')
+  })
+
+  it('getOnline returns empty for unknown session', () => {
+    expect(getOnline('no-such-session-xyz')).toEqual([])
+  })
+})

--- a/lib/matching/realtime/feed.ts
+++ b/lib/matching/realtime/feed.ts
@@ -1,0 +1,40 @@
+export type FeedEventType =
+  | 'book_added_new_group'
+  | 'book_added_no_change'
+  | 'book_removed_group_disappeared'
+  | 'book_removed_no_change'
+
+export interface FeedEvent {
+  id: number
+  type: FeedEventType
+  actor: string  // pseudonym
+  bookId: string
+  ts: number
+}
+
+const BUFFER_SIZE = 100
+
+const buffers = new Map<string, FeedEvent[]>()
+const idCounters = new Map<string, number>()
+
+function nextId(sessionId: string): number {
+  const n = (idCounters.get(sessionId) ?? 0) + 1
+  idCounters.set(sessionId, n)
+  return n
+}
+
+export function appendFeed(sessionId: string, event: Omit<FeedEvent, 'id' | 'ts'>): FeedEvent {
+  let buf = buffers.get(sessionId)
+  if (!buf) {
+    buf = []
+    buffers.set(sessionId, buf)
+  }
+  const entry: FeedEvent = { ...event, id: nextId(sessionId), ts: Date.now() }
+  buf.push(entry)
+  if (buf.length > BUFFER_SIZE) buf.shift()
+  return entry
+}
+
+export function getFeed(sessionId: string): FeedEvent[] {
+  return [...(buffers.get(sessionId) ?? [])]
+}

--- a/lib/matching/realtime/presence.ts
+++ b/lib/matching/realtime/presence.ts
@@ -1,0 +1,67 @@
+import { broadcast } from './hub'
+
+const TIMEOUT_MS = 55_000
+const SWEEP_INTERVAL_MS = 10_000
+
+// Map: sessionId → Map<userId, lastSeenMs>
+const store = new Map<string, Map<string, number>>()
+// Map: sessionId → pseudonym for each userId
+const pseudonymStore = new Map<string, Map<string, string>>()
+
+let sweepTimer: ReturnType<typeof setInterval> | null = null
+
+function ensureSession(sessionId: string) {
+  if (!store.has(sessionId)) store.set(sessionId, new Map())
+  if (!pseudonymStore.has(sessionId)) pseudonymStore.set(sessionId, new Map())
+}
+
+export function touch(sessionId: string, userId: string, pseudonym: string): void {
+  ensureSession(sessionId)
+  store.get(sessionId)!.set(userId, Date.now())
+  pseudonymStore.get(sessionId)!.set(userId, pseudonym)
+  ensureSweep()
+}
+
+export function remove(sessionId: string, userId: string): void {
+  store.get(sessionId)?.delete(userId)
+  pseudonymStore.get(sessionId)?.delete(userId)
+}
+
+export function getOnline(sessionId: string): string[] {
+  const now = Date.now()
+  const sessionMap = store.get(sessionId)
+  if (!sessionMap) return []
+  const pseudonyms = pseudonymStore.get(sessionId) ?? new Map()
+  const online: string[] = []
+  for (const [uid, lastSeen] of Array.from(sessionMap.entries())) {
+    if (now - lastSeen < TIMEOUT_MS) {
+      online.push(pseudonyms.get(uid) ?? uid)
+    }
+  }
+  return online
+}
+
+function sweep() {
+  const now = Date.now()
+  for (const [sessionId, sessionMap] of Array.from(store.entries())) {
+    let changed = false
+    for (const [uid, lastSeen] of Array.from(sessionMap.entries())) {
+      if (now - lastSeen >= TIMEOUT_MS) {
+        sessionMap.delete(uid)
+        pseudonymStore.get(sessionId)?.delete(uid)
+        changed = true
+      }
+    }
+    if (changed) {
+      broadcast(sessionId, 'presence', { online: getOnline(sessionId) })
+    }
+  }
+}
+
+function ensureSweep() {
+  if (!sweepTimer) {
+    sweepTimer = setInterval(sweep, SWEEP_INTERVAL_MS)
+  }
+}
+
+export const presence = { touch, remove, getOnline }


### PR DESCRIPTION
## Summary
- **3-3**: Server-side scenario recomputation already covered by GET /api/matching/state (from Story 3-2)
- **3-4**: `lib/matching/realtime/presence.ts` — in-memory presence store; `POST /api/matching/sessions/:id/heartbeat` updates lastSeen, broadcasts `presence` event when set changes; sweep timer removes stale users (>55s silent) every 10s
- **3-5**: `MatchingRealtimeClient` component — SSE connection with polling fallback after 3 errors + backoff >30s; polls every 3s; shows ⟳ indicator in polling mode
- **3-6**: `lib/matching/realtime/feed.ts` — per-session ring buffer (100 events) with FIFO eviction; FeedEvent types: book_added_new_group/no_change/book_removed_group_disappeared/no_change
- **3-7**: `session_frozen` broadcast already added to POST /sessions/:id/freeze in Story 3-2; `MatchingRealtimeClient` handles `session_frozen` event via `onFrozen` callback

## Test plan
- [ ] 4 presence unit tests pass
- [ ] Heartbeat POST updates presence; presence broadcast sent when set changes
- [ ] SSE client falls back to polling after 3 errors with 30s+ backoff
- [ ] `session_frozen` event triggers `onFrozen` callback on all clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)