### PR TITLE
feat(catalog): personalStatus на карточках — reading/read → мягкая метка

### DIFF
--- a/components/nd/BookCard.tsx
+++ b/components/nd/BookCard.tsx
@@ -2,12 +2,14 @@
 
 import { useEffect, useRef, useState } from 'react'
 import type { BookWithCover } from '@/lib/books-with-covers'
+import type { PersonalBookStatus } from '@/lib/signup-books'
 import CoverImage from './CoverImage'
 
 interface Props {
   book: BookWithCover
   isSelected: boolean
   onToggle: (book: BookWithCover) => void
+  personalStatus?: PersonalBookStatus | null
 }
 
 function extractYear(date: string): string {
@@ -35,7 +37,7 @@ function parseRecommendationLink(raw: string): { text: string; url: string } | n
   return { text, url }
 }
 
-export default function BookCard({ book, isSelected, onToggle }: Props) {
+export default function BookCard({ book, isSelected, onToggle, personalStatus }: Props) {
   const year = extractYear(book.date)
   const [descExpanded, setDescExpanded] = useState(false)
   const [descHovered, setDescHovered] = useState(false)
@@ -488,28 +490,48 @@ export default function BookCard({ book, isSelected, onToggle }: Props) {
       {/* Spacer */}
       <div style={{ flex: 1 }} />
 
-      {/* Toggle button */}
+      {/* Toggle button / personal status label */}
       <div style={{ padding: '0.75rem' }}>
-        <button
-          onClick={() => onToggle(book)}
-          aria-pressed={isSelected}
-          style={{
-            display: 'block',
-            width: '100%',
-            padding: '0.5rem 1rem',
-            fontFamily: 'var(--nd-sans), system-ui, sans-serif',
-            fontSize: '0.7rem',
-            textTransform: 'uppercase',
-            letterSpacing: '0.08em',
-            cursor: 'pointer',
-            border: '1px solid #111',
-            background: isSelected ? '#111' : 'transparent',
-            color: isSelected ? '#fff' : '#111',
-            transition: 'background 0.15s, color 0.15s',
-          }}
-        >
-          {isSelected ? '✓ Вы записаны' : 'Хочу читать'}
-        </button>
+        {personalStatus === 'reading' || personalStatus === 'read' ? (
+          <div
+            style={{
+              display: 'block',
+              width: '100%',
+              padding: '0.5rem 1rem',
+              fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+              fontSize: '0.7rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              border: '1px solid #D0D0D0',
+              color: '#999',
+              textAlign: 'center',
+              boxSizing: 'border-box',
+            }}
+          >
+            {personalStatus === 'reading' ? 'Читаю сейчас' : 'Прочитал:а'}
+          </div>
+        ) : (
+          <button
+            onClick={() => onToggle(book)}
+            aria-pressed={isSelected}
+            style={{
+              display: 'block',
+              width: '100%',
+              padding: '0.5rem 1rem',
+              fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+              fontSize: '0.7rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              cursor: 'pointer',
+              border: '1px solid #111',
+              background: isSelected ? '#111' : 'transparent',
+              color: isSelected ? '#fff' : '#111',
+              transition: 'background 0.15s, color 0.15s',
+            }}
+          >
+            {isSelected ? '✓ Вы записаны' : 'Хочу читать'}
+          </button>
+        )}
       </div>
     </article>
   )

--- a/components/nd/BookRow.tsx
+++ b/components/nd/BookRow.tsx
@@ -2,11 +2,13 @@
 
 import { useState } from 'react'
 import type { BookWithCover } from '@/lib/books-with-covers'
+import type { PersonalBookStatus } from '@/lib/signup-books'
 
 interface Props {
   book: BookWithCover
   isSelected: boolean
   onToggle: (book: BookWithCover) => void
+  personalStatus?: PersonalBookStatus | null
 }
 
 function extractYear(date: string): string {
@@ -26,7 +28,7 @@ function formatSignupCount(n: number): string {
 const sans = 'var(--nd-sans), system-ui, sans-serif'
 const serif = 'var(--nd-serif), Georgia, serif'
 
-export default function BookRow({ book, isSelected, onToggle }: Props) {
+export default function BookRow({ book, isSelected, onToggle, personalStatus }: Props) {
   const [hovered, setHovered] = useState(false)
   const [signupTooltip, setSignupTooltip] = useState(false)
   const isReading = book.status === 'reading'
@@ -127,27 +129,45 @@ export default function BookRow({ book, isSelected, onToggle }: Props) {
         )}
       </td>
 
-      {/* Button */}
+      {/* Button / personal status label */}
       <td style={{ padding: '0.6rem 0.75rem', verticalAlign: 'middle', textAlign: 'right' }}>
-        <button
-          onClick={() => onToggle(book)}
-          aria-pressed={isSelected}
-          style={{
-            padding: '0.3rem 0.75rem',
-            fontFamily: sans,
-            fontSize: '0.65rem',
-            textTransform: 'uppercase',
-            letterSpacing: '0.08em',
-            cursor: 'pointer',
-            border: '1px solid #111',
-            background: isSelected ? '#111' : 'transparent',
-            color: isSelected ? '#fff' : '#111',
-            whiteSpace: 'nowrap',
-            transition: 'background 0.15s, color 0.15s',
-          }}
-        >
-          {isSelected ? '✓ Вы записаны' : 'Хочу читать'}
-        </button>
+        {personalStatus === 'reading' || personalStatus === 'read' ? (
+          <span
+            style={{
+              display: 'inline-block',
+              padding: '0.3rem 0.75rem',
+              fontFamily: sans,
+              fontSize: '0.65rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              border: '1px solid #D0D0D0',
+              color: '#999',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {personalStatus === 'reading' ? 'Читаю сейчас' : 'Прочитал:а'}
+          </span>
+        ) : (
+          <button
+            onClick={() => onToggle(book)}
+            aria-pressed={isSelected}
+            style={{
+              padding: '0.3rem 0.75rem',
+              fontFamily: sans,
+              fontSize: '0.65rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              cursor: 'pointer',
+              border: '1px solid #111',
+              background: isSelected ? '#111' : 'transparent',
+              color: isSelected ? '#fff' : '#111',
+              whiteSpace: 'nowrap',
+              transition: 'background 0.15s, color 0.15s',
+            }}
+          >
+            {isSelected ? '✓ Вы записаны' : 'Хочу читать'}
+          </button>
+        )}
       </td>
     </tr>
   )

--- a/components/nd/BooksPage.tsx
+++ b/components/nd/BooksPage.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useEffect, useRef } from 'react'
 import { flushSync } from 'react-dom'
 import { useSession, signOut } from 'next-auth/react'
 import type { BookWithCover } from '@/lib/books-with-covers'
-import type { UserSignup } from '@/lib/signup-books'
+import type { UserSignup, PersonalBookStatus } from '@/lib/signup-books'
 import { searchBooks } from '@/lib/search'
 import { bookMatchesAuthor, getUniqueAuthors } from '@/lib/authors'
 import Header from './Header'
@@ -202,6 +202,16 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
 
   const hasReadBooks = useMemo(() => books.some(b => b.status === 'read'), [books])
   const hasNewBooks = useMemo(() => books.some(b => b.isNew), [books])
+
+  // Per-book personal reading status from SSR (reflects state at page load).
+  // reading/read → catalog shows a soft label instead of the signup toggle.
+  const personalStatusMap = useMemo(() => {
+    const map = new Map<string, PersonalBookStatus>()
+    for (const s of (currentUser?.signups ?? [])) {
+      if (s.personalStatus) map.set(s.bookId, s.personalStatus)
+    }
+    return map
+  }, [currentUser?.signups])
 
   function handleToggle(book: BookWithCover) {
     if (!isLoggedIn) {
@@ -471,7 +481,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: '1.5rem' }}>
             <SubmitBookCard onClick={handleSubmitBookClick} />
             {filteredBooks.map(book => (
-              <BookCard key={book.id} book={book} isSelected={selectedBooks.includes(book.id)} onToggle={handleToggle} />
+              <BookCard key={book.id} book={book} isSelected={selectedBooks.includes(book.id)} onToggle={handleToggle} personalStatus={personalStatusMap.get(book.id) ?? null} />
             ))}
           </div>
         ) : (
@@ -498,7 +508,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
                 </td>
               </tr>
               {filteredBooks.map(book => (
-                <BookRow key={book.id} book={book} isSelected={selectedBooks.includes(book.id)} onToggle={handleToggle} />
+                <BookRow key={book.id} book={book} isSelected={selectedBooks.includes(book.id)} onToggle={handleToggle} personalStatus={personalStatusMap.get(book.id) ?? null} />
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
## Summary

- Когда `personal_status = 'reading'`: кнопка «Хочу читать» заменяется меткой **«Читаю сейчас»** (рамка #D0D0D0, цвет #999)
- Когда `personal_status = 'read'`: метка **«Прочитал:а»** в том же стиле
- При `personalStatus = null` (или не задан): поведение прежнее — toggle «Хочу читать» / «✓ Вы записаны»
- Работает в обоих режимах отображения: карточки (`BookCard`) и список (`BookRow`)
- Статус читается из SSR (`currentUser.signups`), отражает состояние на момент загрузки

## Test plan

- [ ] `npm run lint && npm run typecheck && npm test` — зелёный
- [ ] CI (E2E + build) — зелёный
- [ ] Ручная проверка: залогиниться, пометить книгу «Читаю» в профиле, обновить страницу — кнопка заменилась меткой

🤖 Generated with [Claude Code](https://claude.com/claude-code)