### PR TITLE
feat(matching): wire SSE realtime client to matching page (Story 4.5)

### DIFF
--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -12,6 +12,7 @@ import MatchingPersonalList from '@/components/nd/MatchingPersonalList'
 import MatchingScenarios from '@/components/nd/MatchingScenarios'
 import MatchingMyMoves from '@/components/nd/MatchingMyMoves'
 import MatchingRankNudge from '@/components/nd/MatchingRankNudge'
+import MatchingRealtimeWrapper from '@/components/nd/MatchingRealtimeWrapper'
 
 function DeadlineCountdown({ deadlineAt }: { deadlineAt: Date }) {
   const now = Date.now()
@@ -226,6 +227,8 @@ export default async function MatchingPage({
           </a>
         </section>
       )}
+
+      <MatchingRealtimeWrapper sessionId={activeSession.id} />
     </main>
   )
 }

--- a/components/nd/MatchingRealtimeWrapper.tsx
+++ b/components/nd/MatchingRealtimeWrapper.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+import MatchingRealtimeClient from './MatchingRealtimeClient'
+
+interface Props {
+  sessionId: string
+}
+
+export default function MatchingRealtimeWrapper({ sessionId }: Props) {
+  const router = useRouter()
+
+  const handleStateChange = useCallback(() => {
+    router.refresh()
+  }, [router])
+
+  const handleFrozen = useCallback(() => {
+    router.refresh()
+  }, [router])
+
+  return (
+    <MatchingRealtimeClient
+      sessionId={sessionId}
+      onStateChange={handleStateChange}
+      onFrozen={handleFrozen}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `MatchingRealtimeWrapper` client component that wraps `MatchingRealtimeClient`
- Calls `router.refresh()` on `state_changed` and `session_frozen` SSE events to re-render the server component
- Rendered for all users: participants, admins, and admins in `?as=` impersonation mode
- Admin SSE subscriptions are already silently admitted by the stream endpoint without adding admins to presence (confirmed in heartbeat route)

## Test plan
- [x] `npm run lint && npm run typecheck` — clean

E2E: не нужен — SSE wiring is infrastructure; existing presence tests cover the heartbeat/presence logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)