### PR TITLE
feat(matching): two-column dashboard redesign — warm cream palette, participant chips

### DIFF
--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -9,23 +9,13 @@ import { fetchPersonalList } from '@/lib/matching/personal-list'
 import { generateScenarios } from '@/lib/matching/scenarios'
 import { fetchMyMoves } from '@/lib/matching/my-moves'
 import MatchingPersonalList from '@/components/nd/MatchingPersonalList'
+import type { BookParticipant } from '@/components/nd/MatchingPersonalList'
 import MatchingScenarios from '@/components/nd/MatchingScenarios'
 import MatchingMyMoves from '@/components/nd/MatchingMyMoves'
 import MatchingRankNudge from '@/components/nd/MatchingRankNudge'
 import MatchingRealtimeWrapper from '@/components/nd/MatchingRealtimeWrapper'
+import MatchingHeader from '@/components/nd/MatchingHeader'
 import { assignPseudonym } from '@/lib/matching/pseudonyms'
-
-function DeadlineCountdown({ deadlineAt }: { deadlineAt: Date }) {
-  const now = Date.now()
-  const delta = deadlineAt.getTime() - now
-  if (delta <= 0) return <span style={{ color: '#c00' }}>Дедлайн истёк</span>
-  const days = Math.floor(delta / 86_400_000)
-  const hours = Math.floor((delta % 86_400_000) / 3_600_000)
-  const minutes = Math.floor((delta % 3_600_000) / 60_000)
-  if (days > 0) return <span>{days} д {hours} ч</span>
-  if (hours > 0) return <span>{hours} ч {minutes} мин</span>
-  return <span>{minutes} мин</span>
-}
 
 export default async function MatchingPage({
   searchParams,
@@ -50,9 +40,15 @@ export default async function MatchingPage({
 
   if (!activeSession) {
     return (
-      <main style={{ fontFamily: 'var(--nd-mono), monospace', padding: '2rem', maxWidth: 720, margin: '0 auto' }}>
-        <h1 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '1rem' }}>Матчинг</h1>
-        <p style={{ color: '#999' }}>Нет активной сессии. Создайте её в <a href="/admin?tab=matching" style={{ color: '#333' }}>Админ-панели → Матчинг</a>.</p>
+      <main className="font-mono p-8 max-w-2xl mx-auto">
+        <h1 className="text-lg font-semibold mb-4">Матчинг</h1>
+        <p className="text-[#999]">
+          Нет активной сессии. Создайте её в{' '}
+          <a href="/admin?tab=matching" className="text-[#333] underline">
+            Админ-панели → Матчинг
+          </a>
+          .
+        </p>
       </main>
     )
   }
@@ -62,10 +58,12 @@ export default async function MatchingPage({
     const existing = await db
       .select({ userId: matchingSessionParticipants.userId })
       .from(matchingSessionParticipants)
-      .where(and(
-        eq(matchingSessionParticipants.sessionId, activeSession.id),
-        eq(matchingSessionParticipants.userId, session.user.id!),
-      ))
+      .where(
+        and(
+          eq(matchingSessionParticipants.sessionId, activeSession.id),
+          eq(matchingSessionParticipants.userId, session.user.id!),
+        ),
+      )
       .limit(1)
 
     if (existing.length === 0) {
@@ -73,13 +71,16 @@ export default async function MatchingPage({
         .select({ pseudonym: matchingSessionParticipants.pseudonym })
         .from(matchingSessionParticipants)
         .where(eq(matchingSessionParticipants.sessionId, activeSession.id))
-      const takenSet = new Set(taken.map(r => r.pseudonym))
+      const takenSet = new Set(taken.map((r) => r.pseudonym))
       const pseudonym = assignPseudonym(takenSet)
-      await db.insert(matchingSessionParticipants).values({
-        sessionId: activeSession.id,
-        userId: session.user.id!,
-        pseudonym,
-      }).onConflictDoNothing()
+      await db
+        .insert(matchingSessionParticipants)
+        .values({
+          sessionId: activeSession.id,
+          userId: session.user.id!,
+          pseudonym,
+        })
+        .onConflictDoNothing()
     }
   }
 
@@ -99,10 +100,46 @@ export default async function MatchingPage({
     fetchMyMoves(viewingUserId, activeSession.id, activeSession.targetGroupSize),
   ])
 
-  const participantUserIds = participants.map(p => p.userId)
+  const participantUserIds = participants.map((p) => p.userId)
   const viewedParticipant = isImpersonating
-    ? participants.find(p => p.userId === asParam)
+    ? participants.find((p) => p.userId === asParam)
     : null
+
+  // Fetch per-book participant signups for chips in the personal list
+  const bookParticipants: BookParticipant[] =
+    personalBooks.length > 0 && participantUserIds.length > 0
+      ? await db
+          .select({
+            userId: signupBooks.userId,
+            bookId: signupBooks.bookId,
+            rank: bookPriorities.rank,
+          })
+          .from(signupBooks)
+          .leftJoin(
+            bookPriorities,
+            and(
+              eq(bookPriorities.userId, signupBooks.userId),
+              eq(bookPriorities.bookId, signupBooks.bookId),
+            ),
+          )
+          .where(
+            and(
+              inArray(signupBooks.bookId, personalBooks.map((b) => b.bookId)),
+              inArray(signupBooks.userId, participantUserIds),
+            ),
+          )
+          .then((rows) =>
+            rows.map((row) => {
+              const participant = participants.find((p) => p.userId === row.userId)
+              return {
+                userId: row.userId,
+                bookId: row.bookId,
+                pseudonym: participant?.pseudonym ?? row.userId,
+                rank: row.rank,
+              }
+            }),
+          )
+      : []
 
   // Fetch scenario data only when enough participants
   const scenarios =
@@ -111,182 +148,148 @@ export default async function MatchingPage({
       : []
 
   // Fetch book details for scenario cards
-  const scenarioBookIds = Array.from(new Set(scenarios.map(s => s.bookId)))
+  const scenarioBookIds = Array.from(new Set(scenarios.map((s) => s.bookId)))
   const scenarioBooks =
     scenarioBookIds.length > 0
-      ? await db.select({ id: books.id, title: books.title, author: books.author, coverUrl: books.coverUrl })
+      ? await db
+          .select({ id: books.id, title: books.title, author: books.author, coverUrl: books.coverUrl })
           .from(books)
           .where(inArray(books.id, scenarioBookIds))
       : []
-  const bookById = new Map(scenarioBooks.map(b => [b.id, b]))
+  const bookById = new Map(scenarioBooks.map((b) => [b.id, b]))
 
-  // When impersonating, list and moves are read-only
+  // Frozen or impersonating = read-only
   const isFrozenOrImpersonating = activeSession.status === 'frozen' || isImpersonating
 
   return (
-    <main style={{ fontFamily: 'var(--nd-mono), monospace', padding: '2rem', maxWidth: 720, margin: '0 auto' }}>
-      {isImpersonating && (
-        <div
-          data-testid="admin-impersonation-banner"
-          role="status"
-          style={{
-            background: '#fffbea',
-            border: '1px solid #f0d060',
-            borderRadius: 4,
-            padding: '0.6rem 1rem',
-            marginBottom: '1.5rem',
-            fontSize: '0.8rem',
-            color: '#7a5c00',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.75rem',
-          }}
-        >
-          <span>👁 Просмотр за</span>
-          <strong>{viewedParticipant?.pseudonym ?? asParam}</strong>
-          {viewedParticipant?.name && (
-            <span style={{ color: '#a07800' }}>({viewedParticipant.name})</span>
-          )}
-          <span style={{ marginLeft: 'auto', opacity: 0.7 }}>только чтение</span>
-          <a
-            href="/matching"
-            style={{ color: '#7a5c00', textDecoration: 'underline', fontSize: '0.75rem' }}
-          >
-            ← вернуться к своему виду
-          </a>
-        </div>
-      )}
+    <div className="flex flex-col bg-[#f6f2e8]" style={{ height: '100svh', overflow: 'hidden' }}>
+      <MatchingHeader
+        sessionName={activeSession.name}
+        sessionStatus={activeSession.status}
+        targetGroupSize={activeSession.targetGroupSize}
+        deadlineAt={activeSession.deadlineAt ? new Date(activeSession.deadlineAt).toISOString() : null}
+        participants={participants.map((p) => ({ userId: p.userId, pseudonym: p.pseudonym, name: p.name ?? null }))}
+        isAdmin={isAdmin}
+        isImpersonating={isImpersonating}
+        viewedPseudonym={viewedParticipant?.pseudonym ?? null}
+        viewedName={viewedParticipant?.name ?? null}
+        asParam={asParam}
+      />
 
-      <header style={{ marginBottom: '2rem' }}>
-        <h1 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.25rem' }}>
-          {activeSession.name}
-        </h1>
-        <div style={{ fontSize: '0.78rem', color: '#666', display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
-          <span>Группы по {activeSession.targetGroupSize}</span>
-          {activeSession.deadlineAt && (
-            <span>
-              Дедлайн: <DeadlineCountdown deadlineAt={new Date(activeSession.deadlineAt)} />
-            </span>
+      {/* Two-column workspace */}
+      <div
+        className="flex-1 min-h-0 p-4 gap-4 grid"
+        style={{ gridTemplateColumns: 'minmax(0, 1.4fr) minmax(0, 1fr)' }}
+      >
+        {/* Left: personal book list */}
+        <div className="flex flex-col bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_4px_24px_rgba(25,24,23,0.08)] overflow-hidden min-h-0">
+          <div className="px-4 py-3 border-b border-[#ded6c8] shrink-0">
+            <h2 className="text-base font-semibold m-0 text-[#191817]">
+              {isImpersonating ? 'Список участника' : 'Мой список'}
+            </h2>
+            {!isImpersonating && (
+              <p className="text-xs text-[#6d675f] mt-0.5 m-0">
+                Перетащи книги, чтобы расставить приоритеты
+              </p>
+            )}
+          </div>
+          {!isImpersonating && (
+            <MatchingRankNudge
+              show={personalBooks.length > 0 && personalBooks.every((b) => b.rank === null)}
+            />
           )}
-          {activeSession.status === 'frozen' ? (
-            <span style={{ color: '#888', background: '#f0f0f0', padding: '1px 8px', borderRadius: 3, fontSize: '0.72rem' }}>
-              Зафиксирована
-            </span>
-          ) : (
-            <span style={{ color: '#4a7' }}>● активна</span>
-          )}
-        </div>
-      </header>
-
-      <section>
-        <h2 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.75rem' }}>
-          Участники ({participants.length})
-        </h2>
-        {participants.length === 0 ? (
-          <p style={{ color: '#999', fontSize: '0.8rem' }}>Пока никто не присоединился.</p>
-        ) : (
-          <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
-            {participants.map(p => (
-              <li
-                key={p.userId}
-                style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', fontSize: '0.82rem' }}
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            <MatchingPersonalList
+              books={personalBooks}
+              bookParticipants={bookParticipants}
+              viewingUserId={viewingUserId}
+              frozen={isFrozenOrImpersonating}
+            />
+          </div>
+          {isAdmin && !isImpersonating && (
+            <div className="px-4 py-2.5 border-t border-[#ded6c8] shrink-0">
+              <a
+                href="/admin?tab=matching"
+                className="text-xs text-[#6d675f] underline hover:text-[#191817]"
               >
-                <span
-                  style={{
-                    background: isImpersonating && p.userId === asParam ? '#fffbea' : '#f3f3f3',
-                    border: isImpersonating && p.userId === asParam ? '1px solid #f0d060' : '1px solid transparent',
-                    padding: '2px 8px',
-                    borderRadius: 3,
-                    fontWeight: 500,
-                  }}
-                >
-                  {p.pseudonym}
-                </span>
-                {isAdmin && p.name && (
-                  <a
-                    href={`/matching?as=${p.userId}`}
-                    style={{ color: '#999', fontSize: '0.75rem', textDecoration: 'none' }}
-                    title="Посмотреть за этого участника"
-                  >
-                    {p.name}
-                  </a>
-                )}
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+                Перейти в Админ-панель → Матчинг
+              </a>
+            </div>
+          )}
+        </div>
 
-      <section style={{ marginTop: '2rem' }}>
-        <h2 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.75rem' }}>
-          {isImpersonating ? `Список участника` : `Мой список`}
-        </h2>
-        {!isImpersonating && (
-          <MatchingRankNudge
-            show={personalBooks.length > 0 && personalBooks.every(b => b.rank === null)}
-          />
-        )}
-        <MatchingPersonalList
-          books={personalBooks}
-          frozen={isFrozenOrImpersonating}
-        />
-      </section>
+        {/* Right column: scenarios + moves stacked */}
+        <div className="flex flex-col gap-4 min-h-0 overflow-hidden">
+          {/* Scenarios */}
+          <div className="flex flex-col flex-1 bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_4px_24px_rgba(25,24,23,0.08)] overflow-hidden min-h-0">
+            <div className="px-4 py-3 border-b border-[#ded6c8] shrink-0">
+              <h2
+                className="text-base font-semibold m-0 text-[#191817]"
+                title="Сортировка: макс. участников → больше топ-3 книг → ниже средний ранг"
+              >
+                Сценарии групп
+              </h2>
+            </div>
+            <div className="flex-1 min-h-0 overflow-y-auto p-3">
+              <MatchingScenarios scenarios={scenarios} bookById={bookById} />
+            </div>
+          </div>
 
-      <section style={{ marginTop: '2rem' }}>
-        <h2 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.75rem' }}>
-          {isImpersonating ? `Ходы участника` : `Мои ходы`}
-        </h2>
-        <MatchingMyMoves moves={myMoves} />
-      </section>
-
-      <section style={{ marginTop: '2rem' }}>
-        <h2 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.75rem' }}>
-          Сценарии групп
-        </h2>
-        <MatchingScenarios scenarios={scenarios} bookById={bookById} />
-      </section>
-
-      {isAdmin && !isImpersonating && (
-        <section style={{ marginTop: '2rem', paddingTop: '1.5rem', borderTop: '1px solid #eee' }}>
-          <h2 style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.5rem' }}>Управление</h2>
-          <a href="/admin?tab=matching" style={{ fontSize: '0.78rem', color: '#333', textDecoration: 'underline' }}>
-            Перейти в Админ-панель → Матчинг
-          </a>
-        </section>
-      )}
+          {/* My moves */}
+          <div className="flex flex-col flex-1 bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_4px_24px_rgba(25,24,23,0.08)] overflow-hidden min-h-0">
+            <div className="px-4 py-3 border-b border-[#ded6c8] shrink-0">
+              <h2 className="text-base font-semibold m-0 text-[#191817]">
+                {isImpersonating ? 'Ходы участника' : 'Мои ходы'}
+              </h2>
+            </div>
+            <div className="flex-1 min-h-0 overflow-y-auto p-3">
+              <MatchingMyMoves moves={myMoves} frozen={isFrozenOrImpersonating} />
+            </div>
+          </div>
+        </div>
+      </div>
 
       <MatchingRealtimeWrapper sessionId={activeSession.id} />
-    </main>
+    </div>
   )
 }
 
-async function fetchAndGenerateScenarios(participantUserIds: string[], targetGroupSize: number) {
+async function fetchAndGenerateScenarios(
+  participantUserIds: string[],
+  targetGroupSize: number,
+) {
   const [allSignups, allRanks, allBooks] = await Promise.all([
-    db.select({ userId: signupBooks.userId, bookId: signupBooks.bookId })
+    db
+      .select({ userId: signupBooks.userId, bookId: signupBooks.bookId })
       .from(signupBooks)
       .where(inArray(signupBooks.userId, participantUserIds)),
-    db.select({ userId: bookPriorities.userId, bookId: bookPriorities.bookId, rank: bookPriorities.rank })
+    db
+      .select({
+        userId: bookPriorities.userId,
+        bookId: bookPriorities.bookId,
+        rank: bookPriorities.rank,
+      })
       .from(bookPriorities)
       .where(inArray(bookPriorities.userId, participantUserIds)),
-    db.select({ id: books.id, readingStatus: books.readingStatus })
+    db
+      .select({ id: books.id, readingStatus: books.readingStatus })
       .from(books)
       .where(and(eq(books.visibility, 'published'))),
   ])
 
-  // Only include books that are signed up by at least one session participant
-  const signedUpBookIds = new Set(allSignups.map(s => s.bookId))
+  // Only include books signed up by at least one session participant
+  const signedUpBookIds = new Set(allSignups.map((s) => s.bookId))
   const sessionBooks = allBooks
-    .filter(b => signedUpBookIds.has(b.id))
-    .map(b => ({ bookId: b.id, readingStatus: b.readingStatus ?? null }))
+    .filter((b) => signedUpBookIds.has(b.id))
+    .map((b) => ({ bookId: b.id, readingStatus: b.readingStatus ?? null }))
 
-  // Build participant list from userIds (pseudonyms not needed for engine)
-  const scenarioParticipants = participantUserIds.map(userId => ({ userId, pseudonym: userId }))
+  const scenarioParticipants = participantUserIds.map((userId) => ({ userId, pseudonym: userId }))
 
   return generateScenarios({
     participants: scenarioParticipants,
     books: sessionBooks,
-    signups: allSignups.map(s => ({ userId: s.userId, bookId: s.bookId })),
-    ranks: allRanks.map(r => ({ userId: r.userId, bookId: r.bookId, rank: r.rank })),
+    signups: allSignups.map((s) => ({ userId: s.userId, bookId: s.bookId })),
+    ranks: allRanks.map((r) => ({ userId: r.userId, bookId: r.bookId, rank: r.rank })),
     targetGroupSize,
     maxResults: 10,
   })

--- a/components/nd/MatchingHeader.tsx
+++ b/components/nd/MatchingHeader.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import * as Popover from '@radix-ui/react-popover'
+
+interface Participant {
+  userId: string
+  pseudonym: string
+  name: string | null
+}
+
+interface Props {
+  sessionName: string
+  sessionStatus: string
+  targetGroupSize: number
+  deadlineAt: string | null
+  participants: Participant[]
+  isAdmin: boolean
+  isImpersonating: boolean
+  viewedPseudonym: string | null
+  viewedName: string | null
+  asParam: string | null
+}
+
+function useDeadlineText(deadlineAt: string | null): { text: string; urgent: boolean } {
+  const [state, setState] = useState({ text: '', urgent: false })
+
+  useEffect(() => {
+    if (!deadlineAt) return
+
+    function compute() {
+      const delta = new Date(deadlineAt!).getTime() - Date.now()
+      if (delta <= 0) {
+        setState({ text: 'Дедлайн истёк', urgent: true })
+        return
+      }
+      const days = Math.floor(delta / 86_400_000)
+      const hours = Math.floor((delta % 86_400_000) / 3_600_000)
+      const mins = Math.floor((delta % 3_600_000) / 60_000)
+      const urgent = delta < 3_600_000 // less than 1 hour
+      if (days > 0) setState({ text: `${days} д ${hours} ч`, urgent: false })
+      else if (hours > 0) setState({ text: `${hours} ч ${mins} мин`, urgent: false })
+      else setState({ text: `${mins} мин`, urgent })
+    }
+
+    compute()
+    const id = setInterval(compute, 60_000)
+    return () => clearInterval(id)
+  }, [deadlineAt])
+
+  return state
+}
+
+const PSEUDONYM_COLORS = [
+  'bg-[#fde8d8] text-[#7c3516]',
+  'bg-[#dcfce7] text-[#14532d]',
+  'bg-[#dbeafe] text-[#1e3a8a]',
+  'bg-[#fef9c3] text-[#713f12]',
+  'bg-[#f3e8ff] text-[#581c87]',
+  'bg-[#ffe4e6] text-[#881337]',
+  'bg-[#d1fae5] text-[#065f46]',
+  'bg-[#e0f2fe] text-[#075985]',
+]
+
+function pseudonymColor(pseudonym: string) {
+  let hash = 0
+  for (let i = 0; i < pseudonym.length; i++) hash = pseudonym.charCodeAt(i) + ((hash << 5) - hash)
+  return PSEUDONYM_COLORS[Math.abs(hash) % PSEUDONYM_COLORS.length]
+}
+
+export default function MatchingHeader({
+  sessionName,
+  sessionStatus,
+  targetGroupSize,
+  deadlineAt,
+  participants,
+  isAdmin,
+  isImpersonating,
+  viewedPseudonym,
+  viewedName,
+  asParam,
+}: Props) {
+  const { text: deadlineText, urgent } = useDeadlineText(deadlineAt)
+
+  return (
+    <>
+      {isImpersonating && (
+        <div
+          data-testid="admin-impersonation-banner"
+          role="status"
+          className="flex items-center gap-3 px-4 py-2 text-xs text-[#7a5c00] bg-[#fffbea] border-b border-[#f0d060]"
+        >
+          <span>👁 Просмотр за</span>
+          <strong>{viewedPseudonym ?? asParam}</strong>
+          {viewedName && <span className="text-[#a07800]">({viewedName})</span>}
+          <span className="ml-auto opacity-70">только чтение</span>
+          <a
+            href="/matching"
+            className="text-[#7a5c00] underline text-[11px] hover:text-[#5c4000]"
+          >
+            ← вернуться к своему виду
+          </a>
+        </div>
+      )}
+
+      <header className="flex items-center justify-between gap-4 px-4 h-14 shrink-0 border-b border-[#ded6c8] bg-[rgba(246,242,232,0.94)] backdrop-blur-sm">
+        {/* Left: session info */}
+        <div className="flex items-center gap-4 min-w-0">
+          <h1
+            className="text-xl leading-none m-0 font-medium truncate"
+            style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          >
+            {sessionName}
+          </h1>
+          <div className="hidden sm:flex items-center gap-3 text-sm text-[#6d675f] shrink-0">
+            <span>Группы по {targetGroupSize}</span>
+            {deadlineText && (
+              <span>
+                Дедлайн:{' '}
+                <span className={urgent ? 'text-red-600 font-medium' : ''}>
+                  {deadlineText}
+                </span>
+              </span>
+            )}
+            {sessionStatus === 'frozen' ? (
+              <span className="bg-[#f0f0f0] text-[#888] px-2 py-0.5 rounded text-xs">
+                Зафиксирована
+              </span>
+            ) : (
+              <span className="text-[#0f766e]">● активна</span>
+            )}
+          </div>
+        </div>
+
+        {/* Right: participants popover */}
+        <Popover.Root>
+          <Popover.Trigger asChild>
+            <button className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[#ded6c8] bg-[#fffdf8] hover:border-[#b8ad9b] hover:-translate-y-px transition-all text-sm text-[#6d675f] shrink-0">
+              <div className="flex -space-x-2">
+                {participants.slice(0, 6).map((p) => (
+                  <div
+                    key={p.userId}
+                    className={`w-6 h-6 rounded-full border-2 border-[#fffdf8] flex items-center justify-center text-[9px] font-bold ${pseudonymColor(p.pseudonym)}`}
+                    title={p.pseudonym}
+                  >
+                    {p.pseudonym[0].toUpperCase()}
+                  </div>
+                ))}
+                {participants.length > 6 && (
+                  <div className="w-6 h-6 rounded-full border-2 border-[#fffdf8] bg-[#ece4d5] flex items-center justify-center text-[9px] font-bold text-[#5c4a3a]">
+                    +{participants.length - 6}
+                  </div>
+                )}
+              </div>
+              <span className="font-medium">{participants.length}</span>
+            </button>
+          </Popover.Trigger>
+
+          <Popover.Portal>
+            <Popover.Content
+              className="z-50 bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_8px_32px_rgba(25,24,23,0.15)] p-3 min-w-[220px] max-w-[300px]"
+              sideOffset={8}
+              align="end"
+            >
+              <div className="text-xs font-semibold text-[#6d675f] mb-2.5 uppercase tracking-wide">
+                Участники ({participants.length})
+              </div>
+              <div className="flex flex-col gap-1">
+                {participants.length === 0 ? (
+                  <div className="text-sm text-[#6d675f]">Пока никто не присоединился.</div>
+                ) : (
+                  participants.map((p) => (
+                    <div key={p.userId} className="flex items-center gap-2.5 py-1">
+                      <div
+                        className={`w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 ${pseudonymColor(p.pseudonym)}`}
+                      >
+                        {p.pseudonym[0].toUpperCase()}
+                      </div>
+                      <span className="text-sm font-medium text-[#191817] flex-1">{p.pseudonym}</span>
+                      {isAdmin && p.name && (
+                        <a
+                          href={`/matching?as=${p.userId}`}
+                          className="text-xs text-[#8c7b6b] hover:text-[#5c4a3a] shrink-0"
+                          title="Посмотреть за этого участника"
+                        >
+                          {p.name}
+                        </a>
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+              <Popover.Arrow className="fill-[#ded6c8]" />
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
+      </header>
+    </>
+  )
+}

--- a/components/nd/MatchingMyMoves.tsx
+++ b/components/nd/MatchingMyMoves.tsx
@@ -6,13 +6,32 @@ import CoverImage from './CoverImage'
 
 interface Props {
   moves: MyMoveBook[]
+  frozen?: boolean
 }
 
-export default function MatchingMyMoves({ moves: initialMoves }: Props) {
+const PSEUDONYM_COLORS = [
+  'bg-[#fde8d8] text-[#7c3516]',
+  'bg-[#dcfce7] text-[#14532d]',
+  'bg-[#dbeafe] text-[#1e3a8a]',
+  'bg-[#fef9c3] text-[#713f12]',
+  'bg-[#f3e8ff] text-[#581c87]',
+  'bg-[#ffe4e6] text-[#881337]',
+  'bg-[#d1fae5] text-[#065f46]',
+  'bg-[#e0f2fe] text-[#075985]',
+]
+
+function pseudonymColor(pseudonym: string) {
+  let hash = 0
+  for (let i = 0; i < pseudonym.length; i++) hash = pseudonym.charCodeAt(i) + ((hash << 5) - hash)
+  return PSEUDONYM_COLORS[Math.abs(hash) % PSEUDONYM_COLORS.length]
+}
+
+export default function MatchingMyMoves({ moves: initialMoves, frozen = false }: Props) {
   const [moves, setMoves] = useState(initialMoves)
   const [adding, setAdding] = useState<string | null>(null)
 
   async function handleAdd(bookId: string) {
+    if (frozen) return
     setAdding(bookId)
     try {
       const res = await fetch('/api/matching/books', {
@@ -21,7 +40,7 @@ export default function MatchingMyMoves({ moves: initialMoves }: Props) {
         body: JSON.stringify({ bookId }),
       })
       if (res.ok) {
-        setMoves(prev => prev.filter(m => m.bookId !== bookId))
+        setMoves((prev) => prev.filter((m) => m.bookId !== bookId))
       }
     } finally {
       setAdding(null)
@@ -30,64 +49,54 @@ export default function MatchingMyMoves({ moves: initialMoves }: Props) {
 
   if (moves.length === 0) {
     return (
-      <p style={{ color: '#999', fontSize: '0.8rem' }}>
-        Нет книг, где ваш сигнап завершит группу.
-      </p>
+      <div className="flex flex-col items-center justify-center h-full p-6 text-center text-[#6d675f]">
+        <div className="text-3xl mb-2">✅</div>
+        <p className="text-sm">Нет книг, где ваш сигнап завершит группу.</p>
+      </div>
     )
   }
 
   return (
-    <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
-      {moves.map(move => (
+    <ul className="list-none p-0 m-0 flex flex-col gap-2.5">
+      {moves.map((move) => (
         <li
           key={move.bookId}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.75rem',
-            padding: '0.6rem 0.75rem',
-            borderRadius: 5,
-            background: '#fafff8',
-            border: '1px solid #d4ecd4',
-          }}
+          className="rounded-xl border border-[#86efac] bg-[#f0fdf4] p-3"
         >
-          <div style={{ width: 36, height: 52, flexShrink: 0 }}>
-            <CoverImage coverUrl={move.coverUrl} title={move.title} author={move.author} />
+          <div className="flex gap-3 mb-2.5">
+            <div className="relative rounded overflow-hidden shrink-0" style={{ width: 40, height: 56 }}>
+              <CoverImage coverUrl={move.coverUrl} title={move.title} author={move.author} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="font-semibold text-sm leading-snug mb-0.5 text-[#191817]" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {move.title}
+              </div>
+              <div className="text-xs text-[#6d675f] mb-1.5">{move.author}</div>
+              <div className="flex flex-wrap gap-1">
+                {move.existingParticipants.map((p) => (
+                  <span
+                    key={p.pseudonym}
+                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] ${pseudonymColor(p.pseudonym)}`}
+                  >
+                    {p.pseudonym}
+                  </span>
+                ))}
+              </div>
+            </div>
           </div>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div
-              style={{
-                fontFamily: 'var(--nd-mono), monospace',
-                fontSize: '0.82rem',
-                fontWeight: 500,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
+          {!frozen && (
+            <button
+              onClick={() => handleAdd(move.bookId)}
+              disabled={adding === move.bookId}
+              className={`w-full text-sm py-2 px-3 rounded-lg border transition-colors font-medium ${
+                adding === move.bookId
+                  ? 'bg-[#f0f0f0] border-[#ddd] text-[#999] cursor-default'
+                  : 'bg-[#0f766e] border-[#0f766e] text-white hover:bg-[#0a5c54] hover:border-[#0a5c54] cursor-pointer'
+              }`}
             >
-              {move.title}
-            </div>
-            <div style={{ fontSize: '0.7rem', color: '#888', marginTop: '0.15rem' }}>
-              Уже записаны: {move.existingParticipants.map(p => p.pseudonym).join(', ')}
-            </div>
-          </div>
-          <button
-            onClick={() => handleAdd(move.bookId)}
-            disabled={adding === move.bookId}
-            style={{
-              fontFamily: 'var(--nd-mono), monospace',
-              fontSize: '0.72rem',
-              padding: '4px 10px',
-              borderRadius: 3,
-              border: '1px solid #4a7',
-              background: adding === move.bookId ? '#eee' : '#f0faf0',
-              color: adding === move.bookId ? '#999' : '#4a7',
-              cursor: adding === move.bookId ? 'default' : 'pointer',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {adding === move.bookId ? '…' : 'Хочу читать'}
-          </button>
+              {adding === move.bookId ? '…' : 'Хочу читать'}
+            </button>
+          )}
         </li>
       ))}
     </ul>

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -22,23 +22,42 @@ import { CSS } from '@dnd-kit/utilities'
 import type { PersonalListBook } from '@/lib/matching/personal-list'
 import CoverImage from './CoverImage'
 
+export interface BookParticipant {
+  userId: string
+  bookId: string
+  pseudonym: string
+  rank: number | null
+}
+
 interface Props {
   books: PersonalListBook[]
+  bookParticipants: BookParticipant[]
+  viewingUserId: string
   frozen?: boolean
 }
 
-const interestLabel = (rank: number | null, readingStatus: string | null): string => {
+const PSEUDONYM_COLORS = [
+  { chip: 'bg-[#fde8d8] text-[#7c3516]', border: 'border-[#f8c4a0]', ring: 'ring-[#7c3516]' },
+  { chip: 'bg-[#dcfce7] text-[#14532d]', border: 'border-[#86efac]', ring: 'ring-[#14532d]' },
+  { chip: 'bg-[#dbeafe] text-[#1e3a8a]', border: 'border-[#93c5fd]', ring: 'ring-[#1e3a8a]' },
+  { chip: 'bg-[#fef9c3] text-[#713f12]', border: 'border-[#fde047]', ring: 'ring-[#713f12]' },
+  { chip: 'bg-[#f3e8ff] text-[#581c87]', border: 'border-[#d8b4fe]', ring: 'ring-[#581c87]' },
+  { chip: 'bg-[#ffe4e6] text-[#881337]', border: 'border-[#fda4af]', ring: 'ring-[#881337]' },
+  { chip: 'bg-[#d1fae5] text-[#065f46]', border: 'border-[#6ee7b7]', ring: 'ring-[#065f46]' },
+  { chip: 'bg-[#e0f2fe] text-[#075985]', border: 'border-[#7dd3fc]', ring: 'ring-[#075985]' },
+]
+
+function getPseudonymColor(pseudonym: string) {
+  let hash = 0
+  for (let i = 0; i < pseudonym.length; i++) hash = pseudonym.charCodeAt(i) + ((hash << 5) - hash)
+  return PSEUDONYM_COLORS[Math.abs(hash) % PSEUDONYM_COLORS.length]
+}
+
+function interestLabel(rank: number | null, readingStatus: string | null): string {
   if (readingStatus === 'reading') return 'читается'
   if (rank === null) return 'без ранга'
   if (rank <= 3) return 'хочу читать'
   return 'готов(а)'
-}
-
-const labelColor = (rank: number | null, readingStatus: string | null): string => {
-  if (readingStatus === 'reading') return '#888'
-  if (rank === null) return '#bbb'
-  if (rank <= 3) return '#4a7'
-  return '#999'
 }
 
 interface SortableRowProps {
@@ -46,128 +65,127 @@ interface SortableRowProps {
   index: number
   total: number
   frozen: boolean
+  chipsForBook: BookParticipant[]
+  viewingUserId: string
   onMoveUp: (bookId: string) => void
   onMoveDown: (bookId: string) => void
 }
 
-function SortableRow({ book, index, total, frozen, onMoveUp, onMoveDown }: SortableRowProps) {
+function SortableRow({
+  book,
+  index,
+  total,
+  frozen,
+  chipsForBook,
+  viewingUserId,
+  onMoveUp,
+  onMoveDown,
+}: SortableRowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: book.bookId,
     disabled: frozen || book.readingStatus === 'reading',
   })
 
-  const style: React.CSSProperties = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.75rem',
-    padding: '0.4rem 0',
-    borderBottom: '1px solid #f0f0f0',
-    opacity: isDragging ? 0.5 : book.readingStatus === 'reading' ? 0.7 : 1,
-    background: isDragging ? '#f9f9f9' : undefined,
-    cursor: frozen || book.readingStatus === 'reading' ? 'default' : 'grab',
-  }
-
   const canReorder = !frozen && book.readingStatus !== 'reading'
 
   return (
-    <li ref={setNodeRef} style={style}>
-      {canReorder && (
-        <span
-          {...attributes}
-          {...listeners}
-          aria-label={`Перетащить книгу ${book.title}`}
-          style={{ fontSize: '0.75rem', color: '#ccc', cursor: 'grab', flexShrink: 0, userSelect: 'none' }}
-        >
-          ⠿
-        </span>
-      )}
-
-      <span
-        style={{
-          fontFamily: 'var(--nd-mono), monospace',
-          fontSize: '0.7rem',
-          color: '#bbb',
-          minWidth: 18,
-          textAlign: 'right',
-          flexShrink: 0,
-        }}
-      >
-        {book.rank ?? '—'}
-      </span>
-
-      <div style={{ width: 32, height: 32, flexShrink: 0, position: 'relative' }}>
-        <CoverImage
-          coverUrl={book.coverUrl}
-          title={book.title}
-          author={book.author}
-        />
+    <li
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        display: 'grid',
+        gridTemplateColumns: '52px 1fr 90px',
+        gap: '14px',
+        padding: '14px 16px',
+        borderBottom: '1px solid #ded6c8',
+        opacity: isDragging ? 0.5 : book.readingStatus === 'reading' ? 0.7 : 1,
+        background: isDragging ? '#fff7e7' : undefined,
+        alignItems: 'start',
+      }}
+    >
+      {/* Cover with drag handle */}
+      <div style={{ position: 'relative' }}>
+        {canReorder && (
+          <button
+            {...attributes}
+            {...listeners}
+            aria-label={`Перетащить книгу ${book.title}`}
+            className="absolute text-[#ccc] cursor-grab hover:text-[#999] select-none touch-none text-lg leading-none"
+            style={{ left: -14, top: '50%', transform: 'translateY(-50%)' }}
+          >
+            ⠿
+          </button>
+        )}
+        <div className="relative rounded overflow-hidden" style={{ width: 48, height: 68 }}>
+          <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
+        </div>
       </div>
 
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div
-          style={{
-            fontFamily: 'var(--nd-mono), monospace',
-            fontSize: '0.82rem',
-            fontWeight: 500,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
+      {/* Title / author / participant chips */}
+      <div className="min-w-0">
+        <div className="font-semibold text-sm leading-snug mb-0.5 text-[#191817]" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {book.title}
         </div>
-        <div style={{ fontSize: '0.72rem', color: '#999' }}>{book.author}</div>
+        <div className="text-xs text-[#6d675f] mb-2" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {book.author}
+        </div>
+        {chipsForBook.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {chipsForBook.map((p) => {
+              const colors = getPseudonymColor(p.pseudonym)
+              const isMe = p.userId === viewingUserId
+              const label = interestLabel(p.rank, book.readingStatus)
+              const rankStr = p.rank != null ? ` #${p.rank}` : ''
+              return (
+                <span
+                  key={p.userId}
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] border ${colors.chip} ${colors.border} ${isMe ? `ring-1 ${colors.ring}` : ''}`}
+                  title={isMe ? 'Это вы' : undefined}
+                >
+                  {p.pseudonym} · {label}{rankStr}
+                </span>
+              )
+            })}
+          </div>
+        )}
       </div>
 
-      <span
-        style={{
-          fontFamily: 'var(--nd-mono), monospace',
-          fontSize: '0.68rem',
-          color: labelColor(book.rank, book.readingStatus),
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {interestLabel(book.rank, book.readingStatus)}
-      </span>
-
-      {canReorder && (
-        <span style={{ display: 'flex', flexDirection: 'column', gap: 1, flexShrink: 0 }}>
-          <button
-            onClick={() => onMoveUp(book.bookId)}
-            disabled={index === 0}
-            aria-label={`Переместить ${book.title} выше`}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: index === 0 ? 'default' : 'pointer',
-              color: index === 0 ? '#ddd' : '#999',
-              fontSize: '0.65rem',
-              padding: '1px 3px',
-              lineHeight: 1,
-            }}
-          >
-            ▲
-          </button>
-          <button
-            onClick={() => onMoveDown(book.bookId)}
-            disabled={index === total - 1}
-            aria-label={`Переместить ${book.title} ниже`}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: index === total - 1 ? 'default' : 'pointer',
-              color: index === total - 1 ? '#ddd' : '#999',
-              fontSize: '0.65rem',
-              padding: '1px 3px',
-              lineHeight: 1,
-            }}
-          >
-            ▼
-          </button>
-        </span>
-      )}
+      {/* Rank + reorder */}
+      <div className="flex flex-col items-end gap-1">
+        {book.rank != null && (
+          <span className="text-2xl font-bold leading-none text-[#191817]">#{book.rank}</span>
+        )}
+        <span className="text-[10px] text-[#6d675f]">место в списке</span>
+        {canReorder && (
+          <div className="flex flex-col gap-0.5 mt-0.5">
+            <button
+              onClick={() => onMoveUp(book.bookId)}
+              disabled={index === 0}
+              aria-label={`Переместить ${book.title} выше`}
+              className={`text-[11px] px-1.5 py-0.5 leading-none border rounded transition-colors ${
+                index === 0
+                  ? 'text-[#ddd] border-[#eee] cursor-default'
+                  : 'text-[#999] border-[#ddd] hover:text-[#555] hover:border-[#bbb] cursor-pointer'
+              }`}
+            >
+              ▲
+            </button>
+            <button
+              onClick={() => onMoveDown(book.bookId)}
+              disabled={index === total - 1}
+              aria-label={`Переместить ${book.title} ниже`}
+              className={`text-[11px] px-1.5 py-0.5 leading-none border rounded transition-colors ${
+                index === total - 1
+                  ? 'text-[#ddd] border-[#eee] cursor-default'
+                  : 'text-[#999] border-[#ddd] hover:text-[#555] hover:border-[#bbb] cursor-pointer'
+              }`}
+            >
+              ▼
+            </button>
+          </div>
+        )}
+      </div>
     </li>
   )
 }
@@ -180,7 +198,12 @@ async function patchPriorities(bookIds: string[]) {
   })
 }
 
-export default function MatchingPersonalList({ books: initialBooks, frozen = false }: Props) {
+export default function MatchingPersonalList({
+  books: initialBooks,
+  bookParticipants,
+  viewingUserId,
+  frozen = false,
+}: Props) {
   const [books, setBooks] = useState(initialBooks)
   const [announcement, setAnnouncement] = useState('')
 
@@ -191,50 +214,74 @@ export default function MatchingPersonalList({ books: initialBooks, frozen = fal
   )
 
   const applyNewOrder = useCallback(async (newBooks: PersonalListBook[]) => {
-    const rankable = newBooks.filter(b => b.readingStatus !== 'reading')
+    const rankable = newBooks.filter((b) => b.readingStatus !== 'reading')
     const ranked = rankable.map((b, i) => ({ ...b, rank: i + 1 }))
-    const updated = newBooks.map(b => {
-      const r = ranked.find(rb => rb.bookId === b.bookId)
+    const updated = newBooks.map((b) => {
+      const r = ranked.find((rb) => rb.bookId === b.bookId)
       return r ?? b
     })
     setBooks(updated)
-    await patchPriorities(rankable.map(b => b.bookId))
+    await patchPriorities(rankable.map((b) => b.bookId))
     return updated
   }, [])
 
-  const handleDragEnd = useCallback(async (event: DragEndEvent) => {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-    const oldIndex = books.findIndex(b => b.bookId === active.id)
-    const newIndex = books.findIndex(b => b.bookId === over.id)
-    const newBooks = arrayMove(books, oldIndex, newIndex)
-    await applyNewOrder(newBooks)
-    setAnnouncement(`Книга ${books[oldIndex].title} перемещена на позицию ${newIndex + 1} из ${books.filter(b => b.readingStatus !== 'reading').length}`)
-  }, [books, applyNewOrder])
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+      const oldIndex = books.findIndex((b) => b.bookId === active.id)
+      const newIndex = books.findIndex((b) => b.bookId === over.id)
+      const newBooks = arrayMove(books, oldIndex, newIndex)
+      await applyNewOrder(newBooks)
+      setAnnouncement(
+        `Книга ${books[oldIndex].title} перемещена на позицию ${newIndex + 1} из ${books.filter((b) => b.readingStatus !== 'reading').length}`,
+      )
+    },
+    [books, applyNewOrder],
+  )
 
-  const handleMoveUp = useCallback(async (bookId: string) => {
-    const index = books.findIndex(b => b.bookId === bookId)
-    if (index <= 0) return
-    const newBooks = arrayMove(books, index, index - 1)
-    await applyNewOrder(newBooks)
-    setAnnouncement(`Книга ${books[index].title} перемещена на позицию ${index} из ${books.filter(b => b.readingStatus !== 'reading').length}`)
-  }, [books, applyNewOrder])
+  const handleMoveUp = useCallback(
+    async (bookId: string) => {
+      const index = books.findIndex((b) => b.bookId === bookId)
+      if (index <= 0) return
+      const newBooks = arrayMove(books, index, index - 1)
+      await applyNewOrder(newBooks)
+      setAnnouncement(
+        `Книга ${books[index].title} перемещена на позицию ${index} из ${books.filter((b) => b.readingStatus !== 'reading').length}`,
+      )
+    },
+    [books, applyNewOrder],
+  )
 
-  const handleMoveDown = useCallback(async (bookId: string) => {
-    const index = books.findIndex(b => b.bookId === bookId)
-    if (index >= books.length - 1) return
-    const newBooks = arrayMove(books, index, index + 1)
-    await applyNewOrder(newBooks)
-    setAnnouncement(`Книга ${books[index].title} перемещена на позицию ${index + 2} из ${books.filter(b => b.readingStatus !== 'reading').length}`)
-  }, [books, applyNewOrder])
+  const handleMoveDown = useCallback(
+    async (bookId: string) => {
+      const index = books.findIndex((b) => b.bookId === bookId)
+      if (index >= books.length - 1) return
+      const newBooks = arrayMove(books, index, index + 1)
+      await applyNewOrder(newBooks)
+      setAnnouncement(
+        `Книга ${books[index].title} перемещена на позицию ${index + 2} из ${books.filter((b) => b.readingStatus !== 'reading').length}`,
+      )
+    },
+    [books, applyNewOrder],
+  )
 
   if (books.length === 0) {
     return (
-      <p style={{ color: '#999', fontSize: '0.8rem' }}>
-        Вы ещё не добавили книги. Перейдите в каталог, чтобы выбрать книги для чтения.
-      </p>
+      <div className="flex flex-col items-center justify-center h-full p-8 text-center text-[#6d675f]">
+        <div className="text-4xl mb-3">📚</div>
+        <p className="text-sm leading-relaxed">
+          Вы ещё не добавили книги.{' '}
+          <a href="/" className="underline text-[#0f766e] hover:text-[#0a5c54]">
+            Перейдите в каталог
+          </a>
+          , чтобы выбрать книги для чтения.
+        </p>
+      </div>
     )
   }
+
+  const rankableCount = books.filter((b) => b.readingStatus !== 'reading').length
 
   return (
     <>
@@ -243,31 +290,30 @@ export default function MatchingPersonalList({ books: initialBooks, frozen = fal
         aria-live="polite"
         aria-atomic="true"
         data-testid="dnd-announcement"
-        style={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0,0,0,0)' }}
+        className="absolute w-px h-px overflow-hidden"
+        style={{ clip: 'rect(0,0,0,0)' }}
       >
         {announcement}
       </div>
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext items={books.map(b => b.bookId)} strategy={verticalListSortingStrategy}>
-          <ul
-            style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
-            data-testid="matching-personal-list"
-          >
-            {books.map((book, idx) => (
-              <SortableRow
-                key={book.bookId}
-                book={book}
-                index={idx}
-                total={books.filter(b => b.readingStatus !== 'reading').length}
-                frozen={frozen}
-                onMoveUp={handleMoveUp}
-                onMoveDown={handleMoveDown}
-              />
-            ))}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={books.map((b) => b.bookId)} strategy={verticalListSortingStrategy}>
+          <ul className="list-none p-0 m-0" data-testid="matching-personal-list">
+            {books.map((book, idx) => {
+              const chipsForBook = bookParticipants.filter((p) => p.bookId === book.bookId)
+              return (
+                <SortableRow
+                  key={book.bookId}
+                  book={book}
+                  index={idx}
+                  total={rankableCount}
+                  frozen={frozen}
+                  chipsForBook={chipsForBook}
+                  viewingUserId={viewingUserId}
+                  onMoveUp={handleMoveUp}
+                  onMoveDown={handleMoveDown}
+                />
+              )
+            })}
           </ul>
         </SortableContext>
       </DndContext>

--- a/components/nd/MatchingRankNudge.tsx
+++ b/components/nd/MatchingRankNudge.tsx
@@ -45,37 +45,13 @@ export default function MatchingRankNudge({ show }: Props) {
     <div
       role="status"
       aria-live="polite"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        gap: '0.75rem',
-        padding: '0.6rem 0.75rem',
-        marginBottom: '0.75rem',
-        borderRadius: 4,
-        background: '#fffbe6',
-        border: '1px solid #f5d35e',
-        fontSize: '0.78rem',
-        fontFamily: 'var(--nd-mono), monospace',
-        color: '#7a6000',
-      }}
+      className="flex items-center justify-between gap-3 mx-4 mt-3 px-3 py-2 rounded-lg bg-[#fef9c3] border border-[#fde047] text-xs text-[#713f12]"
     >
-      <span>
-        Расставь ранги, чтобы улучшить выбор сценариев
-      </span>
+      <span>Расставь ранги, чтобы улучшить выбор сценариев</span>
       <button
         onClick={dismiss}
         aria-label="Закрыть подсказку"
-        style={{
-          background: 'none',
-          border: 'none',
-          cursor: 'pointer',
-          color: '#7a6000',
-          fontSize: '0.9rem',
-          lineHeight: 1,
-          padding: '0 2px',
-          flexShrink: 0,
-        }}
+        className="text-[#713f12] hover:text-[#422808] cursor-pointer text-base leading-none px-0.5 shrink-0"
       >
         ×
       </button>

--- a/components/nd/MatchingScenarios.tsx
+++ b/components/nd/MatchingScenarios.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import type { ScenarioCard } from '@/lib/matching/scenarios'
 import CoverImage from './CoverImage'
 
@@ -16,27 +16,42 @@ interface Props {
   bookById: Map<string, BookInfo>
 }
 
-const tierStyle = (tier: ScenarioCard['tier']): React.CSSProperties => {
-  if (tier === 'leader') return { background: '#f0faf0', border: '1px solid #b2d8b2' }
-  if (tier === 'max-coverage') return { background: '#f5f8ff', border: '1px solid #c0cff0' }
-  return { background: '#fafaf8', border: '1px solid #e8e8e4' }
-}
+const tierConfig = {
+  leader: {
+    bg: 'bg-[#f0fdf4]',
+    border: 'border-[#86efac]',
+    label: 'лидер',
+    labelClass: 'text-[#15803d] border-[#86efac]',
+  },
+  'max-coverage': {
+    bg: 'bg-[#eff6ff]',
+    border: 'border-[#93c5fd]',
+    label: 'макс. покрытие',
+    labelClass: 'text-[#1d4ed8] border-[#93c5fd]',
+  },
+  'sub-max': {
+    bg: 'bg-[#fafaf8]',
+    border: 'border-[#e8e8e4]',
+    label: null,
+    labelClass: '',
+  },
+} as const
 
-const tierLabel = (tier: ScenarioCard['tier']): string | null => {
-  if (tier === 'leader') return 'лидер'
-  if (tier === 'max-coverage') return 'макс. покрытие'
-  return null
-}
+const PSEUDONYM_COLORS = [
+  'bg-[#fde8d8] text-[#7c3516]',
+  'bg-[#dcfce7] text-[#14532d]',
+  'bg-[#dbeafe] text-[#1e3a8a]',
+  'bg-[#fef9c3] text-[#713f12]',
+  'bg-[#f3e8ff] text-[#581c87]',
+  'bg-[#ffe4e6] text-[#881337]',
+  'bg-[#d1fae5] text-[#065f46]',
+  'bg-[#e0f2fe] text-[#075985]',
+]
 
-const tierLabelColor = (tier: ScenarioCard['tier']): string => {
-  if (tier === 'leader') return '#4a7'
-  return '#6699cc'
-}
-
-const interestChipStyle = (interest: string): React.CSSProperties => {
-  if (interest === 'хочу читать') return { background: '#e8f5e8', color: '#4a7', border: '1px solid #b2d8b2' }
-  if (interest === 'готов(а)') return { background: '#f0f0f0', color: '#888', border: '1px solid #ddd' }
-  return { background: '#f9f9f9', color: '#bbb', border: '1px solid #eee' }
+function pseudonymColor(pseudonym: string) {
+  let hash = 0
+  for (let i = 0; i < pseudonym.length; i++) hash = pseudonym.charCodeAt(i) + ((hash << 5) - hash)
+  return PSEUDONYM_COLORS[Math.abs(hash) % PSEUDONYM_COLORS.length]
 }
 
 interface BookModalProps {
@@ -45,50 +60,31 @@ interface BookModalProps {
 }
 
 function BookModal({ book, onClose }: BookModalProps) {
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    document.addEventListener('keydown', handler)
-    return () => document.removeEventListener('keydown', handler)
-  }, [onClose])
-
   return (
     <div
       role="presentation"
       onClick={onClose}
-      style={{
-        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.35)',
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-        zIndex: 1000,
-      }}
+      className="fixed inset-0 bg-black/30 flex items-center justify-center z-50 p-4"
     >
       <div
         role="dialog"
         aria-modal="true"
         aria-label={book.title}
-        onClick={e => e.stopPropagation()}
-        style={{
-          background: '#fff', borderRadius: 6, padding: '1.5rem',
-          maxWidth: 380, width: '90%', fontFamily: 'var(--nd-mono), monospace',
-          boxShadow: '0 4px 24px rgba(0,0,0,0.12)',
-        }}
+        onClick={(e) => e.stopPropagation()}
+        className="bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_24px_70px_rgba(25,24,23,0.24)] p-5 max-w-[380px] w-full"
       >
-        <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
-          <div style={{ width: 56, height: 80, flexShrink: 0 }}>
+        <div className="flex gap-4 mb-4">
+          <div className="relative rounded overflow-hidden shrink-0" style={{ width: 56, height: 80 }}>
             <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
           </div>
-          <div>
-            <div style={{ fontWeight: 600, fontSize: '0.9rem', marginBottom: '0.25rem' }}>{book.title}</div>
-            <div style={{ fontSize: '0.78rem', color: '#666' }}>{book.author}</div>
+          <div className="min-w-0">
+            <div className="font-semibold text-sm leading-snug mb-1">{book.title}</div>
+            <div className="text-xs text-[#6d675f]">{book.author}</div>
           </div>
         </div>
         <button
           onClick={onClose}
-          style={{
-            marginTop: '0.5rem', fontSize: '0.78rem', color: '#999',
-            background: 'none', border: 'none', cursor: 'pointer', padding: 0,
-          }}
+          className="text-xs text-[#999] hover:text-[#555] cursor-pointer"
         >
           Закрыть (Esc)
         </button>
@@ -104,82 +100,53 @@ export default function MatchingScenarios({ scenarios, bookById }: Props) {
 
   if (scenarios.length === 0) {
     return (
-      <p style={{ color: '#999', fontSize: '0.8rem' }}>
-        Недостаточно участников или сигнапов для формирования сценариев.
-      </p>
+      <div className="flex flex-col items-center justify-center h-full p-6 text-center text-[#6d675f]">
+        <div className="text-3xl mb-2">🎯</div>
+        <p className="text-sm">Недостаточно участников или сигнапов для формирования сценариев.</p>
+      </div>
     )
   }
 
   return (
     <>
       {modalBook && <BookModal book={modalBook} onClose={closeModal} />}
-      <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      <ul className="list-none p-0 m-0 flex flex-col gap-3">
         {scenarios.map((card) => {
           const book = bookById.get(card.bookId)
-          const label = tierLabel(card.tier)
+          const tier = tierConfig[card.tier]
           return (
             <li
               key={card.bookId}
-              style={{
-                borderRadius: 5,
-                padding: '0.75rem',
-                ...tierStyle(card.tier),
-              }}
+              className={`rounded-xl border p-3.5 ${tier.bg} ${tier.border}`}
             >
-              <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.75rem' }}>
+              <div className="flex items-start gap-3">
                 {book && (
-                  <div style={{ width: 36, height: 52, flexShrink: 0 }}>
+                  <div className="relative rounded overflow-hidden shrink-0" style={{ width: 40, height: 56 }}>
                     <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
                   </div>
                 )}
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.3rem' }}>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-2 flex-wrap">
                     <button
                       onClick={() => book && openModal(book)}
-                      style={{
-                        background: 'none', border: 'none', padding: 0,
-                        fontFamily: 'var(--nd-mono), monospace',
-                        fontSize: '0.82rem', fontWeight: 600,
-                        cursor: book ? 'pointer' : 'default',
-                        textAlign: 'left',
-                        textDecoration: book ? 'underline' : 'none',
-                        color: '#222',
-                      }}
+                      className="text-sm font-semibold text-[#191817] hover:text-[#0f766e] text-left leading-snug"
                     >
                       {book?.title ?? card.bookId}
                     </button>
-                    {label && (
-                      <span
-                        style={{
-                          fontSize: '0.65rem',
-                          color: tierLabelColor(card.tier),
-                          border: `1px solid ${tierLabelColor(card.tier)}`,
-                          borderRadius: 3,
-                          padding: '1px 5px',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {label}
+                    {tier.label && (
+                      <span className={`text-[10px] border rounded-full px-2 py-0.5 shrink-0 ${tier.labelClass}`}>
+                        {tier.label}
                       </span>
                     )}
                   </div>
-                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem' }}>
-                    {card.members.map(m => (
+                  <div className="flex flex-wrap gap-1">
+                    {card.members.map((m) => (
                       <span
                         key={m.userId}
-                        style={{ display: 'flex', alignItems: 'center', gap: '0.3rem' }}
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] ${pseudonymColor(m.pseudonym)}`}
                       >
-                        <span style={{ fontSize: '0.78rem', color: '#555' }}>{m.pseudonym}</span>
-                        <span
-                          style={{
-                            fontSize: '0.6rem',
-                            padding: '1px 4px',
-                            borderRadius: 3,
-                            ...interestChipStyle(m.interest),
-                          }}
-                        >
-                          {m.interest}
-                        </span>
+                        {m.pseudonym}
+                        <span className="ml-1 opacity-70">· {m.interest}</span>
                       </span>
                     ))}
                   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@neondatabase/serverless": "^1.0.2",
+        "@radix-ui/react-popover": "^1.1.15",
         "@t3-oss/env-nextjs": "^0.13.10",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^2.0.0",
@@ -1779,6 +1780,44 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -3911,6 +3950,435 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4759,7 +5227,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -5653,6 +6121,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -7312,6 +7792,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -8968,6 +9454,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-package-type": {
@@ -15857,6 +16352,75 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -18156,6 +18720,49 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@neondatabase/serverless": "^1.0.2",
+    "@radix-ui/react-popover": "^1.1.15",
     "@t3-oss/env-nextjs": "^0.13.10",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^2.0.0",


### PR DESCRIPTION
## Summary

- **Two-column full-viewport layout**: левая панель — список книг, правая — сценарии + ходы. Страница больше не скроллится целиком, только панели внутри.
- **Warm cream palette**: фон `#f6f2e8`, карточки `#fffdf8`, граница `#ded6c8` — как в прототипе.
- **MatchingHeader** (новый): название сессии, дедлайн, статус + Radix Popover с аватарками и списком участников по клику.
- **Participant chips в книгах**: в каждой строке книжного списка — цветные чипы всех участников сессии, которые записаны на эту книгу (с рангом и меткой «хочу читать» / «готов(а)»).
- **Обложки 48×68** вместо 32×32 — лучше видно.
- Все сценарии и ходы переоформлены в карточки нового стиля.
- Импersonation-баннер перенесён в MatchingHeader.
- Добавлена зависимость `@radix-ui/react-popover`.

## Test plan

- [ ] Открыть `/matching` — должен показаться двухколоночный дашборд на кремовом фоне
- [ ] Кликнуть по ряду аватарок — должен открыться поповер со списком участников
- [ ] DnD и кнопки ▲/▼ в списке книг работают
- [ ] Чипы участников отображаются у книг, на которые записаны другие
- [ ] Кнопка «Хочу читать» в «Мои ходы» добавляет книгу и убирает карточку
- [ ] Режим `?as=userId` показывает баннер и read-only данные
- [ ] На мобильных (<1080px) интерфейс остаётся читаемым

🤖 Generated with [Claude Code](https://claude.com/claude-code)