### PR TITLE
style(matching): привести /matching к дизайн-системе сайта

### DIFF
--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -40,11 +40,18 @@ export default async function MatchingPage({
 
   if (!activeSession) {
     return (
-      <main className="font-mono p-8 max-w-2xl mx-auto">
+      <main
+        className="p-8 max-w-2xl mx-auto"
+        style={{ background: 'var(--bg)', color: 'var(--text)', minHeight: '100svh' }}
+      >
         <h1 className="text-lg font-semibold mb-4">Матчинг</h1>
-        <p className="text-[#999]">
+        <p style={{ color: 'var(--text-muted)' }}>
           Нет активной сессии. Создайте её в{' '}
-          <a href="/admin?tab=matching" className="text-[#333] underline">
+          <a
+            href="/admin?tab=matching"
+            className="underline"
+            style={{ color: 'var(--accent)' }}
+          >
             Админ-панели → Матчинг
           </a>
           .
@@ -164,7 +171,10 @@ export default async function MatchingPage({
   const isFrozenOrImpersonating = activeSession.status === 'frozen' || isImpersonating
 
   return (
-    <div className="flex flex-col bg-[#f6f2e8]" style={{ height: '100svh', overflow: 'hidden' }}>
+    <div
+      className="flex flex-col"
+      style={{ height: '100svh', overflow: 'hidden', background: 'var(--bg)', color: 'var(--text)' }}
+    >
       <MatchingHeader
         sessionName={activeSession.name}
         sessionStatus={activeSession.status}
@@ -184,13 +194,23 @@ export default async function MatchingPage({
         style={{ gridTemplateColumns: 'minmax(0, 1.4fr) minmax(0, 1fr)' }}
       >
         {/* Left: personal book list */}
-        <div className="flex flex-col bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_4px_24px_rgba(25,24,23,0.08)] overflow-hidden min-h-0">
-          <div className="px-4 py-3 border-b border-[#ded6c8] shrink-0">
-            <h2 className="text-base font-semibold m-0 text-[#191817]">
+        <div
+          className="flex flex-col rounded-xl overflow-hidden min-h-0 border"
+          style={{
+            background: 'var(--bg-input)',
+            borderColor: 'var(--border)',
+            boxShadow: '0 4px 24px var(--shadow-card)',
+          }}
+        >
+          <div
+            className="px-4 py-3 shrink-0 border-b"
+            style={{ borderColor: 'var(--border)' }}
+          >
+            <h2 className="text-base font-semibold m-0" style={{ color: 'var(--text)' }}>
               {isImpersonating ? 'Список участника' : 'Мой список'}
             </h2>
             {!isImpersonating && (
-              <p className="text-xs text-[#6d675f] mt-0.5 m-0">
+              <p className="text-xs mt-0.5 m-0" style={{ color: 'var(--text-muted)' }}>
                 Перетащи книги, чтобы расставить приоритеты
               </p>
             )}
@@ -209,10 +229,14 @@ export default async function MatchingPage({
             />
           </div>
           {isAdmin && !isImpersonating && (
-            <div className="px-4 py-2.5 border-t border-[#ded6c8] shrink-0">
+            <div
+              className="px-4 py-2.5 shrink-0 border-t"
+              style={{ borderColor: 'var(--border)' }}
+            >
               <a
                 href="/admin?tab=matching"
-                className="text-xs text-[#6d675f] underline hover:text-[#191817]"
+                className="text-xs underline"
+                style={{ color: 'var(--text-muted)' }}
               >
                 Перейти в Админ-панель → Матчинг
               </a>
@@ -223,10 +247,21 @@ export default async function MatchingPage({
         {/* Right column: scenarios + moves stacked */}
         <div className="flex flex-col gap-4 min-h-0 overflow-hidden">
           {/* Scenarios */}
-          <div className="flex flex-col flex-1 bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_4px_24px_rgba(25,24,23,0.08)] overflow-hidden min-h-0">
-            <div className="px-4 py-3 border-b border-[#ded6c8] shrink-0">
+          <div
+            className="flex flex-col flex-1 rounded-xl overflow-hidden min-h-0 border"
+            style={{
+              background: 'var(--bg-input)',
+              borderColor: 'var(--border)',
+              boxShadow: '0 4px 24px var(--shadow-card)',
+            }}
+          >
+            <div
+              className="px-4 py-3 shrink-0 border-b"
+              style={{ borderColor: 'var(--border)' }}
+            >
               <h2
-                className="text-base font-semibold m-0 text-[#191817]"
+                className="text-base font-semibold m-0"
+                style={{ color: 'var(--text)' }}
                 title="Сортировка: макс. участников → больше топ-3 книг → ниже средний ранг"
               >
                 Сценарии групп
@@ -238,9 +273,19 @@ export default async function MatchingPage({
           </div>
 
           {/* My moves */}
-          <div className="flex flex-col flex-1 bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_4px_24px_rgba(25,24,23,0.08)] overflow-hidden min-h-0">
-            <div className="px-4 py-3 border-b border-[#ded6c8] shrink-0">
-              <h2 className="text-base font-semibold m-0 text-[#191817]">
+          <div
+            className="flex flex-col flex-1 rounded-xl overflow-hidden min-h-0 border"
+            style={{
+              background: 'var(--bg-input)',
+              borderColor: 'var(--border)',
+              boxShadow: '0 4px 24px var(--shadow-card)',
+            }}
+          >
+            <div
+              className="px-4 py-3 shrink-0 border-b"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              <h2 className="text-base font-semibold m-0" style={{ color: 'var(--text)' }}>
                 {isImpersonating ? 'Ходы участника' : 'Мои ходы'}
               </h2>
             </div>

--- a/components/nd/MatchingHeader.tsx
+++ b/components/nd/MatchingHeader.tsx
@@ -88,22 +88,34 @@ export default function MatchingHeader({
         <div
           data-testid="admin-impersonation-banner"
           role="status"
-          className="flex items-center gap-3 px-4 py-2 text-xs text-[#7a5c00] bg-[#fffbea] border-b border-[#f0d060]"
+          className="flex items-center gap-3 px-4 py-2 text-xs border-b"
+          style={{
+            color: '#7a5c00',
+            background: '#fffbea',
+            borderColor: '#f0d060',
+          }}
         >
           <span>👁 Просмотр за</span>
           <strong>{viewedPseudonym ?? asParam}</strong>
-          {viewedName && <span className="text-[#a07800]">({viewedName})</span>}
+          {viewedName && <span style={{ color: '#a07800' }}>({viewedName})</span>}
           <span className="ml-auto opacity-70">только чтение</span>
           <a
             href="/matching"
-            className="text-[#7a5c00] underline text-[11px] hover:text-[#5c4000]"
+            className="underline text-[11px]"
+            style={{ color: '#7a5c00' }}
           >
             ← вернуться к своему виду
           </a>
         </div>
       )}
 
-      <header className="flex items-center justify-between gap-4 px-4 h-14 shrink-0 border-b border-[#ded6c8] bg-[rgba(246,242,232,0.94)] backdrop-blur-sm">
+      <header
+        className="flex items-center justify-between gap-4 px-4 h-14 shrink-0 border-b backdrop-blur-sm"
+        style={{
+          borderColor: 'var(--border)',
+          background: 'var(--bg-elevated)',
+        }}
+      >
         {/* Left: session info */}
         <div className="flex items-center gap-4 min-w-0">
           <h1
@@ -112,7 +124,10 @@ export default function MatchingHeader({
           >
             {sessionName}
           </h1>
-          <div className="hidden sm:flex items-center gap-3 text-sm text-[#6d675f] shrink-0">
+          <div
+            className="hidden sm:flex items-center gap-3 text-sm shrink-0"
+            style={{ color: 'var(--text-muted)' }}
+          >
             <span>Группы по {targetGroupSize}</span>
             {deadlineText && (
               <span>
@@ -123,11 +138,14 @@ export default function MatchingHeader({
               </span>
             )}
             {sessionStatus === 'frozen' ? (
-              <span className="bg-[#f0f0f0] text-[#888] px-2 py-0.5 rounded text-xs">
+              <span
+                className="px-2 py-0.5 rounded text-xs"
+                style={{ background: 'var(--bg-tag)', color: 'var(--text-muted)' }}
+              >
                 Зафиксирована
               </span>
             ) : (
-              <span className="text-[#0f766e]">● активна</span>
+              <span style={{ color: 'var(--success)' }}>● активна</span>
             )}
           </div>
         </div>
@@ -135,19 +153,34 @@ export default function MatchingHeader({
         {/* Right: participants popover */}
         <Popover.Root>
           <Popover.Trigger asChild>
-            <button className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[#ded6c8] bg-[#fffdf8] hover:border-[#b8ad9b] hover:-translate-y-px transition-all text-sm text-[#6d675f] shrink-0">
+            <button
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg border hover:-translate-y-px transition-all text-sm shrink-0"
+              style={{
+                borderColor: 'var(--border)',
+                background: 'var(--bg-input)',
+                color: 'var(--text-muted)',
+              }}
+            >
               <div className="flex -space-x-2">
                 {participants.slice(0, 6).map((p) => (
                   <div
                     key={p.userId}
-                    className={`w-6 h-6 rounded-full border-2 border-[#fffdf8] flex items-center justify-center text-[9px] font-bold ${pseudonymColor(p.pseudonym)}`}
+                    className={`w-6 h-6 rounded-full border-2 flex items-center justify-center text-[9px] font-bold ${pseudonymColor(p.pseudonym)}`}
+                    style={{ borderColor: 'var(--bg-input)' }}
                     title={p.pseudonym}
                   >
                     {p.pseudonym[0].toUpperCase()}
                   </div>
                 ))}
                 {participants.length > 6 && (
-                  <div className="w-6 h-6 rounded-full border-2 border-[#fffdf8] bg-[#ece4d5] flex items-center justify-center text-[9px] font-bold text-[#5c4a3a]">
+                  <div
+                    className="w-6 h-6 rounded-full border-2 flex items-center justify-center text-[9px] font-bold"
+                    style={{
+                      borderColor: 'var(--bg-input)',
+                      background: 'var(--bg-elevated)',
+                      color: 'var(--text-secondary)',
+                    }}
+                  >
                     +{participants.length - 6}
                   </div>
                 )}
@@ -158,16 +191,26 @@ export default function MatchingHeader({
 
           <Popover.Portal>
             <Popover.Content
-              className="z-50 bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_8px_32px_rgba(25,24,23,0.15)] p-3 min-w-[220px] max-w-[300px]"
+              className="z-50 border rounded-xl p-3 min-w-[220px] max-w-[300px]"
+              style={{
+                background: 'var(--bg-input)',
+                borderColor: 'var(--border)',
+                boxShadow: '0 8px 32px var(--shadow)',
+              }}
               sideOffset={8}
               align="end"
             >
-              <div className="text-xs font-semibold text-[#6d675f] mb-2.5 uppercase tracking-wide">
+              <div
+                className="text-xs font-semibold mb-2.5 uppercase tracking-wide"
+                style={{ color: 'var(--text-muted)' }}
+              >
                 Участники ({participants.length})
               </div>
               <div className="flex flex-col gap-1">
                 {participants.length === 0 ? (
-                  <div className="text-sm text-[#6d675f]">Пока никто не присоединился.</div>
+                  <div className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                    Пока никто не присоединился.
+                  </div>
                 ) : (
                   participants.map((p) => (
                     <div key={p.userId} className="flex items-center gap-2.5 py-1">
@@ -176,11 +219,17 @@ export default function MatchingHeader({
                       >
                         {p.pseudonym[0].toUpperCase()}
                       </div>
-                      <span className="text-sm font-medium text-[#191817] flex-1">{p.pseudonym}</span>
+                      <span
+                        className="text-sm font-medium flex-1"
+                        style={{ color: 'var(--text)' }}
+                      >
+                        {p.pseudonym}
+                      </span>
                       {isAdmin && p.name && (
                         <a
                           href={`/matching?as=${p.userId}`}
-                          className="text-xs text-[#8c7b6b] hover:text-[#5c4a3a] shrink-0"
+                          className="text-xs shrink-0"
+                          style={{ color: 'var(--text-muted)' }}
                           title="Посмотреть за этого участника"
                         >
                           {p.name}
@@ -190,7 +239,7 @@ export default function MatchingHeader({
                   ))
                 )}
               </div>
-              <Popover.Arrow className="fill-[#ded6c8]" />
+              <Popover.Arrow style={{ fill: 'var(--border)' }} />
             </Popover.Content>
           </Popover.Portal>
         </Popover.Root>

--- a/components/nd/MatchingMyMoves.tsx
+++ b/components/nd/MatchingMyMoves.tsx
@@ -49,7 +49,10 @@ export default function MatchingMyMoves({ moves: initialMoves, frozen = false }:
 
   if (moves.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full p-6 text-center text-[#6d675f]">
+      <div
+        className="flex flex-col items-center justify-center h-full p-6 text-center"
+        style={{ color: 'var(--text-muted)' }}
+      >
         <div className="text-3xl mb-2">✅</div>
         <p className="text-sm">Нет книг, где ваш сигнап завершит группу.</p>
       </div>
@@ -61,17 +64,26 @@ export default function MatchingMyMoves({ moves: initialMoves, frozen = false }:
       {moves.map((move) => (
         <li
           key={move.bookId}
-          className="rounded-xl border border-[#86efac] bg-[#f0fdf4] p-3"
+          className="rounded-xl border p-3"
+          style={{
+            borderColor: 'var(--success)',
+            background: 'var(--bg-tag-green)',
+          }}
         >
           <div className="flex gap-3 mb-2.5">
             <div className="relative rounded overflow-hidden shrink-0" style={{ width: 40, height: 56 }}>
               <CoverImage coverUrl={move.coverUrl} title={move.title} author={move.author} />
             </div>
             <div className="min-w-0 flex-1">
-              <div className="font-semibold text-sm leading-snug mb-0.5 text-[#191817]" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              <div
+                className="font-semibold text-sm leading-snug mb-0.5"
+                style={{ color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              >
                 {move.title}
               </div>
-              <div className="text-xs text-[#6d675f] mb-1.5">{move.author}</div>
+              <div className="text-xs mb-1.5" style={{ color: 'var(--text-muted)' }}>
+                {move.author}
+              </div>
               <div className="flex flex-wrap gap-1">
                 {move.existingParticipants.map((p) => (
                   <span
@@ -88,11 +100,22 @@ export default function MatchingMyMoves({ moves: initialMoves, frozen = false }:
             <button
               onClick={() => handleAdd(move.bookId)}
               disabled={adding === move.bookId}
-              className={`w-full text-sm py-2 px-3 rounded-lg border transition-colors font-medium ${
+              className="w-full text-sm py-2 px-3 rounded-lg border transition-colors font-medium"
+              style={
                 adding === move.bookId
-                  ? 'bg-[#f0f0f0] border-[#ddd] text-[#999] cursor-default'
-                  : 'bg-[#0f766e] border-[#0f766e] text-white hover:bg-[#0a5c54] hover:border-[#0a5c54] cursor-pointer'
-              }`}
+                  ? {
+                      background: 'var(--bg-elevated)',
+                      borderColor: 'var(--border)',
+                      color: 'var(--text-muted)',
+                      cursor: 'default',
+                    }
+                  : {
+                      background: 'var(--success)',
+                      borderColor: 'var(--success)',
+                      color: '#fff',
+                      cursor: 'pointer',
+                    }
+              }
             >
               {adding === move.bookId ? '…' : 'Хочу читать'}
             </button>

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -102,9 +102,9 @@ function SortableRow({
         gridTemplateColumns: '52px 1fr 90px',
         gap: '14px',
         padding: '14px 16px',
-        borderBottom: '1px solid #ded6c8',
+        borderBottom: '1px solid var(--border)',
         opacity: isDragging ? 0.5 : 1,
-        background: isDragging ? '#fff7e7' : undefined,
+        background: isDragging ? 'var(--bg-elevated)' : undefined,
         alignItems: 'start',
       }}
     >
@@ -115,8 +115,8 @@ function SortableRow({
             {...attributes}
             {...listeners}
             aria-label={`Перетащить книгу ${book.title}`}
-            className="absolute text-[#ccc] cursor-grab hover:text-[#999] select-none touch-none text-lg leading-none"
-            style={{ left: -14, top: '50%', transform: 'translateY(-50%)' }}
+            className="absolute cursor-grab select-none touch-none text-lg leading-none"
+            style={{ color: 'var(--text-muted)', opacity: 0.5, left: -14, top: '50%', transform: 'translateY(-50%)' }}
           >
             ⠿
           </button>
@@ -128,17 +128,22 @@ function SortableRow({
 
       {/* Title / author / participant chips */}
       <div className="min-w-0">
-        <div className="font-semibold text-sm leading-snug mb-0.5 text-[#191817]" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        <div className="font-semibold text-sm leading-snug mb-0.5" style={{ color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {book.title}
         </div>
-        <div className="text-xs text-[#6d675f] mb-2" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        <div className="text-xs mb-2" style={{ color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {book.author}
         </div>
         {!frozen && (
           <select
             value={book.personalStatus ?? ''}
             onChange={(e) => onStatusChange(book.bookId, e.target.value || null)}
-            className="text-[11px] border border-[#ded6c8] rounded px-1.5 py-0.5 bg-[#fafaf8] text-[#6d675f] cursor-pointer hover:border-[#bbb] mb-1.5"
+            className="text-[11px] border rounded px-1.5 py-0.5 cursor-pointer mb-1.5"
+            style={{
+              borderColor: 'var(--border)',
+              background: 'var(--bg-elevated)',
+              color: 'var(--text-muted)',
+            }}
           >
             <option value="">В списке</option>
             <option value="reading">Читаю сейчас</option>
@@ -169,9 +174,13 @@ function SortableRow({
       {/* Rank + reorder */}
       <div className="flex flex-col items-end gap-1">
         {book.rank != null && (
-          <span className="text-2xl font-bold leading-none text-[#191817]">#{book.rank}</span>
+          <span className="text-2xl font-bold leading-none" style={{ color: 'var(--text)' }}>
+            #{book.rank}
+          </span>
         )}
-        <span className="text-[10px] text-[#6d675f]">место в списке</span>
+        <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+          место в списке
+        </span>
         {canReorder && (
           <div className="flex flex-col gap-0.5 mt-0.5">
             <button
@@ -180,9 +189,10 @@ function SortableRow({
               aria-label={`Переместить ${book.title} выше`}
               className={`text-[11px] px-1.5 py-0.5 leading-none border rounded transition-colors ${
                 index === 0
-                  ? 'text-[#ddd] border-[#eee] cursor-default'
-                  : 'text-[#999] border-[#ddd] hover:text-[#555] hover:border-[#bbb] cursor-pointer'
+                  ? 'cursor-default opacity-30'
+                  : 'cursor-pointer opacity-70 hover:opacity-100'
               }`}
+              style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
             >
               ▲
             </button>
@@ -192,9 +202,10 @@ function SortableRow({
               aria-label={`Переместить ${book.title} ниже`}
               className={`text-[11px] px-1.5 py-0.5 leading-none border rounded transition-colors ${
                 index === total - 1
-                  ? 'text-[#ddd] border-[#eee] cursor-default'
-                  : 'text-[#999] border-[#ddd] hover:text-[#555] hover:border-[#bbb] cursor-pointer'
+                  ? 'cursor-default opacity-30'
+                  : 'cursor-pointer opacity-70 hover:opacity-100'
               }`}
+              style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
             >
               ▼
             </button>
@@ -222,7 +233,7 @@ function StatusRow({ book, chipsForBook, viewingUserId, frozen, onStatusChange }
         gridTemplateColumns: '52px 1fr',
         gap: '14px',
         padding: '14px 16px',
-        borderBottom: '1px solid #ded6c8',
+        borderBottom: '1px solid var(--border)',
         alignItems: 'start',
         opacity: 0.75,
       }}
@@ -233,24 +244,31 @@ function StatusRow({ book, chipsForBook, viewingUserId, frozen, onStatusChange }
         </div>
       </div>
       <div className="min-w-0">
-        <div className="font-semibold text-sm leading-snug mb-0.5 text-[#191817]" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        <div className="font-semibold text-sm leading-snug mb-0.5" style={{ color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {book.title}
         </div>
-        <div className="text-xs text-[#6d675f] mb-2" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        <div className="text-xs mb-2" style={{ color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {book.author}
         </div>
         {!frozen ? (
           <select
             value={book.personalStatus ?? ''}
             onChange={(e) => onStatusChange(book.bookId, e.target.value || null)}
-            className="text-[11px] border border-[#ded6c8] rounded px-1.5 py-0.5 bg-[#fafaf8] text-[#6d675f] cursor-pointer hover:border-[#bbb] mb-1.5"
+            className="text-[11px] border rounded px-1.5 py-0.5 cursor-pointer mb-1.5"
+            style={{
+              borderColor: 'var(--border)',
+              background: 'var(--bg-elevated)',
+              color: 'var(--text-muted)',
+            }}
           >
             <option value="">В списке</option>
             <option value="reading">Читаю сейчас</option>
             <option value="read">Прочитал(а)</option>
           </select>
         ) : (
-          <span className="text-[11px] text-[#999] italic mb-1.5">{statusLabel}</span>
+          <span className="text-[11px] italic mb-1.5" style={{ color: 'var(--text-muted)' }}>
+            {statusLabel}
+          </span>
         )}
         {chipsForBook.length > 0 && (
           <div className="flex flex-wrap gap-1">
@@ -424,11 +442,14 @@ export default function MatchingPersonalList({
 
   if (books.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full p-8 text-center text-[#6d675f]">
+      <div
+        className="flex flex-col items-center justify-center h-full p-8 text-center"
+        style={{ color: 'var(--text-muted)' }}
+      >
         <div className="text-4xl mb-3">📚</div>
         <p className="text-sm leading-relaxed">
           Вы ещё не добавили книги.{' '}
-          <a href="/" className="underline text-[#0f766e] hover:text-[#0a5c54]">
+          <a href="/" className="underline" style={{ color: 'var(--accent)' }}>
             Перейдите в каталог
           </a>
           , чтобы выбрать книги для чтения.
@@ -482,8 +503,14 @@ export default function MatchingPersonalList({
 
       {statusBooks.length > 0 && (
         <>
-          <div className="px-4 py-2 border-b border-[#ded6c8] border-t bg-[#f6f2e8]">
-            <span className="text-[11px] font-medium text-[#999] uppercase tracking-wide">
+          <div
+            className="px-4 py-2 border-b border-t"
+            style={{ borderColor: 'var(--border)', background: 'var(--bg-elevated)' }}
+          >
+            <span
+              className="text-[11px] font-medium uppercase tracking-wide"
+              style={{ color: 'var(--text-muted)' }}
+            >
               В процессе / Прочитано
             </span>
           </div>

--- a/components/nd/MatchingScenarios.tsx
+++ b/components/nd/MatchingScenarios.tsx
@@ -30,8 +30,8 @@ const tierConfig = {
     labelClass: 'text-[#1d4ed8] border-[#93c5fd]',
   },
   'sub-max': {
-    bg: 'bg-[#fafaf8]',
-    border: 'border-[#e8e8e4]',
+    bg: 'bg-[var(--bg-elevated)]',
+    border: 'border-[var(--border-subtle)]',
     label: null,
     labelClass: '',
   },
@@ -71,7 +71,12 @@ function BookModal({ book, onClose }: BookModalProps) {
         aria-modal="true"
         aria-label={book.title}
         onClick={(e) => e.stopPropagation()}
-        className="bg-[#fffdf8] border border-[#ded6c8] rounded-xl shadow-[0_24px_70px_rgba(25,24,23,0.24)] p-5 max-w-[380px] w-full"
+        className="border rounded-xl p-5 max-w-[380px] w-full"
+        style={{
+          background: 'var(--bg-input)',
+          borderColor: 'var(--border)',
+          boxShadow: '0 24px 70px var(--shadow)',
+        }}
       >
         <div className="flex gap-4 mb-4">
           <div className="relative rounded overflow-hidden shrink-0" style={{ width: 56, height: 80 }}>
@@ -79,12 +84,13 @@ function BookModal({ book, onClose }: BookModalProps) {
           </div>
           <div className="min-w-0">
             <div className="font-semibold text-sm leading-snug mb-1">{book.title}</div>
-            <div className="text-xs text-[#6d675f]">{book.author}</div>
+            <div className="text-xs" style={{ color: 'var(--text-muted)' }}>{book.author}</div>
           </div>
         </div>
         <button
           onClick={onClose}
-          className="text-xs text-[#999] hover:text-[#555] cursor-pointer"
+          className="text-xs cursor-pointer"
+          style={{ color: 'var(--text-muted)' }}
         >
           Закрыть (Esc)
         </button>
@@ -100,7 +106,10 @@ export default function MatchingScenarios({ scenarios, bookById }: Props) {
 
   if (scenarios.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full p-6 text-center text-[#6d675f]">
+      <div
+        className="flex flex-col items-center justify-center h-full p-6 text-center"
+        style={{ color: 'var(--text-muted)' }}
+      >
         <div className="text-3xl mb-2">🎯</div>
         <p className="text-sm">Недостаточно участников или сигнапов для формирования сценариев.</p>
       </div>
@@ -129,7 +138,8 @@ export default function MatchingScenarios({ scenarios, bookById }: Props) {
                   <div className="flex items-center gap-2 mb-2 flex-wrap">
                     <button
                       onClick={() => book && openModal(book)}
-                      className="text-sm font-semibold text-[#191817] hover:text-[#0f766e] text-left leading-snug"
+                      className="text-sm font-semibold text-left leading-snug hover:underline"
+                      style={{ color: 'var(--text)' }}
                     >
                       {book?.title ?? card.bookId}
                     </button>


### PR DESCRIPTION
## Summary
- Хардкод цветов (`#f6f2e8`, `#fffdf8`, `#ded6c8`, `#191817`, `#6d675f`, `#0f766e`, `font-mono` пустой стейт) на странице `/matching` заменён на CSS-переменные из `app/globals.css` (`--bg`, `--bg-input`, `--bg-elevated`, `--border`, `--text`, `--text-muted`, `--accent`, `--success`, `--shadow`).
- Страница теперь визуально согласована с остальным сайтом и автоматически работает в dark mode через `[data-theme=\"dark\"]`.
- Цвет-теги участников и tier-бейджи сценариев оставлены прежними — они семантические (различают участников / тип сценария), а не привязаны к фону.

Затронуто: `app/matching/page.tsx`, `components/nd/Matching{Header,PersonalList,MyMoves,Scenarios}.tsx`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 635 passed
- [ ] Визуальная проверка на проде после деплоя (light + dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)