### PR TITLE
feat(matching): redesign catalog panel — all books, popup, clean design system

### DIFF
--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -170,6 +170,11 @@ export default async function MatchingPage({
   // Frozen or impersonating = read-only
   const isFrozenOrImpersonating = activeSession.status === 'frozen' || isImpersonating
 
+  // Get current user's pseudonym (not impersonating) or null if impersonating
+  const userPseudonym = !isImpersonating
+    ? participants.find((p) => p.userId === session.user.id)?.pseudonym ?? null
+    : null
+
   return (
     <div
       className="flex flex-col"
@@ -186,6 +191,7 @@ export default async function MatchingPage({
         viewedPseudonym={viewedParticipant?.pseudonym ?? null}
         viewedName={viewedParticipant?.name ?? null}
         asParam={asParam}
+        userPseudonym={userPseudonym}
       />
 
       {/* Two-column workspace */}

--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -112,10 +112,10 @@ export default async function MatchingPage({
     ? participants.find((p) => p.userId === asParam)
     : null
 
-  // Fetch per-book participant signups for chips in the personal list
+  // Fetch per-book participant signups for chips in the popup (all catalog books, not just user's list)
   const inListBookIds = personalBooks.filter((b) => b.isInList).map((b) => b.bookId)
   const bookParticipants: BookParticipant[] =
-    inListBookIds.length > 0 && participantUserIds.length > 0
+    participantUserIds.length > 0
       ? await db
           .select({
             userId: signupBooks.userId,
@@ -131,12 +131,7 @@ export default async function MatchingPage({
               eq(bookPriorities.bookId, signupBooks.bookId),
             ),
           )
-          .where(
-            and(
-              inArray(signupBooks.bookId, inListBookIds),
-              inArray(signupBooks.userId, participantUserIds),
-            ),
-          )
+          .where(inArray(signupBooks.userId, participantUserIds))
           .then((rows) =>
             rows.map((row) => {
               const participant = participants.find((p) => p.userId === row.userId)
@@ -214,7 +209,7 @@ export default async function MatchingPage({
             style={{ borderColor: 'var(--border)' }}
           >
             <h2 className="text-base font-semibold m-0" style={{ color: 'var(--text)' }}>
-              {isImpersonating ? 'Список участника' : 'Мой список'}
+              {isImpersonating ? 'Список участника' : 'Каталог'}
             </h2>
             {!isImpersonating && (
               <p className="text-xs mt-0.5 m-0" style={{ color: 'var(--text-muted)' }}>
@@ -235,20 +230,6 @@ export default async function MatchingPage({
               frozen={isFrozenOrImpersonating}
             />
           </div>
-          {isAdmin && !isImpersonating && (
-            <div
-              className="px-4 py-2.5 shrink-0 border-t"
-              style={{ borderColor: 'var(--border)' }}
-            >
-              <a
-                href="/admin?tab=matching"
-                className="text-xs underline"
-                style={{ color: 'var(--text-muted)' }}
-              >
-                Перейти в Админ-панель → Матчинг
-              </a>
-            </div>
-          )}
         </div>
 
         {/* Right column: scenarios + moves stacked */}

--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from 'next/navigation'
 import { db } from '@/lib/db'
 import { matchingSessions, matchingSessionParticipants, users, signupBooks, bookPriorities, books } from '@/lib/db/schema'
 import { eq, inArray, and } from 'drizzle-orm'
-import { fetchPersonalList } from '@/lib/matching/personal-list'
+import { fetchCatalogWithPersonalData } from '@/lib/matching/personal-list'
 import { generateScenarios } from '@/lib/matching/scenarios'
 import { fetchMyMoves } from '@/lib/matching/my-moves'
 import MatchingPersonalList from '@/components/nd/MatchingPersonalList'
@@ -103,7 +103,7 @@ export default async function MatchingPage({
       .leftJoin(users, eq(matchingSessionParticipants.userId, users.id))
       .where(eq(matchingSessionParticipants.sessionId, activeSession.id))
       .orderBy(matchingSessionParticipants.joinedAt),
-    fetchPersonalList(viewingUserId),
+    fetchCatalogWithPersonalData(viewingUserId),
     fetchMyMoves(viewingUserId, activeSession.id, activeSession.targetGroupSize),
   ])
 
@@ -113,8 +113,9 @@ export default async function MatchingPage({
     : null
 
   // Fetch per-book participant signups for chips in the personal list
+  const inListBookIds = personalBooks.filter((b) => b.isInList).map((b) => b.bookId)
   const bookParticipants: BookParticipant[] =
-    personalBooks.length > 0 && participantUserIds.length > 0
+    inListBookIds.length > 0 && participantUserIds.length > 0
       ? await db
           .select({
             userId: signupBooks.userId,
@@ -132,7 +133,7 @@ export default async function MatchingPage({
           )
           .where(
             and(
-              inArray(signupBooks.bookId, personalBooks.map((b) => b.bookId)),
+              inArray(signupBooks.bookId, inListBookIds),
               inArray(signupBooks.userId, participantUserIds),
             ),
           )
@@ -223,7 +224,7 @@ export default async function MatchingPage({
           </div>
           {!isImpersonating && (
             <MatchingRankNudge
-              show={personalBooks.length > 0 && personalBooks.every((b) => b.rank === null)}
+              show={inListBookIds.length > 0 && personalBooks.filter((b) => b.isInList).every((b) => b.rank === null)}
             />
           )}
           <div className="flex-1 min-h-0 overflow-y-auto">

--- a/components/nd/MatchingHeader.tsx
+++ b/components/nd/MatchingHeader.tsx
@@ -20,6 +20,7 @@ interface Props {
   viewedPseudonym: string | null
   viewedName: string | null
   asParam: string | null
+  userPseudonym: string | null
 }
 
 function useDeadlineText(deadlineAt: string | null): { text: string; urgent: boolean } {
@@ -79,6 +80,7 @@ export default function MatchingHeader({
   viewedPseudonym,
   viewedName,
   asParam,
+  userPseudonym,
 }: Props) {
   const { text: deadlineText, urgent } = useDeadlineText(deadlineAt)
 
@@ -135,6 +137,13 @@ export default function MatchingHeader({
                 <span className={urgent ? 'text-red-600 font-medium' : ''}>
                   {deadlineText}
                 </span>
+              </span>
+            )}
+            {userPseudonym && (
+              <span
+                className={`text-[11px] px-2.5 py-1 rounded-full font-medium shrink-0 ${pseudonymColor(userPseudonym)}`}
+              >
+                Я: {userPseudonym}
               </span>
             )}
             {sessionStatus === 'frozen' ? (

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import {
   DndContext,
   closestCenter,
@@ -19,9 +19,10 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import type { PersonalListBook } from '@/lib/matching/personal-list'
+import type { CatalogBook } from '@/lib/matching/personal-list'
 import CoverImage from './CoverImage'
 
+// BookParticipant stays — used for chips in the popup
 export interface BookParticipant {
   userId: string
   bookId: string
@@ -30,22 +31,15 @@ export interface BookParticipant {
   personalStatus: string | null
 }
 
-interface Props {
-  books: PersonalListBook[]
-  bookParticipants: BookParticipant[]
-  viewingUserId: string
-  frozen?: boolean
-}
-
 const PSEUDONYM_COLORS = [
-  { chip: 'bg-[#fde8d8] text-[#7c3516]', border: 'border-[#f8c4a0]', ring: 'ring-[#7c3516]' },
-  { chip: 'bg-[#dcfce7] text-[#14532d]', border: 'border-[#86efac]', ring: 'ring-[#14532d]' },
-  { chip: 'bg-[#dbeafe] text-[#1e3a8a]', border: 'border-[#93c5fd]', ring: 'ring-[#1e3a8a]' },
-  { chip: 'bg-[#fef9c3] text-[#713f12]', border: 'border-[#fde047]', ring: 'ring-[#713f12]' },
-  { chip: 'bg-[#f3e8ff] text-[#581c87]', border: 'border-[#d8b4fe]', ring: 'ring-[#581c87]' },
-  { chip: 'bg-[#ffe4e6] text-[#881337]', border: 'border-[#fda4af]', ring: 'ring-[#881337]' },
-  { chip: 'bg-[#d1fae5] text-[#065f46]', border: 'border-[#6ee7b7]', ring: 'ring-[#065f46]' },
-  { chip: 'bg-[#e0f2fe] text-[#075985]', border: 'border-[#7dd3fc]', ring: 'ring-[#075985]' },
+  { chip: 'bg-[#fde8d8] text-[#7c3516]', border: 'border-[#f8c4a0]' },
+  { chip: 'bg-[#dcfce7] text-[#14532d]', border: 'border-[#86efac]' },
+  { chip: 'bg-[#dbeafe] text-[#1e3a8a]', border: 'border-[#93c5fd]' },
+  { chip: 'bg-[#fef9c3] text-[#713f12]', border: 'border-[#fde047]' },
+  { chip: 'bg-[#f3e8ff] text-[#581c87]', border: 'border-[#d8b4fe]' },
+  { chip: 'bg-[#ffe4e6] text-[#881337]', border: 'border-[#fda4af]' },
+  { chip: 'bg-[#d1fae5] text-[#065f46]', border: 'border-[#6ee7b7]' },
+  { chip: 'bg-[#e0f2fe] text-[#075985]', border: 'border-[#7dd3fc]' },
 ]
 
 function getPseudonymColor(pseudonym: string) {
@@ -62,35 +56,25 @@ function interestLabel(rank: number | null, personalStatus: string | null): stri
   return 'готов(а)'
 }
 
-interface SortableRowProps {
-  book: PersonalListBook
-  index: number
-  total: number
-  frozen: boolean
-  chipsForBook: BookParticipant[]
+interface Props {
+  books: CatalogBook[]
+  bookParticipants: BookParticipant[]
   viewingUserId: string
-  onMoveUp: (bookId: string) => void
-  onMoveDown: (bookId: string) => void
-  onStatusChange: (bookId: string, status: string | null) => void
+  frozen?: boolean
 }
 
-function SortableRow({
-  book,
-  index,
-  total,
-  frozen,
-  chipsForBook,
-  viewingUserId,
-  onMoveUp,
-  onMoveDown,
-  onStatusChange,
-}: SortableRowProps) {
+interface SortableRowProps {
+  book: CatalogBook
+  index: number
+  frozen: boolean
+  onClick: (book: CatalogBook) => void
+}
+
+function SortableRow({ book, index, frozen, onClick }: SortableRowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: book.bookId,
     disabled: frozen,
   })
-
-  const canReorder = !frozen
 
   return (
     <li
@@ -99,198 +83,351 @@ function SortableRow({
         transform: CSS.Transform.toString(transform),
         transition,
         display: 'grid',
-        gridTemplateColumns: '52px 1fr 90px',
-        gap: '14px',
-        padding: '14px 16px',
+        gridTemplateColumns: '48px 1fr',
+        gap: '12px',
+        padding: '12px 16px',
         borderBottom: '1px solid var(--border)',
         opacity: isDragging ? 0.5 : 1,
         background: isDragging ? 'var(--bg-elevated)' : undefined,
         alignItems: 'start',
+        cursor: 'pointer',
       }}
+      onClick={() => onClick(book)}
     >
-      {/* Cover with drag handle */}
-      <div style={{ position: 'relative' }}>
-        {canReorder && (
+      {/* Rank + drag handle stacked */}
+      <div className="flex flex-col items-center gap-0.5 pt-0.5">
+        {book.rank != null && (
+          <span className="text-lg font-bold leading-none" style={{ color: 'var(--text)' }}>
+            #{index + 1}
+          </span>
+        )}
+        {!frozen && (
           <button
             {...attributes}
             {...listeners}
             aria-label={`Перетащить книгу ${book.title}`}
-            className="absolute cursor-grab select-none touch-none text-lg leading-none"
-            style={{ color: 'var(--text-muted)', opacity: 0.5, left: -14, top: '50%', transform: 'translateY(-50%)' }}
+            onClick={(e) => e.stopPropagation()}
+            className="cursor-grab select-none touch-none text-base leading-none"
+            style={{ color: 'var(--text-muted)', opacity: 0.5 }}
           >
             ⠿
           </button>
         )}
-        <div className="relative rounded overflow-hidden" style={{ width: 48, height: 68 }}>
+      </div>
+
+      {/* Cover + title + author */}
+      <div className="flex gap-3 min-w-0">
+        <div className="relative rounded overflow-hidden shrink-0" style={{ width: 44, height: 62 }}>
           <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
         </div>
-      </div>
-
-      {/* Title / author / participant chips */}
-      <div className="min-w-0">
-        <div className="font-semibold text-sm leading-snug mb-0.5" style={{ color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {book.title}
-        </div>
-        <div className="text-xs mb-2" style={{ color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {book.author}
-        </div>
-        {!frozen && (
-          <select
-            value={book.personalStatus ?? ''}
-            onChange={(e) => onStatusChange(book.bookId, e.target.value || null)}
-            className="text-[11px] border rounded px-1.5 py-0.5 cursor-pointer mb-1.5"
-            style={{
-              borderColor: 'var(--border)',
-              background: 'var(--bg-elevated)',
-              color: 'var(--text-muted)',
-            }}
+        <div className="min-w-0">
+          <div
+            className="font-semibold text-sm leading-snug mb-0.5"
+            style={{ color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
           >
-            <option value="">В списке</option>
-            <option value="reading">Читаю сейчас</option>
-            <option value="read">Прочитал(а)</option>
-          </select>
-        )}
-        {chipsForBook.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {chipsForBook.map((p) => {
-              const colors = getPseudonymColor(p.pseudonym)
-              const isMe = p.userId === viewingUserId
-              const label = interestLabel(p.rank, p.personalStatus)
-              const rankStr = p.rank != null ? ` #${p.rank}` : ''
-              return (
-                <span
-                  key={p.userId}
-                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] border ${colors.chip} ${colors.border} ${isMe ? `ring-1 ${colors.ring}` : ''}`}
-                  title={isMe ? 'Это вы' : undefined}
-                >
-                  {p.pseudonym} · {label}{rankStr}
-                </span>
-              )
-            })}
+            {book.title}
           </div>
-        )}
-      </div>
-
-      {/* Rank + reorder */}
-      <div className="flex flex-col items-end gap-1">
-        {book.rank != null && (
-          <span className="text-2xl font-bold leading-none" style={{ color: 'var(--text)' }}>
-            #{book.rank}
-          </span>
-        )}
-        <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
-          место в списке
-        </span>
-        {canReorder && (
-          <div className="flex flex-col gap-0.5 mt-0.5">
-            <button
-              onClick={() => onMoveUp(book.bookId)}
-              disabled={index === 0}
-              aria-label={`Переместить ${book.title} выше`}
-              className={`text-[11px] px-1.5 py-0.5 leading-none border rounded transition-colors ${
-                index === 0
-                  ? 'cursor-default opacity-30'
-                  : 'cursor-pointer opacity-70 hover:opacity-100'
-              }`}
-              style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
-            >
-              ▲
-            </button>
-            <button
-              onClick={() => onMoveDown(book.bookId)}
-              disabled={index === total - 1}
-              aria-label={`Переместить ${book.title} ниже`}
-              className={`text-[11px] px-1.5 py-0.5 leading-none border rounded transition-colors ${
-                index === total - 1
-                  ? 'cursor-default opacity-30'
-                  : 'cursor-pointer opacity-70 hover:opacity-100'
-              }`}
-              style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
-            >
-              ▼
-            </button>
+          <div
+            className="text-xs"
+            style={{ color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {book.author}
           </div>
-        )}
+        </div>
       </div>
     </li>
   )
 }
 
 interface StatusRowProps {
-  book: PersonalListBook
-  chipsForBook: BookParticipant[]
-  viewingUserId: string
-  frozen: boolean
-  onStatusChange: (bookId: string, status: string | null) => void
+  book: CatalogBook
+  onClick: (book: CatalogBook) => void
 }
 
-function StatusRow({ book, chipsForBook, viewingUserId, frozen, onStatusChange }: StatusRowProps) {
-  const statusLabel = book.personalStatus === 'reading' ? 'Читаю' : 'Прочитал(а)'
+function StatusRow({ book, onClick }: StatusRowProps) {
+  const statusIcon = book.personalStatus === 'reading' ? '📖' : '✓'
   return (
     <li
       style={{
         display: 'grid',
-        gridTemplateColumns: '52px 1fr',
-        gap: '14px',
-        padding: '14px 16px',
+        gridTemplateColumns: '48px 1fr',
+        gap: '12px',
+        padding: '12px 16px',
         borderBottom: '1px solid var(--border)',
         alignItems: 'start',
-        opacity: 0.75,
+        opacity: 0.7,
+        cursor: 'pointer',
       }}
+      onClick={() => onClick(book)}
     >
-      <div style={{ position: 'relative' }}>
-        <div className="relative rounded overflow-hidden" style={{ width: 48, height: 68 }}>
+      <div className="flex justify-center pt-1">
+        <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>{statusIcon}</span>
+      </div>
+      <div className="flex gap-3 min-w-0">
+        <div className="relative rounded overflow-hidden shrink-0" style={{ width: 44, height: 62 }}>
           <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
         </div>
-      </div>
-      <div className="min-w-0">
-        <div className="font-semibold text-sm leading-snug mb-0.5" style={{ color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {book.title}
-        </div>
-        <div className="text-xs mb-2" style={{ color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {book.author}
-        </div>
-        {!frozen ? (
-          <select
-            value={book.personalStatus ?? ''}
-            onChange={(e) => onStatusChange(book.bookId, e.target.value || null)}
-            className="text-[11px] border rounded px-1.5 py-0.5 cursor-pointer mb-1.5"
-            style={{
-              borderColor: 'var(--border)',
-              background: 'var(--bg-elevated)',
-              color: 'var(--text-muted)',
-            }}
+        <div className="min-w-0">
+          <div
+            className="font-semibold text-sm leading-snug mb-0.5"
+            style={{ color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
           >
-            <option value="">В списке</option>
-            <option value="reading">Читаю сейчас</option>
-            <option value="read">Прочитал(а)</option>
-          </select>
-        ) : (
-          <span className="text-[11px] italic mb-1.5" style={{ color: 'var(--text-muted)' }}>
-            {statusLabel}
-          </span>
-        )}
-        {chipsForBook.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {chipsForBook.map((p) => {
-              const colors = getPseudonymColor(p.pseudonym)
-              const isMe = p.userId === viewingUserId
-              const label = interestLabel(p.rank, p.personalStatus)
-              const rankStr = p.rank != null ? ` #${p.rank}` : ''
-              return (
-                <span
-                  key={p.userId}
-                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] border ${colors.chip} ${colors.border} ${isMe ? `ring-1 ${colors.ring}` : ''}`}
-                  title={isMe ? 'Это вы' : undefined}
-                >
-                  {p.pseudonym} · {label}{rankStr}
-                </span>
-              )
-            })}
+            {book.title}
           </div>
-        )}
+          <div
+            className="text-xs"
+            style={{ color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {book.author}
+          </div>
+        </div>
       </div>
     </li>
+  )
+}
+
+interface CatalogRowProps {
+  book: CatalogBook
+  onClick: (book: CatalogBook) => void
+}
+
+function CatalogRow({ book, onClick }: CatalogRowProps) {
+  return (
+    <li
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '48px 1fr',
+        gap: '12px',
+        padding: '12px 16px',
+        borderBottom: '1px solid var(--border)',
+        alignItems: 'start',
+        cursor: 'pointer',
+      }}
+      onClick={() => onClick(book)}
+    >
+      <div className="flex justify-center pt-1">
+        <span className="text-base leading-none" style={{ color: 'var(--text-muted)', opacity: 0.4 }}>+</span>
+      </div>
+      <div className="flex gap-3 min-w-0">
+        <div className="relative rounded overflow-hidden shrink-0" style={{ width: 44, height: 62 }}>
+          <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
+        </div>
+        <div className="min-w-0">
+          <div
+            className="font-semibold text-sm leading-snug mb-0.5"
+            style={{ color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {book.title}
+          </div>
+          <div
+            className="text-xs"
+            style={{ color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {book.author}
+          </div>
+        </div>
+      </div>
+    </li>
+  )
+}
+
+interface BookDetailModalProps {
+  book: CatalogBook
+  chips: BookParticipant[]
+  viewingUserId: string
+  frozen: boolean
+  onClose: () => void
+  onStatusChange: (bookId: string, status: string | null) => Promise<void>
+  onAddToList: (bookId: string) => Promise<void>
+  onRemoveFromList: (bookId: string) => Promise<void>
+}
+
+function BookDetailModal({
+  book,
+  chips,
+  viewingUserId,
+  frozen,
+  onClose,
+  onStatusChange,
+  onAddToList,
+  onRemoveFromList,
+}: BookDetailModalProps) {
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  async function handleAddToList() {
+    setBusy(true)
+    try { await onAddToList(book.bookId) } finally { setBusy(false) }
+  }
+
+  async function handleRemoveFromList() {
+    setBusy(true)
+    try { await onRemoveFromList(book.bookId) } finally { setBusy(false) }
+  }
+
+  async function handleStatusChange(newStatus: string | null) {
+    setBusy(true)
+    try { await onStatusChange(book.bookId, newStatus) } finally { setBusy(false) }
+  }
+
+  const meta: string[] = []
+  if (book.publishedDate) meta.push(book.publishedDate.split('/').at(-1) ?? book.publishedDate)
+  if (book.pages) meta.push(`${book.pages} стр.`)
+
+  return (
+    <div
+      role="presentation"
+      onClick={onClose}
+      className="fixed inset-0 flex items-center justify-center z-50 p-4"
+      style={{ background: 'rgba(26, 23, 20, 0.4)' }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={book.title}
+        onClick={(e) => e.stopPropagation()}
+        className="border rounded-xl p-5 max-w-[420px] w-full"
+        style={{
+          background: 'var(--bg-input)',
+          borderColor: 'var(--border)',
+          boxShadow: '0 24px 70px rgba(26,23,20,0.18)',
+          maxHeight: '85vh',
+          overflowY: 'auto',
+        }}
+      >
+        {/* Cover + title */}
+        <div className="flex gap-4 mb-4">
+          <div className="relative rounded overflow-hidden shrink-0" style={{ width: 64, height: 92 }}>
+            <CoverImage coverUrl={book.coverUrl} title={book.title} author={book.author} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div
+              className="font-semibold text-base leading-snug mb-1"
+              style={{ fontFamily: 'Georgia, "Times New Roman", serif', color: 'var(--text)' }}
+            >
+              {book.title}
+            </div>
+            <div className="text-sm mb-1" style={{ color: 'var(--text-muted)' }}>
+              {book.author}
+            </div>
+            {meta.length > 0 && (
+              <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                {meta.join(' · ')}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Participant chips */}
+        {chips.length > 0 && (
+          <div className="mb-4">
+            <div className="text-xs font-medium mb-1.5" style={{ color: 'var(--text-muted)' }}>
+              Участники
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {chips.map((p) => {
+                const colors = getPseudonymColor(p.pseudonym)
+                const isMe = p.userId === viewingUserId
+                const label = interestLabel(p.rank, p.personalStatus)
+                const rankStr = p.rank != null ? ` #${p.rank}` : ''
+                return (
+                  <span
+                    key={p.userId}
+                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] border ${colors.chip} ${colors.border} ${isMe ? 'ring-1 ring-current' : ''}`}
+                    title={isMe ? 'Это вы' : undefined}
+                  >
+                    {p.pseudonym} · {label}{rankStr}
+                  </span>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Description */}
+        {book.description && (
+          <p
+            className="text-sm leading-relaxed mb-4"
+            style={{ color: 'var(--text-body)' }}
+          >
+            {book.description}
+          </p>
+        )}
+
+        {/* Status (only if in list and not frozen) */}
+        {book.isInList && !frozen && (
+          <div className="mb-4">
+            <label className="text-xs font-medium block mb-1.5" style={{ color: 'var(--text-muted)' }}>
+              Статус
+            </label>
+            <select
+              value={book.personalStatus ?? ''}
+              onChange={(e) => handleStatusChange(e.target.value || null)}
+              disabled={busy}
+              className="w-full text-sm border rounded-lg px-3 py-2 cursor-pointer"
+              style={{
+                borderColor: 'var(--border)',
+                background: 'var(--bg-elevated)',
+                color: 'var(--text)',
+              }}
+            >
+              <option value="">В списке</option>
+              <option value="reading">Читаю сейчас</option>
+              <option value="read">Прочитал(а)</option>
+            </select>
+          </div>
+        )}
+
+        {/* Add/Remove buttons */}
+        {!frozen && (
+          <div className="flex gap-2">
+            {book.isInList ? (
+              <button
+                onClick={handleRemoveFromList}
+                disabled={busy}
+                className="flex-1 text-sm py-2 px-3 rounded-lg border transition-colors"
+                style={{
+                  borderColor: 'var(--border)',
+                  background: 'var(--bg-elevated)',
+                  color: 'var(--text-muted)',
+                  cursor: busy ? 'default' : 'pointer',
+                }}
+              >
+                {busy ? '…' : 'Убрать из списка'}
+              </button>
+            ) : (
+              <button
+                onClick={handleAddToList}
+                disabled={busy}
+                className="flex-1 text-sm py-2 px-3 rounded-lg border transition-colors font-medium"
+                style={{
+                  borderColor: 'var(--accent)',
+                  background: 'var(--accent)',
+                  color: '#fff',
+                  cursor: busy ? 'default' : 'pointer',
+                  opacity: busy ? 0.7 : 1,
+                }}
+              >
+                {busy ? '…' : 'Добавить в список'}
+              </button>
+            )}
+          </div>
+        )}
+
+        <button
+          onClick={onClose}
+          className="mt-4 text-xs cursor-pointer block"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          Закрыть (Esc)
+        </button>
+      </div>
+    </div>
   )
 }
 
@@ -310,6 +447,18 @@ async function patchStatus(bookId: string, status: string | null) {
   })
 }
 
+async function addToList(bookId: string) {
+  await fetch('/api/matching/books', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ bookId }),
+  })
+}
+
+async function removeFromList(bookId: string) {
+  await fetch(`/api/matching/books/${bookId}`, { method: 'DELETE' })
+}
+
 export default function MatchingPersonalList({
   books: initialBooks,
   bookParticipants,
@@ -318,6 +467,7 @@ export default function MatchingPersonalList({
 }: Props) {
   const [books, setBooks] = useState(initialBooks)
   const [announcement, setAnnouncement] = useState('')
+  const [modalBook, setModalBook] = useState<CatalogBook | null>(null)
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -325,11 +475,14 @@ export default function MatchingPersonalList({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   )
 
-  // Re-rank all active books (personalStatus === null) and clear rank on status books
-  function rerank(updatedBooks: PersonalListBook[]): PersonalListBook[] {
+  const activeBooks = books.filter((b) => b.isInList && b.personalStatus === null)
+  const statusBooks = books.filter((b) => b.isInList && b.personalStatus !== null)
+  const catalogOnlyBooks = books.filter((b) => !b.isInList)
+
+  function rerank(updatedBooks: CatalogBook[]): CatalogBook[] {
     let rankCounter = 0
     return updatedBooks.map((b) => {
-      if (b.personalStatus === null) {
+      if (b.isInList && b.personalStatus === null) {
         rankCounter++
         return { ...b, rank: rankCounter }
       }
@@ -337,58 +490,28 @@ export default function MatchingPersonalList({
     })
   }
 
-  const applyNewOrder = useCallback(async (newBooks: PersonalListBook[]) => {
+  const applyNewOrder = useCallback(async (newBooks: CatalogBook[]) => {
     const reranked = rerank(newBooks)
     setBooks(reranked)
-    await patchPriorities(reranked.filter((b) => b.personalStatus === null).map((b) => b.bookId))
+    await patchPriorities(
+      reranked.filter((b) => b.isInList && b.personalStatus === null).map((b) => b.bookId)
+    )
     return reranked
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
       const { active, over } = event
       if (!over || active.id === over.id) return
-      // Only active books are in the DnD context; find within active books
-      const activeBooks = books.filter((b) => b.personalStatus === null)
-      const oldIndex = activeBooks.findIndex((b) => b.bookId === active.id)
-      const newIndex = activeBooks.findIndex((b) => b.bookId === over.id)
-      const reorderedActive = arrayMove(activeBooks, oldIndex, newIndex)
-      // Reconstruct full list: active books (reordered) then status books
-      const statusBooks = books.filter((b) => b.personalStatus !== null)
-      const newBooks = [...reorderedActive, ...statusBooks]
-      await applyNewOrder(newBooks)
+      const currentActive = books.filter((b) => b.isInList && b.personalStatus === null)
+      const oldIndex = currentActive.findIndex((b) => b.bookId === active.id)
+      const newIndex = currentActive.findIndex((b) => b.bookId === over.id)
+      const reorderedActive = arrayMove(currentActive, oldIndex, newIndex)
+      const rest = books.filter((b) => !(b.isInList && b.personalStatus === null))
+      await applyNewOrder([...reorderedActive, ...rest])
       setAnnouncement(
-        `Книга ${activeBooks[oldIndex].title} перемещена на позицию ${newIndex + 1} из ${reorderedActive.length}`,
-      )
-    },
-    [books, applyNewOrder],
-  )
-
-  const handleMoveUp = useCallback(
-    async (bookId: string) => {
-      const activeBooks = books.filter((b) => b.personalStatus === null)
-      const index = activeBooks.findIndex((b) => b.bookId === bookId)
-      if (index <= 0) return
-      const reorderedActive = arrayMove(activeBooks, index, index - 1)
-      const statusBooks = books.filter((b) => b.personalStatus !== null)
-      await applyNewOrder([...reorderedActive, ...statusBooks])
-      setAnnouncement(
-        `Книга ${activeBooks[index].title} перемещена на позицию ${index} из ${reorderedActive.length}`,
-      )
-    },
-    [books, applyNewOrder],
-  )
-
-  const handleMoveDown = useCallback(
-    async (bookId: string) => {
-      const activeBooks = books.filter((b) => b.personalStatus === null)
-      const index = activeBooks.findIndex((b) => b.bookId === bookId)
-      if (index >= activeBooks.length - 1) return
-      const reorderedActive = arrayMove(activeBooks, index, index + 1)
-      const statusBooks = books.filter((b) => b.personalStatus !== null)
-      await applyNewOrder([...reorderedActive, ...statusBooks])
-      setAnnouncement(
-        `Книга ${activeBooks[index].title} перемещена на позицию ${index + 2} из ${reorderedActive.length}`,
+        `Книга ${currentActive[oldIndex].title} перемещена на позицию ${newIndex + 1} из ${reorderedActive.length}`,
       )
     },
     [books, applyNewOrder],
@@ -396,70 +519,55 @@ export default function MatchingPersonalList({
 
   const handleStatusChange = useCallback(
     async (bookId: string, newStatus: string | null) => {
-      if (newStatus === null) {
-        // Book returning to active: preserve existing active books' ranks,
-        // append the returning book at the end without a rank (rank: null).
-        // final_pos = after all ranked active books, unranked at tail.
-        const updatedBooks = books.map((b) =>
-          b.bookId === bookId ? { ...b, personalStatus: null, rank: null } : b,
-        )
-        // Active books: ranked ones first (sorted by rank), then unranked at tail
-        const rankedActive = updatedBooks
-          .filter((b) => b.personalStatus === null && b.rank !== null)
-          .sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))
-        const unrankedActive = updatedBooks.filter(
-          (b) => b.personalStatus === null && b.rank === null,
-        )
-        const statusBooks = updatedBooks.filter((b) => b.personalStatus !== null)
-        const merged = [...rankedActive, ...unrankedActive, ...statusBooks]
-        setBooks(merged)
-
-        await Promise.all([
-          patchStatus(bookId, newStatus),
-          // Only send already-ranked active books to preserve their positions;
-          // do not include the newly returned book so it stays unranked.
-          patchPriorities(rankedActive.map((b) => b.bookId)),
-        ])
-      } else {
-        // Book leaving active (status → reading/read): re-rank remaining active
-        // books to fill the gap left by the departing book.
-        const updatedBooks = books.map((b) =>
-          b.bookId === bookId ? { ...b, personalStatus: newStatus } : b,
-        )
-        const activeBooks = updatedBooks.filter((b) => b.personalStatus === null)
-        const statusBooks = updatedBooks.filter((b) => b.personalStatus !== null)
-        const reranked = rerank([...activeBooks, ...statusBooks])
-        setBooks(reranked)
-
-        await Promise.all([
-          patchStatus(bookId, newStatus),
-          patchPriorities(reranked.filter((b) => b.personalStatus === null).map((b) => b.bookId)),
-        ])
-      }
+      const updatedBooks = books.map((b) =>
+        b.bookId === bookId ? { ...b, personalStatus: newStatus } : b,
+      )
+      const rankedActive = updatedBooks
+        .filter((b) => b.isInList && b.personalStatus === null && b.rank !== null)
+        .sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))
+      const unrankedActive = updatedBooks.filter(
+        (b) => b.isInList && b.personalStatus === null && b.rank === null,
+      )
+      const statusBooksUpdated = updatedBooks.filter((b) => b.isInList && b.personalStatus !== null)
+      const catalog = updatedBooks.filter((b) => !b.isInList)
+      const merged = [...rankedActive, ...unrankedActive, ...statusBooksUpdated, ...catalog]
+      setBooks(merged)
+      setModalBook((prev) => (prev?.bookId === bookId ? { ...prev, personalStatus: newStatus } : prev))
+      await Promise.all([
+        patchStatus(bookId, newStatus),
+        patchPriorities(rankedActive.map((b) => b.bookId)),
+      ])
     },
     [books],
   )
 
-  if (books.length === 0) {
-    return (
-      <div
-        className="flex flex-col items-center justify-center h-full p-8 text-center"
-        style={{ color: 'var(--text-muted)' }}
-      >
-        <div className="text-4xl mb-3">📚</div>
-        <p className="text-sm leading-relaxed">
-          Вы ещё не добавили книги.{' '}
-          <a href="/" className="underline" style={{ color: 'var(--accent)' }}>
-            Перейдите в каталог
-          </a>
-          , чтобы выбрать книги для чтения.
-        </p>
-      </div>
-    )
-  }
+  const handleAddToList = useCallback(
+    async (bookId: string) => {
+      setBooks((prev) =>
+        prev.map((b) => (b.bookId === bookId ? { ...b, isInList: true, rank: null } : b)),
+      )
+      setModalBook((prev) => (prev?.bookId === bookId ? { ...prev, isInList: true } : prev))
+      await addToList(bookId)
+    },
+    [],
+  )
 
-  const activeBooks = books.filter((b) => b.personalStatus === null)
-  const statusBooks = books.filter((b) => b.personalStatus !== null)
+  const handleRemoveFromList = useCallback(
+    async (bookId: string) => {
+      setBooks((prev) => {
+        const updated = prev.map((b) =>
+          b.bookId === bookId ? { ...b, isInList: false, rank: null, personalStatus: null } : b,
+        )
+        return rerank(updated)
+      })
+      setModalBook((prev) =>
+        prev?.bookId === bookId ? { ...prev, isInList: false, rank: null, personalStatus: null } : prev,
+      )
+      await removeFromList(bookId)
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
 
   return (
     <>
@@ -474,34 +582,71 @@ export default function MatchingPersonalList({
         {announcement}
       </div>
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext
-          items={activeBooks.map((b) => b.bookId)}
-          strategy={verticalListSortingStrategy}
-        >
-          <ul className="list-none p-0 m-0" data-testid="matching-personal-list">
-            {activeBooks.map((book, idx) => {
-              const chipsForBook = bookParticipants.filter((p) => p.bookId === book.bookId)
-              return (
+      {modalBook && (
+        <BookDetailModal
+          book={modalBook}
+          chips={bookParticipants.filter((p) => p.bookId === modalBook.bookId)}
+          viewingUserId={viewingUserId}
+          frozen={frozen}
+          onClose={() => setModalBook(null)}
+          onStatusChange={handleStatusChange}
+          onAddToList={handleAddToList}
+          onRemoveFromList={handleRemoveFromList}
+        />
+      )}
+
+      {/* Active ranked books (drag-and-drop) */}
+      {activeBooks.length > 0 && (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext
+            items={activeBooks.map((b) => b.bookId)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul className="list-none p-0 m-0" data-testid="matching-personal-list">
+              {activeBooks.map((book, idx) => (
                 <SortableRow
                   key={book.bookId}
                   book={book}
                   index={idx}
-                  total={activeBooks.length}
                   frozen={frozen}
-                  chipsForBook={chipsForBook}
-                  viewingUserId={viewingUserId}
-                  onMoveUp={handleMoveUp}
-                  onMoveDown={handleMoveDown}
-                  onStatusChange={handleStatusChange}
+                  onClick={setModalBook}
                 />
-              )
-            })}
-          </ul>
-        </SortableContext>
-      </DndContext>
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      )}
 
+      {/* Status books section */}
       {statusBooks.length > 0 && (
+        <>
+          <div
+            className="px-4 py-2 border-b border-t"
+            style={{ borderColor: 'var(--border)', background: 'var(--bg-elevated)' }}
+          >
+            <span
+              className="text-[11px] font-medium uppercase tracking-wide block"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              В процессе / Прочитано
+            </span>
+            <span
+              className="text-[10px] block mt-0.5"
+              style={{ color: 'var(--text-muted)', opacity: 0.75 }}
+            >
+              исключены при расчёте ваших сценариев и ходов
+            </span>
+          </div>
+          <ul className="list-none p-0 m-0">
+            {statusBooks.map((book) => (
+              <StatusRow key={book.bookId} book={book} onClick={setModalBook} />
+            ))}
+          </ul>
+        </>
+      )}
+
+      {/* Catalog (not in list) */}
+      {catalogOnlyBooks.length > 0 && (
         <>
           <div
             className="px-4 py-2 border-b border-t"
@@ -511,25 +656,25 @@ export default function MatchingPersonalList({
               className="text-[11px] font-medium uppercase tracking-wide"
               style={{ color: 'var(--text-muted)' }}
             >
-              В процессе / Прочитано
+              Все книги клуба
             </span>
           </div>
           <ul className="list-none p-0 m-0">
-            {statusBooks.map((book) => {
-              const chipsForBook = bookParticipants.filter((p) => p.bookId === book.bookId)
-              return (
-                <StatusRow
-                  key={book.bookId}
-                  book={book}
-                  chipsForBook={chipsForBook}
-                  viewingUserId={viewingUserId}
-                  frozen={frozen}
-                  onStatusChange={handleStatusChange}
-                />
-              )
-            })}
+            {catalogOnlyBooks.map((book) => (
+              <CatalogRow key={book.bookId} book={book} onClick={setModalBook} />
+            ))}
           </ul>
         </>
+      )}
+
+      {activeBooks.length === 0 && statusBooks.length === 0 && catalogOnlyBooks.length === 0 && (
+        <div
+          className="flex flex-col items-center justify-center h-full p-8 text-center"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          <div className="text-4xl mb-3">📚</div>
+          <p className="text-sm leading-relaxed">Нет опубликованных книг.</p>
+        </div>
       )}
     </>
   )

--- a/components/nd/MatchingScenarios.tsx
+++ b/components/nd/MatchingScenarios.tsx
@@ -18,22 +18,19 @@ interface Props {
 
 const tierConfig = {
   leader: {
-    bg: 'bg-[#f0fdf4]',
-    border: 'border-[#86efac]',
+    style: { background: 'var(--bg-tag-green)', borderColor: 'var(--success)' },
     label: 'лидер',
-    labelClass: 'text-[#15803d] border-[#86efac]',
+    labelStyle: { color: 'var(--success)', borderColor: 'var(--success)' },
   },
   'max-coverage': {
-    bg: 'bg-[#eff6ff]',
-    border: 'border-[#93c5fd]',
+    style: { background: 'var(--bg-elevated)', borderColor: 'var(--border)' },
     label: 'макс. покрытие',
-    labelClass: 'text-[#1d4ed8] border-[#93c5fd]',
+    labelStyle: { color: 'var(--text-secondary)', borderColor: 'var(--border)' },
   },
   'sub-max': {
-    bg: 'bg-[var(--bg-elevated)]',
-    border: 'border-[var(--border-subtle)]',
+    style: { background: 'var(--bg-elevated)', borderColor: 'var(--border)' },
     label: null,
-    labelClass: '',
+    labelStyle: {},
   },
 } as const
 
@@ -126,7 +123,8 @@ export default function MatchingScenarios({ scenarios, bookById }: Props) {
           return (
             <li
               key={card.bookId}
-              className={`rounded-xl border p-3.5 ${tier.bg} ${tier.border}`}
+              className="rounded-xl border p-3.5"
+              style={tier.style}
             >
               <div className="flex items-start gap-3">
                 {book && (
@@ -144,7 +142,7 @@ export default function MatchingScenarios({ scenarios, bookById }: Props) {
                       {book?.title ?? card.bookId}
                     </button>
                     {tier.label && (
-                      <span className={`text-[10px] border rounded-full px-2 py-0.5 shrink-0 ${tier.labelClass}`}>
+                      <span className="text-[10px] border rounded-full px-2 py-0.5 shrink-0" style={tier.labelStyle}>
                         {tier.label}
                       </span>
                     )}

--- a/lib/matching/__tests__/personal-list.test.ts
+++ b/lib/matching/__tests__/personal-list.test.ts
@@ -1,4 +1,4 @@
-import { fetchPersonalList } from '../personal-list'
+import { fetchPersonalList, fetchCatalogWithPersonalData } from '../personal-list'
 import { db } from '@/lib/db'
 
 jest.mock('@/lib/db', () => ({
@@ -16,6 +16,15 @@ function makeChain(result: unknown[]) {
   return {
     from: jest.fn().mockReturnThis(),
     innerJoin: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockResolvedValue(result),
+  }
+}
+
+function makeChainLeftJoin(result: unknown[]) {
+  return {
+    from: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockResolvedValue(result),
@@ -51,5 +60,32 @@ describe('fetchPersonalList', () => {
     mockDb.select = jest.fn().mockReturnValue(makeChain(rows))
     const result = await fetchPersonalList('u1')
     expect(result[0].readingStatus).toBe('reading')
+  })
+})
+
+describe('fetchCatalogWithPersonalData', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns all published books, not just signed-up ones', async () => {
+    const rows = [
+      { bookId: 'b1', title: 'Книга А', author: 'Автор', description: 'desc', coverUrl: null,
+        pages: 300, publishedDate: '2020', rank: 1, personalStatus: null, signupBookId: 'b1' },
+      { bookId: 'b2', title: 'Книга Б', author: 'Автор', description: '', coverUrl: null,
+        pages: null, publishedDate: '', rank: null, personalStatus: 'reading', signupBookId: 'b2' },
+      { bookId: 'b3', title: 'Книга В', author: 'Автор', description: '', coverUrl: null,
+        pages: null, publishedDate: '', rank: null, personalStatus: null, signupBookId: null },
+    ]
+    mockDb.select = jest.fn().mockReturnValue(makeChainLeftJoin(rows))
+    const result = await fetchCatalogWithPersonalData('u1')
+    expect(result).toHaveLength(3)
+    expect(result[0]).toMatchObject({ bookId: 'b1', rank: 1, isInList: true })
+    expect(result[1]).toMatchObject({ bookId: 'b2', personalStatus: 'reading', isInList: true })
+    expect(result[2]).toMatchObject({ bookId: 'b3', rank: null, isInList: false })
+  })
+
+  it('returns empty array when no books published', async () => {
+    mockDb.select = jest.fn().mockReturnValue(makeChainLeftJoin([]))
+    const result = await fetchCatalogWithPersonalData('u1')
+    expect(result).toEqual([])
   })
 })

--- a/lib/matching/personal-list.ts
+++ b/lib/matching/personal-list.ts
@@ -45,3 +45,60 @@ export async function fetchPersonalList(userId: string): Promise<PersonalListBoo
 
   return rows
 }
+
+export interface CatalogBook {
+  bookId: string
+  title: string
+  author: string
+  description: string
+  coverUrl: string | null
+  pages: number | null
+  publishedDate: string
+  rank: number | null
+  personalStatus: string | null
+  isInList: boolean
+}
+
+export async function fetchCatalogWithPersonalData(userId: string): Promise<CatalogBook[]> {
+  const rows = await db
+    .select({
+      bookId: books.id,
+      title: books.title,
+      author: books.author,
+      description: books.description,
+      coverUrl: books.coverUrl,
+      pages: books.pages,
+      publishedDate: books.publishedDate,
+      rank: bookPriorities.rank,
+      personalStatus: signupBooks.personalStatus,
+      signupBookId: signupBooks.bookId,
+    })
+    .from(books)
+    .leftJoin(
+      signupBooks,
+      and(eq(signupBooks.bookId, books.id), eq(signupBooks.userId, userId)),
+    )
+    .leftJoin(
+      bookPriorities,
+      and(eq(bookPriorities.bookId, books.id), eq(bookPriorities.userId, userId)),
+    )
+    .where(eq(books.visibility, 'published'))
+    .orderBy(
+      sql`${bookPriorities.rank} ASC NULLS LAST`,
+      asc(books.sortOrder),
+      asc(books.title),
+    )
+
+  return rows.map((row) => ({
+    bookId: row.bookId,
+    title: row.title,
+    author: row.author,
+    description: row.description,
+    coverUrl: row.coverUrl,
+    pages: row.pages,
+    publishedDate: row.publishedDate,
+    rank: row.rank,
+    personalStatus: row.personalStatus,
+    isInList: row.signupBookId !== null,
+  }))
+}


### PR DESCRIPTION
## Summary

- **Каталог вместо «Мой список»**: левая панель теперь показывает ВСЕ книги клуба (не только подписки), разбитые на 3 секции: активный список (DnD), «В процессе / Прочитано», «Все книги клуба»
- **Попап по клику на книгу**: cover, описание, чипы участников (другие участники сессии), статус-дропдаун (только если книга в списке), кнопки «Добавить» / «Убрать»
- **Убраны из строк**: кнопки ▲▼, inline-чипы участников, inline-статус — всё перенесено в попап
- **Ранг (#N) + drag-handle** рядом слева от обложки
- **Псевдоним пользователя** «Я: Зверь» в шапке сессии
- **Подзаголовок** «исключены при расчёте ваших сценариев и ходов» в секции «В процессе / Прочитано»
- **Убрана ссылка** «Перейти в Админ-панель» из нижней части левой панели
- **Тиры сценариев** переведены на CSS-переменные дизайн-системы (`--bg-tag-green`, `--success`, `--bg-elevated`, `--border`) вместо hardcoded hex

## Test plan

- [ ] Страница /matching отображает все книги клуба в левой панели
- [ ] Клик по книге открывает попап с обложкой, описанием, чипами участников
- [ ] В попапе: статус-дропдаун отображается только для книг в списке; кнопка «Добавить» для книг вне списка
- [ ] Drag-and-drop переставляет книги; ранг #N обновляется
- [ ] Шапка показывает «Я: Псевдоним» для текущего пользователя
- [ ] Сценарии групп отображаются в warm parchment-стиле (не синие/зелёные generic-цвета)
- [ ] Ссылки «Перейти в Админ-панель» нет в панели
- [ ] Frozen/impersonation — режим только чтения (попап без кнопок и статуса)

🤖 Generated with [Claude Code](https://claude.com/claude-code)