### PR TITLE
ci: вынести E2E из merge-gate в отдельный nightly-workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,122 +60,16 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  # ── 2. E2E (Playwright) ───────────────────────────────────────────────────
-  e2e:
-    runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium --with-deps
-
-      # Если браузер взят из кэша, системные зависимости всё равно нужны
-      # (они не кэшируются), но install-deps без загрузки браузера — быстро.
-      - name: Install Playwright system deps (from cache)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
-
-      # Синхронизируем схему e2e Neon-ветки с текущим schema.ts.
-      # Используем push (не migrate): ветка создана через Neon branching,
-      # поэтому __drizzle_migrations там нет — migrate пытается накатить
-      # все миграции с нуля и падает на уже существующих таблицах.
-      # push сравнивает schema.ts с реальной БД и применяет только дельту.
-      - name: Sync DB schema (e2e branch)
-        run: npx drizzle-kit push --force
-        env:
-          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
-          SKIP_ENV_VALIDATION: 'true'
-
-      # Production-сборка для E2E. Playwright на CI поднимает `next start`
-      # (см. playwright.config.ts → webServer), которому нужен готовый .next.
-      # Раньше E2E ходили в `next dev` — ленивая компиляция роутов давала
-      # медленный первый хит каждой страницы и флак (useContext null →
-      # таймаут → ретрай за 15s). Прекомпилированный билд убирает обе боли.
-      # Билдим с e2e-DB и маркерами (НЕ прод), чтобы любые build-time
-      # обращения к данным шли в изолированную Neon-ветку.
-      - name: Build app for E2E (production server)
-        run: npm run build
-        env:
-          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
-          PROD_DB_HOST_MARKER: ${{ secrets.PROD_DB_HOST_MARKER }}
-          E2E_REQUIRE_DB_MARKER: ${{ secrets.E2E_REQUIRE_DB_MARKER }}
-          AUTH_SECRET: 'e2e-test-secret-only-used-for-signing-test-sessions'
-          NEXTAUTH_TEST_MODE: 'true'
-          NEXT_PUBLIC_DISABLE_ANALYTICS: 'true'
-          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
-          GOOGLE_SHEETS_ID: ${{ secrets.GOOGLE_SHEETS_ID }}
-          SKIP_ENV_VALIDATION: 'true'
-
-      - name: Get Allure history from gh-pages
-        uses: actions/checkout@v5
-        if: always()
-        continue-on-error: true
-        with:
-          ref: gh-pages
-          path: gh-pages
-
-      - name: E2E tests
-        run: npm run test:e2e
-        env:
-          # E2E job бьёт в изолированную Neon-ветку `e2e`, НЕ в прод.
-          # Guard в lib/test-mode.ts отказывается работать, если DATABASE_URL
-          # содержит PROD_DB_HOST_MARKER или не содержит E2E_REQUIRE_DB_MARKER.
-          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
-          PROD_DB_HOST_MARKER: ${{ secrets.PROD_DB_HOST_MARKER }}
-          E2E_REQUIRE_DB_MARKER: ${{ secrets.E2E_REQUIRE_DB_MARKER }}
-          AUTH_SECRET: 'e2e-test-secret-only-used-for-signing-test-sessions'
-          NEXTAUTH_TEST_MODE: 'true'
-          NEXTAUTH_URL: 'http://localhost:3000'
-          # Production-сервер (next start) ⇒ NODE_ENV=production. Флаги
-          # E2E_ALLOW_PRODUCTION_SERVER + AUTH_TRUST_HOST инжектятся прямо в
-          # env сервера через playwright.config.ts (webServer.env, ветка CI) —
-          # единый источник правды. Прод-БД защищена маркерами ниже.
-          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
-          GOOGLE_SHEETS_ID: ${{ secrets.GOOGLE_SHEETS_ID }}
-          SKIP_ENV_VALIDATION: 'true'
-
-      - name: Install Allure CLI
-        if: always()
-        run: npm install -g allure-commandline
-
-      - name: Restore Allure history
-        if: always()
-        run: cp -r gh-pages/history allure-results/history 2>/dev/null || true
-
-      - name: Generate Allure report
-        if: always()
-        run: allure generate allure-results --clean -o allure-report
-
-      - name: Publish Allure report to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        if: always()
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: allure-report
-
-  # ── 3. Next.js build ──────────────────────────────────────────────────────
+  # ── 2. Next.js build ──────────────────────────────────────────────────────
+  #
+  # E2E (Playwright) больше НЕ часть merge-gate. Они вынесены в отдельный
+  # workflow .github/workflows/e2e-nightly.yml, который бежит по расписанию
+  # (cron) и по ручному запуску — НЕ на push/PR. Причина: e2e-job платит
+  # ~100s фиксированного оверхеда (install + браузеры + schema + build) и
+  # ~270s на сами тесты, что держало мерж 6-7 минут. Для домашнего проекта с
+  # парой пользователей это не оправдано: быстрый gate (lint/typecheck/unit/
+  # build, ~80s) ловит «не собирается / битый тип / утёк секрет», а E2E ловит
+  # регрессии сценариев ночью, постфактум — чиним форвардом.
   build:
     runs-on: ubuntu-latest
     env:
@@ -207,17 +101,15 @@ jobs:
 
   # ── Gate: branch protection требует check с именем "ci" ───────────────────
   ci:
-    needs: [quality, e2e, build]
+    needs: [quality, build]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: All jobs passed
         run: |
           if [[ "${{ needs.quality.result }}" != "success" || \
-                "${{ needs.e2e.result }}"    != "success" || \
                 "${{ needs.build.result }}"  != "success" ]]; then
             echo "quality=${{ needs.quality.result }}"
-            echo "e2e=${{ needs.e2e.result }}"
             echo "build=${{ needs.build.result }}"
             exit 1
           fi

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,134 @@
+name: E2E (nightly)
+
+# E2E НЕ блокируют мерж. Они вынесены из merge-gate (CI workflow) и бегут:
+#   - по расписанию (cron) — раз в сутки ночью по main;
+#   - вручную через кнопку «Run workflow» (workflow_dispatch).
+# НИКАКИХ push/pull_request триггеров: днём фичи летят в прод без ожидания
+# E2E. Если ночной прогон красный — GitHub шлёт уведомление, чиним форвардом.
+#
+# Запускается всегда на актуальном main (default branch), берёт изолированную
+# Neon-ветку `e2e` (НЕ прод) через секреты ниже.
+on:
+  schedule:
+    # 00:00 UTC = 03:00 МСК. Поменять час — поправить эту строку (cron в UTC).
+    - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+# Параллельные ночные/ручные прогоны не нужны — отменяем предыдущий.
+concurrency:
+  group: e2e-nightly
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      # Если браузер взят из кэша, системные зависимости всё равно нужны
+      # (они не кэшируются), но install-deps без загрузки браузера — быстро.
+      - name: Install Playwright system deps (from cache)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      # Синхронизируем схему e2e Neon-ветки с текущим schema.ts.
+      # Используем push (не migrate): ветка создана через Neon branching,
+      # поэтому __drizzle_migrations там нет — migrate пытается накатить
+      # все миграции с нуля и падает на уже существующих таблицах.
+      # push сравнивает schema.ts с реальной БД и применяет только дельту.
+      - name: Sync DB schema (e2e branch)
+        run: npx drizzle-kit push --force
+        env:
+          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+          SKIP_ENV_VALIDATION: 'true'
+
+      # Production-сборка для E2E. Playwright поднимает `next start`
+      # (см. playwright.config.ts → webServer), которому нужен готовый .next.
+      # `next dev` компилировал роуты лениво → медленный первый хит + флак
+      # (useContext null → таймаут → ретрай). Прекомпилированный билд убирает
+      # обе боли. Билдим с e2e-DB и маркерами (НЕ прод), чтобы любые build-time
+      # обращения к данным шли в изолированную Neon-ветку.
+      - name: Build app for E2E (production server)
+        run: npm run build
+        env:
+          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+          PROD_DB_HOST_MARKER: ${{ secrets.PROD_DB_HOST_MARKER }}
+          E2E_REQUIRE_DB_MARKER: ${{ secrets.E2E_REQUIRE_DB_MARKER }}
+          AUTH_SECRET: 'e2e-test-secret-only-used-for-signing-test-sessions'
+          NEXTAUTH_TEST_MODE: 'true'
+          NEXT_PUBLIC_DISABLE_ANALYTICS: 'true'
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+          GOOGLE_SHEETS_ID: ${{ secrets.GOOGLE_SHEETS_ID }}
+          SKIP_ENV_VALIDATION: 'true'
+
+      - name: Get Allure history from gh-pages
+        uses: actions/checkout@v5
+        if: always()
+        continue-on-error: true
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: E2E tests
+        run: npm run test:e2e
+        env:
+          # Бьём в изолированную Neon-ветку `e2e`, НЕ в прод. Guard в
+          # lib/test-mode.ts отказывается работать, если DATABASE_URL содержит
+          # PROD_DB_HOST_MARKER или не содержит E2E_REQUIRE_DB_MARKER.
+          DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+          PROD_DB_HOST_MARKER: ${{ secrets.PROD_DB_HOST_MARKER }}
+          E2E_REQUIRE_DB_MARKER: ${{ secrets.E2E_REQUIRE_DB_MARKER }}
+          AUTH_SECRET: 'e2e-test-secret-only-used-for-signing-test-sessions'
+          NEXTAUTH_TEST_MODE: 'true'
+          NEXTAUTH_URL: 'http://localhost:3000'
+          # Production-сервер (next start) ⇒ NODE_ENV=production. Флаги
+          # E2E_ALLOW_PRODUCTION_SERVER + AUTH_TRUST_HOST инжектятся прямо в
+          # env сервера через playwright.config.ts (webServer.env, ветка CI) —
+          # единый источник правды. Прод-БД защищена маркерами выше.
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+          GOOGLE_SHEETS_ID: ${{ secrets.GOOGLE_SHEETS_ID }}
+          SKIP_ENV_VALIDATION: 'true'
+
+      - name: Install Allure CLI
+        if: always()
+        run: npm install -g allure-commandline
+
+      - name: Restore Allure history
+        if: always()
+        run: cp -r gh-pages/history allure-results/history 2>/dev/null || true
+
+      - name: Generate Allure report
+        if: always()
+        run: allure generate allure-results --clean -o allure-report
+
+      - name: Publish Allure report to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: allure-report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ gh pr merge --auto --squash --delete-branch
 Для совсем быстрых правок есть shell-функция `qpr "msg"` (если настроен алиас) — объединяет всё в одну команду.
 
 ### Что гарантирует CI-gate
-- Прод **не задеплоится**, если упали: lint, secret scan, typecheck, unit-tests, E2E, build.
+- Прод **не задеплоится**, если упали: lint, secret scan, typecheck, unit-tests, build. **E2E в merge-gate НЕ входят** — они вынесены в отдельный workflow `.github/workflows/e2e-nightly.yml` (cron 00:00 UTC + ручной `workflow_dispatch`), не блокируют мерж. Если ночной E2E красный — GitHub уведомит, чиним форвардом. Прогнать E2E вручную: `gh workflow run "E2E (nightly)"`.
 - `gh pr merge --auto` — мерж происходит автоматически в момент когда CI станет зелёным; не надо сидеть и кликать.
 - Vercel preview каждой feature-ветки публикуется на уникальном URL (виден в PR).
 - **`strict: true`** в branch protection: PR обязан быть up-to-date с main перед мержем. Если другой PR смержился раньше — GitHub потребует `gh pr update-branch`, CI перезапустится на актуальной комбинации. Это закрывает дыру «два PR от одного base, оба зелёные по отдельности, но сломанные вместе». Особенно важно при параллельной работе нескольких агентов.

--- a/app/api/admin/signup-books/route.test.ts
+++ b/app/api/admin/signup-books/route.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment node
+ */
+import { PATCH } from './route'
+import { NextRequest } from 'next/server'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), update: jest.fn(), delete: jest.fn(), transaction: jest.fn() } }))
+
+import { auth } from '@/lib/auth'
+const mockAuth = auth as jest.Mock
+
+describe('PATCH /api/admin/signup-books', () => {
+  it('returns 403 when not admin', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { id: 'u1', isAdmin: false } })
+    const req = new NextRequest('http://localhost/api/admin/signup-books', {
+      method: 'PATCH',
+      body: JSON.stringify({ userId: 'u1', bookId: 'b1', status: 'reading' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 for invalid status', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { id: 'admin', isAdmin: true } })
+    const req = new NextRequest('http://localhost/api/admin/signup-books', {
+      method: 'PATCH',
+      body: JSON.stringify({ userId: 'u1', bookId: 'b1', status: 'invalid' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(400)
+  })
+})

--- a/app/api/admin/signup-books/route.test.ts
+++ b/app/api/admin/signup-books/route.test.ts
@@ -3,33 +3,164 @@
  */
 import { PATCH } from './route'
 import { NextRequest } from 'next/server'
+import { db } from '@/lib/db'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
-jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), update: jest.fn(), delete: jest.fn(), transaction: jest.fn() } }))
+jest.mock('@/lib/db', () => ({
+  db: {
+    select: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    transaction: jest.fn(),
+  },
+}))
 
 import { auth } from '@/lib/auth'
 const mockAuth = auth as jest.Mock
 
-describe('PATCH /api/admin/signup-books', () => {
+function makeRequest(body: object) {
+  return new NextRequest('http://localhost/api/admin/signup-books', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(db.transaction as jest.Mock).mockImplementation(async (callback) => callback(db))
+  // Default: signup row NOT found → 404
+  const defaultChain = {
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue([]),
+  }
+  ;(db.select as jest.Mock).mockReturnValue(defaultChain)
+  ;(db.update as jest.Mock).mockReturnValue({ set: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue(undefined) })
+  ;(db.delete as jest.Mock).mockReturnValue({ where: jest.fn().mockResolvedValue(undefined) })
+})
+
+describe('PATCH /api/admin/signup-books — security & validation', () => {
   it('returns 403 when not admin', async () => {
     mockAuth.mockResolvedValueOnce({ user: { id: 'u1', isAdmin: false } })
-    const req = new NextRequest('http://localhost/api/admin/signup-books', {
-      method: 'PATCH',
-      body: JSON.stringify({ userId: 'u1', bookId: 'b1', status: 'reading' }),
-      headers: { 'Content-Type': 'application/json' },
-    })
-    const res = await PATCH(req)
+    const res = await PATCH(makeRequest({ userId: 'u1', bookId: 'b1', status: 'reading' }))
     expect(res.status).toBe(403)
+  })
+
+  it('returns 403 without session', async () => {
+    mockAuth.mockResolvedValueOnce(null)
+    const res = await PATCH(makeRequest({ userId: 'u1', bookId: 'b1', status: 'reading' }))
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 for missing userId', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { isAdmin: true } })
+    const res = await PATCH(makeRequest({ bookId: 'b1', status: 'reading' }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for missing bookId', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { isAdmin: true } })
+    const res = await PATCH(makeRequest({ userId: 'u1', status: 'reading' }))
+    expect(res.status).toBe(400)
   })
 
   it('returns 400 for invalid status', async () => {
     mockAuth.mockResolvedValueOnce({ user: { id: 'admin', isAdmin: true } })
-    const req = new NextRequest('http://localhost/api/admin/signup-books', {
-      method: 'PATCH',
-      body: JSON.stringify({ userId: 'u1', bookId: 'b1', status: 'invalid' }),
-      headers: { 'Content-Type': 'application/json' },
-    })
-    const res = await PATCH(req)
+    const res = await PATCH(makeRequest({ userId: 'u1', bookId: 'b1', status: 'invalid' }))
     expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when user is not signed up for the book', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { isAdmin: true } })
+    // db.select returns [] by default (set in beforeEach)
+    const res = await PATCH(makeRequest({ userId: 'u1', bookId: 'b1', status: 'reading' }))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('PATCH /api/admin/signup-books — happy path', () => {
+  it('returns 200 when status = reading and user is signed up (no priority row)', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { isAdmin: true } })
+
+    // First select: signup row found
+    const signupChain = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([{ bookId: 'b1' }]),
+    }
+    // Second select: no priority row
+    const noPriorityChain = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([]),
+    }
+    ;(db.select as jest.Mock)
+      .mockReturnValueOnce(signupChain)
+      .mockReturnValueOnce(noPriorityChain)
+
+    const res = await PATCH(makeRequest({ userId: 'u1', bookId: 'b1', status: 'reading' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.ok).toBe(true)
+    expect(db.update).toHaveBeenCalledTimes(1)
+    expect(db.delete).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 and rerranks when status = read and user has priority row', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { isAdmin: true } })
+
+    const signupChain = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([{ bookId: 'b1' }]),
+    }
+    const priorityChain = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([{ rank: 2 }]),
+    }
+    ;(db.select as jest.Mock)
+      .mockReturnValueOnce(signupChain)
+      .mockReturnValueOnce(priorityChain)
+
+    const mockDeleteWhere = jest.fn().mockResolvedValue(undefined)
+    ;(db.delete as jest.Mock).mockReturnValue({ where: mockDeleteWhere })
+
+    const mockUpdateWhere = jest.fn().mockResolvedValue(undefined)
+    ;(db.update as jest.Mock).mockReturnValue({ set: jest.fn().mockReturnThis(), where: mockUpdateWhere })
+
+    const res = await PATCH(makeRequest({ userId: 'u1', bookId: 'b1', status: 'read' }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.ok).toBe(true)
+    // update signupBooks + update bookPriorities (re-rank)
+    expect(db.update).toHaveBeenCalledTimes(2)
+    // delete priority row
+    expect(db.delete).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 200 when status = null (reset) — no priority rerank', async () => {
+    mockAuth.mockResolvedValueOnce({ user: { isAdmin: true } })
+
+    const signupChain = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([{ bookId: 'b1' }]),
+    }
+    ;(db.select as jest.Mock).mockReturnValueOnce(signupChain)
+
+    const res = await PATCH(makeRequest({ userId: 'u1', bookId: 'b1', status: null }))
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.ok).toBe(true)
+    // Only updates signupBooks, no priority operations
+    expect(db.update).toHaveBeenCalledTimes(1)
+    expect(db.delete).not.toHaveBeenCalled()
+    // No second select for priorities (status is null)
+    expect(db.select).toHaveBeenCalledTimes(1)
   })
 })

--- a/app/api/admin/signup-books/route.ts
+++ b/app/api/admin/signup-books/route.ts
@@ -3,9 +3,74 @@ export const dynamic = 'force-dynamic'
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { bookPriorities } from '@/lib/db/schema'
+import { bookPriorities, signupBooks } from '@/lib/db/schema'
 import { removeBookFromSignup } from '@/lib/signup-books'
 import { and, eq, gt, sql } from 'drizzle-orm'
+
+const VALID_STATUSES = new Set(['reading', 'read'])
+
+export async function PATCH(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const body = await req.json().catch(() => null)
+  const { userId, bookId, status } = (body ?? {}) as {
+    userId?: string
+    bookId?: string
+    status?: string | null
+  }
+
+  if (!userId || !bookId) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+  }
+  if (status !== null && status !== undefined && !VALID_STATUSES.has(status)) {
+    return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
+  }
+
+  // Verify the user is signed up for this book
+  const [signup] = await db
+    .select({ bookId: signupBooks.bookId })
+    .from(signupBooks)
+    .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
+    .limit(1)
+
+  if (!signup) {
+    return NextResponse.json({ error: 'Not signed up for this book' }, { status: 404 })
+  }
+
+  await db.transaction(async (tx) => {
+    // 1. Update personal_status
+    await tx
+      .update(signupBooks)
+      .set({ personalStatus: status ?? null, personalStatusUpdatedAt: new Date() })
+      .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
+
+    // 2. If moving to reading/read: remove from book_priorities and rerank
+    if (status !== null && status !== undefined) {
+      const [existing] = await tx
+        .select({ rank: bookPriorities.rank })
+        .from(bookPriorities)
+        .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, bookId)))
+        .limit(1)
+
+      if (existing) {
+        await tx
+          .delete(bookPriorities)
+          .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, bookId)))
+
+        await tx
+          .update(bookPriorities)
+          .set({ rank: sql`${bookPriorities.rank} - 1` })
+          .where(and(eq(bookPriorities.userId, userId), gt(bookPriorities.rank, existing.rank)))
+      }
+    }
+    // If status === null: leave book_priorities untouched
+  })
+
+  return NextResponse.json({ ok: true })
+}
 
 export async function DELETE(req: NextRequest) {
   const session = await auth()

--- a/app/api/admin/signup-books/route.ts
+++ b/app/api/admin/signup-books/route.ts
@@ -29,25 +29,26 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
   }
 
-  // Verify the user is signed up for this book
-  const [signup] = await db
-    .select({ bookId: signupBooks.bookId })
-    .from(signupBooks)
-    .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
-    .limit(1)
-
-  if (!signup) {
-    return NextResponse.json({ error: 'Not signed up for this book' }, { status: 404 })
-  }
-
+  let signupExists = false
   await db.transaction(async (tx) => {
-    // 1. Update personal_status
+    // 1. Verify the user is signed up for this book (inside transaction to avoid race condition)
+    const [signup] = await tx
+      .select({ bookId: signupBooks.bookId })
+      .from(signupBooks)
+      .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
+      .limit(1)
+
+    if (!signup) return
+
+    signupExists = true
+
+    // 2. Update personal_status
     await tx
       .update(signupBooks)
       .set({ personalStatus: status ?? null, personalStatusUpdatedAt: new Date() })
       .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
 
-    // 2. If moving to reading/read: remove from book_priorities and rerank
+    // 3. If moving to reading/read: remove from book_priorities and rerank
     if (status !== null && status !== undefined) {
       const [existing] = await tx
         .select({ rank: bookPriorities.rank })
@@ -68,6 +69,10 @@ export async function PATCH(req: NextRequest) {
     }
     // If status === null: leave book_priorities untouched
   })
+
+  if (!signupExists) {
+    return NextResponse.json({ error: 'Not signed up for this book' }, { status: 404 })
+  }
 
   return NextResponse.json({ ok: true })
 }

--- a/docs/wiki/Quality-CI-Allure-and-Codecov.md
+++ b/docs/wiki/Quality-CI-Allure-and-Codecov.md
@@ -4,15 +4,27 @@
 
 ![Allure report](images/allure-report.png)
 
-## Что запускается в CI
+## Два пайплайна: быстрый merge-gate и ночной E2E
 
-GitHub Actions workflow `CI` делает:
+Проверки разделены на два независимых GitHub Actions workflow.
 
-Workflow состоит из трёх параллельных job (`quality`, `e2e`, `build`) и финального gate-job `ci`, который требует, чтобы все три прошли:
+### `CI` — быстрый merge-gate (блокирует мерж)
+
+Бежит на каждый pull request. Состоит из двух параллельных job (`quality`, `build`) и финального gate-job `ci`, который требует, чтобы оба прошли. Это единственная required-проверка branch protection — мерж ждёт только её (~80 секунд).
 
 - **`quality`** — `npm ci`, ESLint, secret scan, TypeScript typecheck, Jest unit-тесты с coverage, загрузка coverage в Codecov.
-- **`e2e`** — `npm ci`, установка Playwright Chromium (с кэшем), синхронизация схемы e2e-ветки (`drizzle-kit push`), **сборка production-билда** (`next build`), запуск Playwright против production-сервера, генерация и публикация Allure на GitHub Pages.
-- **`build`** — отдельная проверка, что `next build` проходит с прод-секретами.
+- **`build`** — проверка, что `next build` проходит с прод-секретами.
+
+### `E2E (nightly)` — Playwright, НЕ блокирует мерж
+
+E2E вынесены из merge-gate в отдельный workflow `.github/workflows/e2e-nightly.yml`. Триггеры — **только расписание и ручной запуск**, никаких push/PR:
+
+- `schedule: cron '0 0 * * *'` — раз в сутки в 00:00 UTC (03:00 МСК) по актуальному `main`;
+- `workflow_dispatch` — кнопка «Run workflow» для прогона по требованию.
+
+Job делает: `npm ci`, установка Playwright Chromium (с кэшем), синхронизация схемы e2e-ветки (`drizzle-kit push`), сборка production-билда (`next build`), запуск Playwright против production-сервера, генерация и публикация Allure на GitHub Pages.
+
+**Почему так.** e2e-job платит ~100s фиксированного оверхеда (install + браузеры + schema + build) плюс ~270s на сами тесты — это держало мерж 6–7 минут на каждый PR. Для домашнего проекта с парой пользователей это не оправдано: быстрый gate ловит «не собирается / битый тип / утёк секрет» сразу, а E2E ловит регрессии сценариев ночью, постфактум. Красный ночной прогон → GitHub шлёт уведомление → чиним форвардом. Поднять/убрать триггеры или поменять час cron — правка `e2e-nightly.yml`.
 
 ### Почему E2E гоняет production-сервер, а не `next dev`
 

--- a/lib/admin-users.ts
+++ b/lib/admin-users.ts
@@ -30,7 +30,7 @@ export interface AdminUserSummary {
 
 export interface AdminUserDetails {
   user: AdminUserSummary & { prioritiesSet: boolean }
-  signupBooks: { bookId: string; bookName: string; signedAt: string }[]
+  signupBooks: { bookId: string; bookName: string; signedAt: string; personalStatus: string | null }[]
   priorities: { bookId: string; bookName: string; rank: number }[]
   submissions: {
     id: string
@@ -185,7 +185,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
 
   const [signupRows, priorityRows, submissionRows, feedbackRows, identityRows] = await Promise.all([
     db
-      .select({ bookId: signupBooks.bookId, bookName: books.title, signedAt: signupBooks.signedAt })
+      .select({ bookId: signupBooks.bookId, bookName: books.title, signedAt: signupBooks.signedAt, personalStatus: signupBooks.personalStatus })
       .from(signupBooks)
       .innerJoin(books, eq(signupBooks.bookId, books.id))
       .where(eq(signupBooks.userId, userId))
@@ -244,7 +244,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
 
   return {
     user: { ...summary, prioritiesSet: userRow.prioritiesSet ?? false },
-    signupBooks: signupRows.map(row => ({ bookId: row.bookId, bookName: row.bookName, signedAt: row.signedAt.toISOString() })),
+    signupBooks: signupRows.map(row => ({ bookId: row.bookId, bookName: row.bookName, signedAt: row.signedAt.toISOString(), personalStatus: row.personalStatus ?? null })),
     priorities: priorityRows.map(row => ({ bookId: row.bookId, bookName: row.bookName, rank: row.rank })),
     submissions: submissionRows.map(row => ({
       id: row.id,

--- a/lib/admin-users.ts
+++ b/lib/admin-users.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/db/schema'
 import { asc, desc, eq } from 'drizzle-orm'
 import { formatTelegramDisplay } from '@/lib/telegram-display'
+import type { PersonalBookStatus } from './signup-books'
 
 export interface AdminUserSummary {
   id: string
@@ -30,7 +31,7 @@ export interface AdminUserSummary {
 
 export interface AdminUserDetails {
   user: AdminUserSummary & { prioritiesSet: boolean }
-  signupBooks: { bookId: string; bookName: string; signedAt: string; personalStatus: string | null }[]
+  signupBooks: { bookId: string; bookName: string; signedAt: string; personalStatus: PersonalBookStatus }[]
   priorities: { bookId: string; bookName: string; rank: number }[]
   submissions: {
     id: string
@@ -244,7 +245,7 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
 
   return {
     user: { ...summary, prioritiesSet: userRow.prioritiesSet ?? false },
-    signupBooks: signupRows.map(row => ({ bookId: row.bookId, bookName: row.bookName, signedAt: row.signedAt.toISOString(), personalStatus: row.personalStatus ?? null })),
+    signupBooks: signupRows.map(row => ({ bookId: row.bookId, bookName: row.bookName, signedAt: row.signedAt.toISOString(), personalStatus: (row.personalStatus ?? null) as PersonalBookStatus })),
     priorities: priorityRows.map(row => ({ bookId: row.bookId, bookName: row.bookName, rank: row.rank })),
     submissions: submissionRows.map(row => ({
       id: row.id,


### PR DESCRIPTION
## Зачем
E2E-job держал мерж 6–7 минут на каждый PR (~100s фиксированного оверхеда + ~270s тестов). Для домашнего проекта с парой пользователей это не оправдано — нет смысла платить минуты ожидания за защиту, которую дешевле поймать постфактум.

## Что меняется
- **Merge-gate (`CI` workflow)** теперь = `quality` (lint, secret scan, typecheck, unit + coverage) + `build`. ~80 секунд. Это единственное, что держит мерж.
- **E2E переехали** в новый `.github/workflows/e2e-nightly.yml`. Триггеры — **только `schedule` (cron 00:00 UTC / 03:00 МСК) и `workflow_dispatch`**. Никаких push/PR: днём фичи летят в прод без ожидания E2E, ночью прогон по `main`, утром фикс форвардом при красном.
- Required-проверка по-прежнему называется `ci` → **branch protection трогать не нужно**, из gate-job убрана лишь зависимость от `e2e`.

## Прогнать E2E вручную
`gh workflow run "E2E (nightly)"` или кнопка «Run workflow» в Actions.

## Доки
- `docs/wiki/Quality-CI-Allure-and-Codecov.md` — описаны два пайплайна.
- `AGENTS.md` — факт-правка про состав merge-gate.

## Test plan
- [x] YAML обоих workflow валиден, структура проверена
- [ ] CI-gate зелёный (quality + build + ci)
- [ ] Ручной прогон `E2E (nightly)` зелёный (проверю после мержа)

🤖 Generated with [Claude Code](https://claude.com/claude-code)