### PR TITLE
fix(matching): cover overflow + auto-join on page visit

### DIFF
--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -13,6 +13,7 @@ import MatchingScenarios from '@/components/nd/MatchingScenarios'
 import MatchingMyMoves from '@/components/nd/MatchingMyMoves'
 import MatchingRankNudge from '@/components/nd/MatchingRankNudge'
 import MatchingRealtimeWrapper from '@/components/nd/MatchingRealtimeWrapper'
+import { assignPseudonym } from '@/lib/matching/pseudonyms'
 
 function DeadlineCountdown({ deadlineAt }: { deadlineAt: Date }) {
   const now = Date.now()
@@ -54,6 +55,32 @@ export default async function MatchingPage({
         <p style={{ color: '#999' }}>Нет активной сессии. Создайте её в <a href="/admin?tab=matching" style={{ color: '#333' }}>Админ-панели → Матчинг</a>.</p>
       </main>
     )
+  }
+
+  // Auto-join: if not impersonating and session is active, ensure user is a participant
+  if (!isImpersonating && activeSession.status === 'active') {
+    const existing = await db
+      .select({ userId: matchingSessionParticipants.userId })
+      .from(matchingSessionParticipants)
+      .where(and(
+        eq(matchingSessionParticipants.sessionId, activeSession.id),
+        eq(matchingSessionParticipants.userId, session.user.id!),
+      ))
+      .limit(1)
+
+    if (existing.length === 0) {
+      const taken = await db
+        .select({ pseudonym: matchingSessionParticipants.pseudonym })
+        .from(matchingSessionParticipants)
+        .where(eq(matchingSessionParticipants.sessionId, activeSession.id))
+      const takenSet = new Set(taken.map(r => r.pseudonym))
+      const pseudonym = assignPseudonym(takenSet)
+      await db.insert(matchingSessionParticipants).values({
+        sessionId: activeSession.id,
+        userId: session.user.id!,
+        pseudonym,
+      }).onConflictDoNothing()
+    }
   }
 
   const [participants, personalBooks, myMoves] = await Promise.all([

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -97,7 +97,7 @@ function SortableRow({ book, index, total, frozen, onMoveUp, onMoveDown }: Sorta
         {book.rank ?? '—'}
       </span>
 
-      <div style={{ width: 32, height: 32, flexShrink: 0 }}>
+      <div style={{ width: 32, height: 32, flexShrink: 0, position: 'relative' }}>
         <CoverImage
           coverUrl={book.coverUrl}
           title={book.title}


### PR DESCRIPTION
## Summary
- **Cover bug**: `CoverImage` uses Next.js `fill` — requires `position: relative` on parent. Added it to the 32×32 wrapper in `MatchingPersonalList`.
- **Auto-join**: page now auto-inserts visiting user into `matching_session_participants` (with pseudonym) on first visit. Without this "Мои ходы" and "Сценарии" were always empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)