### PR TITLE
feat: personal reading status on signup_books

### DIFF
--- a/app/api/signup-books/[bookId]/status/route.ts
+++ b/app/api/signup-books/[bookId]/status/route.ts
@@ -1,0 +1,47 @@
+export const dynamic = 'force-dynamic'
+
+import { auth } from '@/lib/auth'
+import { NextRequest, NextResponse } from 'next/server'
+import { db } from '@/lib/db'
+import { signupBooks } from '@/lib/db/schema'
+import { and, eq } from 'drizzle-orm'
+
+const VALID_STATUSES = new Set(['reading', 'read'])
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { bookId: string } },
+) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await req.json().catch(() => null)
+  const { status } = body ?? {}
+
+  if (status !== null && status !== undefined && !VALID_STATUSES.has(status)) {
+    return NextResponse.json({ error: 'Invalid status. Expected "reading", "read", or null.' }, { status: 400 })
+  }
+
+  const { bookId } = params
+  const userId = session.user.id
+
+  // Verify user is signed up for this book
+  const [signup] = await db
+    .select({ bookId: signupBooks.bookId })
+    .from(signupBooks)
+    .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
+    .limit(1)
+
+  if (!signup) {
+    return NextResponse.json({ error: 'Not signed up for this book' }, { status: 404 })
+  }
+
+  await db
+    .update(signupBooks)
+    .set({ personalStatus: status ?? null })
+    .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -113,6 +113,7 @@ export default async function MatchingPage({
             userId: signupBooks.userId,
             bookId: signupBooks.bookId,
             rank: bookPriorities.rank,
+            personalStatus: signupBooks.personalStatus,
           })
           .from(signupBooks)
           .leftJoin(
@@ -136,6 +137,7 @@ export default async function MatchingPage({
                 bookId: row.bookId,
                 pseudonym: participant?.pseudonym ?? row.userId,
                 rank: row.rank,
+                personalStatus: row.personalStatus ?? null,
               }
             }),
           )
@@ -260,7 +262,7 @@ async function fetchAndGenerateScenarios(
 ) {
   const [allSignups, allRanks, allBooks] = await Promise.all([
     db
-      .select({ userId: signupBooks.userId, bookId: signupBooks.bookId })
+      .select({ userId: signupBooks.userId, bookId: signupBooks.bookId, personalStatus: signupBooks.personalStatus })
       .from(signupBooks)
       .where(inArray(signupBooks.userId, participantUserIds)),
     db
@@ -272,23 +274,27 @@ async function fetchAndGenerateScenarios(
       .from(bookPriorities)
       .where(inArray(bookPriorities.userId, participantUserIds)),
     db
-      .select({ id: books.id, readingStatus: books.readingStatus })
+      .select({ id: books.id })
       .from(books)
-      .where(and(eq(books.visibility, 'published'))),
+      .where(eq(books.visibility, 'published')),
   ])
 
   // Only include books signed up by at least one session participant
   const signedUpBookIds = new Set(allSignups.map((s) => s.bookId))
   const sessionBooks = allBooks
     .filter((b) => signedUpBookIds.has(b.id))
-    .map((b) => ({ bookId: b.id, readingStatus: b.readingStatus ?? null }))
+    .map((b) => ({ bookId: b.id }))
+
+  // Exclude signups where the user has set a personal status (reading/read) —
+  // they are no longer available as candidates for a new group on that book.
+  const activeSignups = allSignups.filter((s) => s.personalStatus === null)
 
   const scenarioParticipants = participantUserIds.map((userId) => ({ userId, pseudonym: userId }))
 
   return generateScenarios({
     participants: scenarioParticipants,
     books: sessionBooks,
-    signups: allSignups.map((s) => ({ userId: s.userId, bookId: s.bookId })),
+    signups: activeSignups.map((s) => ({ userId: s.userId, bookId: s.bookId })),
     ranks: allRanks.map((r) => ({ userId: r.userId, bookId: r.bookId, rank: r.rank })),
     targetGroupSize,
     maxResults: 10,

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -27,6 +27,7 @@ export interface BookParticipant {
   bookId: string
   pseudonym: string
   rank: number | null
+  personalStatus: string | null
 }
 
 interface Props {
@@ -53,8 +54,9 @@ function getPseudonymColor(pseudonym: string) {
   return PSEUDONYM_COLORS[Math.abs(hash) % PSEUDONYM_COLORS.length]
 }
 
-function interestLabel(rank: number | null, readingStatus: string | null): string {
-  if (readingStatus === 'reading') return 'читается'
+function interestLabel(rank: number | null, personalStatus: string | null): string {
+  if (personalStatus === 'reading') return 'читаю'
+  if (personalStatus === 'read') return 'прочитал(а)'
   if (rank === null) return 'без ранга'
   if (rank <= 3) return 'хочу читать'
   return 'готов(а)'
@@ -69,6 +71,7 @@ interface SortableRowProps {
   viewingUserId: string
   onMoveUp: (bookId: string) => void
   onMoveDown: (bookId: string) => void
+  onStatusChange: (bookId: string, status: string | null) => void
 }
 
 function SortableRow({
@@ -80,13 +83,14 @@ function SortableRow({
   viewingUserId,
   onMoveUp,
   onMoveDown,
+  onStatusChange,
 }: SortableRowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: book.bookId,
-    disabled: frozen || book.readingStatus === 'reading',
+    disabled: frozen,
   })
 
-  const canReorder = !frozen && book.readingStatus !== 'reading'
+  const canReorder = !frozen
 
   return (
     <li
@@ -99,7 +103,7 @@ function SortableRow({
         gap: '14px',
         padding: '14px 16px',
         borderBottom: '1px solid #ded6c8',
-        opacity: isDragging ? 0.5 : book.readingStatus === 'reading' ? 0.7 : 1,
+        opacity: isDragging ? 0.5 : 1,
         background: isDragging ? '#fff7e7' : undefined,
         alignItems: 'start',
       }}
@@ -130,12 +134,23 @@ function SortableRow({
         <div className="text-xs text-[#6d675f] mb-2" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {book.author}
         </div>
+        {!frozen && (
+          <select
+            value={book.personalStatus ?? ''}
+            onChange={(e) => onStatusChange(book.bookId, e.target.value || null)}
+            className="text-[11px] border border-[#ded6c8] rounded px-1.5 py-0.5 bg-[#fafaf8] text-[#6d675f] cursor-pointer hover:border-[#bbb] mb-1.5"
+          >
+            <option value="">В списке</option>
+            <option value="reading">Читаю сейчас</option>
+            <option value="read">Прочитал(а)</option>
+          </select>
+        )}
         {chipsForBook.length > 0 && (
           <div className="flex flex-wrap gap-1">
             {chipsForBook.map((p) => {
               const colors = getPseudonymColor(p.pseudonym)
               const isMe = p.userId === viewingUserId
-              const label = interestLabel(p.rank, book.readingStatus)
+              const label = interestLabel(p.rank, p.personalStatus)
               const rankStr = p.rank != null ? ` #${p.rank}` : ''
               return (
                 <span
@@ -190,11 +205,90 @@ function SortableRow({
   )
 }
 
+interface StatusRowProps {
+  book: PersonalListBook
+  chipsForBook: BookParticipant[]
+  viewingUserId: string
+  frozen: boolean
+  onStatusChange: (bookId: string, status: string | null) => void
+}
+
+function StatusRow({ book, chipsForBook, viewingUserId, frozen, onStatusChange }: StatusRowProps) {
+  const statusLabel = book.personalStatus === 'reading' ? 'Читаю' : 'Прочитал(а)'
+  return (
+    <li
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '52px 1fr',
+        gap: '14px',
+        padding: '14px 16px',
+        borderBottom: '1px solid #ded6c8',
+        alignItems: 'start',
+        opacity: 0.75,
+      }}
+    >
+      <div style={{ position: 'relative' }}>
+        <div className="relative rounded overflow-hidden" style={{ width: 48, height: 68 }}>
+          <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
+        </div>
+      </div>
+      <div className="min-w-0">
+        <div className="font-semibold text-sm leading-snug mb-0.5 text-[#191817]" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {book.title}
+        </div>
+        <div className="text-xs text-[#6d675f] mb-2" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {book.author}
+        </div>
+        {!frozen ? (
+          <select
+            value={book.personalStatus ?? ''}
+            onChange={(e) => onStatusChange(book.bookId, e.target.value || null)}
+            className="text-[11px] border border-[#ded6c8] rounded px-1.5 py-0.5 bg-[#fafaf8] text-[#6d675f] cursor-pointer hover:border-[#bbb] mb-1.5"
+          >
+            <option value="">В списке</option>
+            <option value="reading">Читаю сейчас</option>
+            <option value="read">Прочитал(а)</option>
+          </select>
+        ) : (
+          <span className="text-[11px] text-[#999] italic mb-1.5">{statusLabel}</span>
+        )}
+        {chipsForBook.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {chipsForBook.map((p) => {
+              const colors = getPseudonymColor(p.pseudonym)
+              const isMe = p.userId === viewingUserId
+              const label = interestLabel(p.rank, p.personalStatus)
+              const rankStr = p.rank != null ? ` #${p.rank}` : ''
+              return (
+                <span
+                  key={p.userId}
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] border ${colors.chip} ${colors.border} ${isMe ? `ring-1 ${colors.ring}` : ''}`}
+                  title={isMe ? 'Это вы' : undefined}
+                >
+                  {p.pseudonym} · {label}{rankStr}
+                </span>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </li>
+  )
+}
+
 async function patchPriorities(bookIds: string[]) {
   await fetch('/api/matching/priorities', {
     method: 'PATCH',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ bookIds }),
+  })
+}
+
+async function patchStatus(bookId: string, status: string | null) {
+  await fetch(`/api/signup-books/${bookId}/status`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ status }),
   })
 }
 
@@ -213,28 +307,40 @@ export default function MatchingPersonalList({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   )
 
-  const applyNewOrder = useCallback(async (newBooks: PersonalListBook[]) => {
-    const rankable = newBooks.filter((b) => b.readingStatus !== 'reading')
-    const ranked = rankable.map((b, i) => ({ ...b, rank: i + 1 }))
-    const updated = newBooks.map((b) => {
-      const r = ranked.find((rb) => rb.bookId === b.bookId)
-      return r ?? b
+  // Re-rank all active books (personalStatus === null) and clear rank on status books
+  function rerank(updatedBooks: PersonalListBook[]): PersonalListBook[] {
+    let rankCounter = 0
+    return updatedBooks.map((b) => {
+      if (b.personalStatus === null) {
+        rankCounter++
+        return { ...b, rank: rankCounter }
+      }
+      return { ...b, rank: null }
     })
-    setBooks(updated)
-    await patchPriorities(rankable.map((b) => b.bookId))
-    return updated
+  }
+
+  const applyNewOrder = useCallback(async (newBooks: PersonalListBook[]) => {
+    const reranked = rerank(newBooks)
+    setBooks(reranked)
+    await patchPriorities(reranked.filter((b) => b.personalStatus === null).map((b) => b.bookId))
+    return reranked
   }, [])
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
       const { active, over } = event
       if (!over || active.id === over.id) return
-      const oldIndex = books.findIndex((b) => b.bookId === active.id)
-      const newIndex = books.findIndex((b) => b.bookId === over.id)
-      const newBooks = arrayMove(books, oldIndex, newIndex)
+      // Only active books are in the DnD context; find within active books
+      const activeBooks = books.filter((b) => b.personalStatus === null)
+      const oldIndex = activeBooks.findIndex((b) => b.bookId === active.id)
+      const newIndex = activeBooks.findIndex((b) => b.bookId === over.id)
+      const reorderedActive = arrayMove(activeBooks, oldIndex, newIndex)
+      // Reconstruct full list: active books (reordered) then status books
+      const statusBooks = books.filter((b) => b.personalStatus !== null)
+      const newBooks = [...reorderedActive, ...statusBooks]
       await applyNewOrder(newBooks)
       setAnnouncement(
-        `Книга ${books[oldIndex].title} перемещена на позицию ${newIndex + 1} из ${books.filter((b) => b.readingStatus !== 'reading').length}`,
+        `Книга ${activeBooks[oldIndex].title} перемещена на позицию ${newIndex + 1} из ${reorderedActive.length}`,
       )
     },
     [books, applyNewOrder],
@@ -242,12 +348,14 @@ export default function MatchingPersonalList({
 
   const handleMoveUp = useCallback(
     async (bookId: string) => {
-      const index = books.findIndex((b) => b.bookId === bookId)
+      const activeBooks = books.filter((b) => b.personalStatus === null)
+      const index = activeBooks.findIndex((b) => b.bookId === bookId)
       if (index <= 0) return
-      const newBooks = arrayMove(books, index, index - 1)
-      await applyNewOrder(newBooks)
+      const reorderedActive = arrayMove(activeBooks, index, index - 1)
+      const statusBooks = books.filter((b) => b.personalStatus !== null)
+      await applyNewOrder([...reorderedActive, ...statusBooks])
       setAnnouncement(
-        `Книга ${books[index].title} перемещена на позицию ${index} из ${books.filter((b) => b.readingStatus !== 'reading').length}`,
+        `Книга ${activeBooks[index].title} перемещена на позицию ${index} из ${reorderedActive.length}`,
       )
     },
     [books, applyNewOrder],
@@ -255,15 +363,37 @@ export default function MatchingPersonalList({
 
   const handleMoveDown = useCallback(
     async (bookId: string) => {
-      const index = books.findIndex((b) => b.bookId === bookId)
-      if (index >= books.length - 1) return
-      const newBooks = arrayMove(books, index, index + 1)
-      await applyNewOrder(newBooks)
+      const activeBooks = books.filter((b) => b.personalStatus === null)
+      const index = activeBooks.findIndex((b) => b.bookId === bookId)
+      if (index >= activeBooks.length - 1) return
+      const reorderedActive = arrayMove(activeBooks, index, index + 1)
+      const statusBooks = books.filter((b) => b.personalStatus !== null)
+      await applyNewOrder([...reorderedActive, ...statusBooks])
       setAnnouncement(
-        `Книга ${books[index].title} перемещена на позицию ${index + 2} из ${books.filter((b) => b.readingStatus !== 'reading').length}`,
+        `Книга ${activeBooks[index].title} перемещена на позицию ${index + 2} из ${reorderedActive.length}`,
       )
     },
     [books, applyNewOrder],
+  )
+
+  const handleStatusChange = useCallback(
+    async (bookId: string, newStatus: string | null) => {
+      // Optimistic update: change personalStatus, then re-rank
+      const updatedBooks = books.map((b) =>
+        b.bookId === bookId ? { ...b, personalStatus: newStatus } : b,
+      )
+      // Keep order: active books first (preserving relative order), then status books
+      const activeBooks = updatedBooks.filter((b) => b.personalStatus === null)
+      const statusBooks = updatedBooks.filter((b) => b.personalStatus !== null)
+      const reranked = rerank([...activeBooks, ...statusBooks])
+      setBooks(reranked)
+
+      await Promise.all([
+        patchStatus(bookId, newStatus),
+        patchPriorities(reranked.filter((b) => b.personalStatus === null).map((b) => b.bookId)),
+      ])
+    },
+    [books],
   )
 
   if (books.length === 0) {
@@ -281,7 +411,8 @@ export default function MatchingPersonalList({
     )
   }
 
-  const rankableCount = books.filter((b) => b.readingStatus !== 'reading').length
+  const activeBooks = books.filter((b) => b.personalStatus === null)
+  const statusBooks = books.filter((b) => b.personalStatus !== null)
 
   return (
     <>
@@ -295,28 +426,58 @@ export default function MatchingPersonalList({
       >
         {announcement}
       </div>
+
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext items={books.map((b) => b.bookId)} strategy={verticalListSortingStrategy}>
+        <SortableContext
+          items={activeBooks.map((b) => b.bookId)}
+          strategy={verticalListSortingStrategy}
+        >
           <ul className="list-none p-0 m-0" data-testid="matching-personal-list">
-            {books.map((book, idx) => {
+            {activeBooks.map((book, idx) => {
               const chipsForBook = bookParticipants.filter((p) => p.bookId === book.bookId)
               return (
                 <SortableRow
                   key={book.bookId}
                   book={book}
                   index={idx}
-                  total={rankableCount}
+                  total={activeBooks.length}
                   frozen={frozen}
                   chipsForBook={chipsForBook}
                   viewingUserId={viewingUserId}
                   onMoveUp={handleMoveUp}
                   onMoveDown={handleMoveDown}
+                  onStatusChange={handleStatusChange}
                 />
               )
             })}
           </ul>
         </SortableContext>
       </DndContext>
+
+      {statusBooks.length > 0 && (
+        <>
+          <div className="px-4 py-2 border-b border-[#ded6c8] border-t bg-[#f6f2e8]">
+            <span className="text-[11px] font-medium text-[#999] uppercase tracking-wide">
+              В процессе / Прочитано
+            </span>
+          </div>
+          <ul className="list-none p-0 m-0">
+            {statusBooks.map((book) => {
+              const chipsForBook = bookParticipants.filter((p) => p.bookId === book.bookId)
+              return (
+                <StatusRow
+                  key={book.bookId}
+                  book={book}
+                  chipsForBook={chipsForBook}
+                  viewingUserId={viewingUserId}
+                  frozen={frozen}
+                  onStatusChange={handleStatusChange}
+                />
+              )
+            })}
+          </ul>
+        </>
+      )}
     </>
   )
 }

--- a/drizzle/0031_signup_books_personal_status.sql
+++ b/drizzle/0031_signup_books_personal_status.sql
@@ -1,0 +1,5 @@
+-- Add personal_status to signup_books so users can track their reading progress.
+-- Values: 'reading' (actively reading), 'read' (finished).
+-- NULL means "signed up but no personal status" — this is the normal state for matching candidates.
+ALTER TABLE signup_books
+  ADD COLUMN personal_status TEXT CHECK(personal_status IN ('reading', 'read'));

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -127,9 +127,10 @@ export const bookPriorities = pgTable('book_priorities', {
 }))
 
 export const signupBooks = pgTable('signup_books', {
-  userId:   text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-  bookId:   text('book_id').notNull().references(() => books.id, { onDelete: 'cascade' }),
-  signedAt: timestamp('signed_at', { mode: 'date' }).notNull().defaultNow(),
+  userId:         text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  bookId:         text('book_id').notNull().references(() => books.id, { onDelete: 'cascade' }),
+  signedAt:       timestamp('signed_at', { mode: 'date' }).notNull().defaultNow(),
+  personalStatus: text('personal_status'), // null | 'reading' | 'read'
 }, (t) => ({
   pk: primaryKey({ columns: [t.userId, t.bookId] }),
 }))

--- a/lib/matching/__tests__/scenarios.test.ts
+++ b/lib/matching/__tests__/scenarios.test.ts
@@ -5,8 +5,8 @@ function makeParticipants(n: number) {
   return Array.from({ length: n }, (_, i) => ({ userId: `u${i + 1}`, pseudonym: `Участник${i + 1}` }))
 }
 
-function makeBook(bookId: string, readingStatus: string | null = null) {
-  return { bookId, readingStatus }
+function makeBook(bookId: string) {
+  return { bookId }
 }
 
 function allSignedUp(userIds: string[], bookId: string) {
@@ -43,15 +43,17 @@ describe('generateScenarios', () => {
     expect(result).toEqual([])
   })
 
-  it('excludes books with reading_status=reading', () => {
+  it('includes books regardless of global reading_status (filtering is upstream concern)', () => {
+    // The engine no longer filters by readingStatus — callers filter signups by personalStatus before passing in.
     const result = generateScenarios({
       participants,
-      books: [makeBook('b1', 'reading')],
+      books: [makeBook('b1')],
       signups: allSignedUp(userIds, 'b1'),
       ranks: rankAll(userIds, 'b1', 1),
       targetGroupSize: 3,
     })
-    expect(result).toEqual([])
+    expect(result).toHaveLength(1)
+    expect(result[0].bookId).toBe('b1')
   })
 
   it('excludes books without enough signups', () => {

--- a/lib/matching/my-moves.ts
+++ b/lib/matching/my-moves.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/db'
 import { signupBooks, books, matchingSessionParticipants } from '@/lib/db/schema'
-import { eq, and, inArray, notInArray } from 'drizzle-orm'
+import { eq, and, inArray, notInArray, isNull } from 'drizzle-orm'
 
 export interface MyMoveBook {
   bookId: string
@@ -37,7 +37,9 @@ export async function fetchMyMoves(
     .where(eq(signupBooks.userId, userId))
   const myBookIds = mySignups.map(s => s.bookId)
 
-  // Get signups from other participants for books the current user hasn't joined
+  // Get signups from other participants for books the current user hasn't joined.
+  // Exclude signups with a personal_status set (reading/read) — those users are no longer
+  // available as matching candidates for a new group on that book.
   const otherSignups = myBookIds.length > 0
     ? await db
         .select({ userId: signupBooks.userId, bookId: signupBooks.bookId })
@@ -46,12 +48,18 @@ export async function fetchMyMoves(
           and(
             inArray(signupBooks.userId, otherUserIds),
             notInArray(signupBooks.bookId, myBookIds),
+            isNull(signupBooks.personalStatus),
           ),
         )
     : await db
         .select({ userId: signupBooks.userId, bookId: signupBooks.bookId })
         .from(signupBooks)
-        .where(inArray(signupBooks.userId, otherUserIds))
+        .where(
+          and(
+            inArray(signupBooks.userId, otherUserIds),
+            isNull(signupBooks.personalStatus),
+          ),
+        )
 
   // Group by bookId: find books with exactly targetGroupSize-1 other participants signed up
   const countByBook = new Map<string, string[]>()

--- a/lib/matching/personal-list.ts
+++ b/lib/matching/personal-list.ts
@@ -9,6 +9,7 @@ export interface PersonalListBook {
   coverUrl: string | null
   readingStatus: string | null
   rank: number | null
+  personalStatus: string | null
 }
 
 export async function fetchPersonalList(userId: string): Promise<PersonalListBook[]> {
@@ -20,6 +21,7 @@ export async function fetchPersonalList(userId: string): Promise<PersonalListBoo
       coverUrl: books.coverUrl,
       readingStatus: books.readingStatus,
       rank: bookPriorities.rank,
+      personalStatus: signupBooks.personalStatus,
     })
     .from(signupBooks)
     .innerJoin(books, eq(books.id, signupBooks.bookId))

--- a/lib/matching/scenarios.ts
+++ b/lib/matching/scenarios.ts
@@ -5,7 +5,6 @@ export interface ScenarioParticipant {
 
 export interface ScenarioBook {
   bookId: string
-  readingStatus: string | null
 }
 
 export interface ScenarioSignup {
@@ -158,9 +157,9 @@ export function generateScenarios(input: GenerateScenariosInput): ScenarioCard[]
     signupsByBook.set(s.bookId, arr)
   }
 
-  // Candidate books: not reading, have ≥ targetGroupSize signups
+  // Candidate books: have ≥ targetGroupSize signups
+  // Note: personal status filtering (reading/read) happens upstream at the call site.
   const candidateBookIds = books
-    .filter(b => b.readingStatus !== 'reading')
     .map(b => b.bookId)
     .filter(bookId => (signupsByBook.get(bookId)?.length ?? 0) >= targetGroupSize)
 

--- a/lib/signup-books.ts
+++ b/lib/signup-books.ts
@@ -96,14 +96,31 @@ async function upsertResolvedSignup(userId: string, selectedBooks: SignupBookInp
   const unique = new Map<string, SignupBookInput>()
   for (const book of selectedBooks) unique.set(book.id, book)
   const normalized = Array.from(unique.values())
+  const newBookIds = normalized.map(b => b.id)
 
   await db.transaction(async (tx) => {
-    await tx.delete(signupBooks).where(eq(signupBooks.userId, userId))
+    // Fetch current signups to determine what changed
+    const existing = await tx
+      .select({ bookId: signupBooks.bookId })
+      .from(signupBooks)
+      .where(eq(signupBooks.userId, userId))
 
-    if (normalized.length > 0) {
+    const existingIds = new Set(existing.map(e => e.bookId))
+    const toDelete = Array.from(existingIds).filter(id => !newBookIds.includes(id))
+    const toAdd = newBookIds.filter(id => !existingIds.has(id))
+
+    // Delete only removed books (preserves personal_status on remaining rows)
+    if (toDelete.length > 0) {
+      await tx
+        .delete(signupBooks)
+        .where(and(eq(signupBooks.userId, userId), inArray(signupBooks.bookId, toDelete)))
+    }
+
+    // Insert only newly-added books
+    if (toAdd.length > 0) {
       await tx
         .insert(signupBooks)
-        .values(normalized.map(book => ({ userId, bookId: book.id })))
+        .values(toAdd.map(bookId => ({ userId, bookId })))
         .onConflictDoNothing()
     }
   })


### PR DESCRIPTION
## Summary

- Adds `personal_status TEXT ('reading' | 'read' | NULL)` column to `signup_books` via migration `0031`
- Matching engine no longer filters by global `books.reading_status` — filtering is now per-user based on `signup_books.personal_status`
- Status dropdown added to each book row in **Мой список**: «В списке» / «Читаю сейчас» / «Прочитал(а)»
- Books with a status move to a separate «В процессе / Прочитано» section below the ranked list
- `PATCH /api/signup-books/[bookId]/status` endpoint for setting the status
- `upsertSignupByBookIds` now does selective insert/delete instead of full DELETE+INSERT, preserving `personal_status`
- `my-moves.ts` excludes signups with `personal_status IS NOT NULL` from group formation count
- Participant chips now show «читаю» / «прочитал(а)» labels when appropriate

## Test plan
- [ ] Run `npm test` — all unit tests pass
- [ ] Visit `/matching`, confirm books appear with status dropdowns
- [ ] Change a book to «Читаю сейчас» — it moves to the bottom section, rank updates, scenarios recalculate
- [ ] Change back to «В списке» — book returns to ranked section
- [ ] Confirm migration runs: `personal_status` column appears in `signup_books`

🤖 Generated with [Claude Code](https://claude.com/claude-code)