### PR TITLE
feat(matching): управление участниками — кнопка выхода для пользователя, добавление/удаление для админа

### DIFF
--- a/app/api/admin/matching/sessions/[id]/participants/[userId]/route.ts
+++ b/app/api/admin/matching/sessions/[id]/participants/[userId]/route.ts
@@ -1,0 +1,44 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { matchingSessions, matchingSessionParticipants } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { broadcast } from '@/lib/matching/realtime/hub'
+
+interface Params { params: { id: string; userId: string } }
+
+export async function DELETE(_req: NextRequest, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  const { id: sessionId, userId } = params
+
+  const [matchingSession] = await db
+    .select({ id: matchingSessions.id, status: matchingSessions.status })
+    .from(matchingSessions)
+    .where(eq(matchingSessions.id, sessionId))
+    .limit(1)
+
+  if (!matchingSession) {
+    return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+  }
+  if (matchingSession.status !== 'active') {
+    return NextResponse.json({ error: 'Session is not active' }, { status: 409 })
+  }
+
+  await db
+    .delete(matchingSessionParticipants)
+    .where(
+      and(
+        eq(matchingSessionParticipants.sessionId, sessionId),
+        eq(matchingSessionParticipants.userId, userId),
+      ),
+    )
+
+  broadcast(sessionId, 'state_changed', { userId, kind: 'participant_left' })
+
+  return NextResponse.json({ success: true })
+}

--- a/app/api/admin/matching/sessions/[id]/participants/route.ts
+++ b/app/api/admin/matching/sessions/[id]/participants/route.ts
@@ -1,0 +1,88 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { matchingSessions, matchingSessionParticipants, users } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { assignPseudonym } from '@/lib/matching/pseudonyms'
+import { broadcast } from '@/lib/matching/realtime/hub'
+
+interface Params { params: { id: string } }
+
+export async function GET(_req: NextRequest, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  const { id: sessionId } = params
+
+  const participants = await db
+    .select({
+      userId: matchingSessionParticipants.userId,
+      pseudonym: matchingSessionParticipants.pseudonym,
+      joinedAt: matchingSessionParticipants.joinedAt,
+      name: users.name,
+    })
+    .from(matchingSessionParticipants)
+    .leftJoin(users, eq(matchingSessionParticipants.userId, users.id))
+    .where(eq(matchingSessionParticipants.sessionId, sessionId))
+    .orderBy(matchingSessionParticipants.joinedAt)
+
+  return NextResponse.json({ success: true, data: participants })
+}
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.isAdmin) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  const { id: sessionId } = params
+
+  const body = await req.json().catch(() => ({}))
+  const { userId } = body as { userId?: string }
+  if (!userId) {
+    return NextResponse.json({ error: 'userId required' }, { status: 400 })
+  }
+
+  const [matchingSession] = await db
+    .select({ id: matchingSessions.id, status: matchingSessions.status })
+    .from(matchingSessions)
+    .where(eq(matchingSessions.id, sessionId))
+    .limit(1)
+
+  if (!matchingSession) {
+    return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+  }
+  if (matchingSession.status !== 'active') {
+    return NextResponse.json({ error: 'Session is not active' }, { status: 409 })
+  }
+
+  const [existing] = await db
+    .select({ pseudonym: matchingSessionParticipants.pseudonym })
+    .from(matchingSessionParticipants)
+    .where(and(
+      eq(matchingSessionParticipants.sessionId, sessionId),
+      eq(matchingSessionParticipants.userId, userId),
+    ))
+    .limit(1)
+
+  if (existing) {
+    return NextResponse.json({ success: true, pseudonym: existing.pseudonym }, { status: 200 })
+  }
+
+  const taken = await db
+    .select({ pseudonym: matchingSessionParticipants.pseudonym })
+    .from(matchingSessionParticipants)
+    .where(eq(matchingSessionParticipants.sessionId, sessionId))
+
+  const takenSet = new Set(taken.map(r => r.pseudonym))
+  const pseudonym = assignPseudonym(takenSet)
+
+  await db.insert(matchingSessionParticipants).values({ sessionId, userId, pseudonym })
+
+  broadcast(sessionId, 'state_changed', { userId, kind: 'participant_joined' })
+
+  return NextResponse.json({ success: true, pseudonym }, { status: 201 })
+}
+

--- a/app/api/matching/sessions/[id]/leave/route.ts
+++ b/app/api/matching/sessions/[id]/leave/route.ts
@@ -1,0 +1,45 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { matchingSessions, matchingSessionParticipants } from '@/lib/db/schema'
+import { eq, and } from 'drizzle-orm'
+import { broadcast } from '@/lib/matching/realtime/hub'
+
+interface Params { params: { id: string } }
+
+export async function DELETE(_req: NextRequest, { params }: Params) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const userId = session.user.id
+  const { id: sessionId } = params
+
+  const [matchingSession] = await db
+    .select({ id: matchingSessions.id, status: matchingSessions.status })
+    .from(matchingSessions)
+    .where(eq(matchingSessions.id, sessionId))
+    .limit(1)
+
+  if (!matchingSession) {
+    return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+  }
+  if (matchingSession.status !== 'active') {
+    return NextResponse.json({ error: 'Session is not active' }, { status: 409 })
+  }
+
+  await db
+    .delete(matchingSessionParticipants)
+    .where(
+      and(
+        eq(matchingSessionParticipants.sessionId, sessionId),
+        eq(matchingSessionParticipants.userId, userId),
+      ),
+    )
+
+  broadcast(sessionId, 'state_changed', { userId, kind: 'participant_left' })
+
+  return NextResponse.json({ success: true })
+}

--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -177,6 +177,7 @@ export default async function MatchingPage({
       style={{ height: '100svh', overflow: 'hidden', background: 'var(--bg)', color: 'var(--text)' }}
     >
       <MatchingHeader
+        sessionId={activeSession.id}
         sessionName={activeSession.name}
         sessionStatus={activeSession.status}
         targetGroupSize={activeSession.targetGroupSize}

--- a/components/nd/AdminMatchingSession.tsx
+++ b/components/nd/AdminMatchingSession.tsx
@@ -20,6 +20,18 @@ interface AuditEntry {
   adminName: string | null
 }
 
+interface Participant {
+  userId: string
+  pseudonym: string
+  joinedAt: string
+  name: string | null
+}
+
+interface AllUser {
+  id: string
+  name: string | null
+}
+
 const fieldInput: React.CSSProperties = {
   fontFamily: 'var(--nd-mono), monospace',
   fontSize: '0.8rem',
@@ -47,6 +59,13 @@ export default function AdminMatchingSession() {
   const [error, setError] = useState<string | null>(null)
   const [auditLog, setAuditLog] = useState<AuditEntry[]>([])
   const [auditLoading, setAuditLoading] = useState(false)
+
+  const [participants, setParticipants] = useState<Participant[]>([])
+  const [allUsers, setAllUsers] = useState<AllUser[]>([])
+  const [participantsLoading, setParticipantsLoading] = useState(false)
+  const [selectedUserId, setSelectedUserId] = useState('')
+  const [addingParticipant, setAddingParticipant] = useState(false)
+  const [removingUserId, setRemovingUserId] = useState<string | null>(null)
 
   // Form state
   const [name, setName] = useState('')
@@ -83,14 +102,69 @@ export default function AdminMatchingSession() {
     }
   }, [])
 
+  const loadParticipants = useCallback(async (sessionId: string) => {
+    setParticipantsLoading(true)
+    try {
+      const res = await fetch(`/api/admin/matching/sessions/${sessionId}/participants`)
+      const json = await res.json()
+      if (res.ok) setParticipants(json.data ?? [])
+    } finally {
+      setParticipantsLoading(false)
+    }
+  }, [])
+
+  const loadAllUsers = useCallback(async () => {
+    const res = await fetch('/api/admin/users')
+    const json = await res.json()
+    if (res.ok) setAllUsers(json.data ?? [])
+  }, [])
+
   useEffect(() => {
     const active = sessions.find(s => s.status === 'active')
-    if (active) loadAudit(active.id)
-  }, [sessions, loadAudit])
+    if (active) {
+      loadAudit(active.id)
+      loadParticipants(active.id)
+      loadAllUsers()
+    }
+  }, [sessions, loadAudit, loadParticipants, loadAllUsers])
 
   const activeSession = sessions.find(s => s.status === 'active')
   const [freezing, setFreezing] = useState(false)
   const [freezeError, setFreezeError] = useState<string | null>(null)
+
+  async function handleAddParticipant() {
+    if (!activeSession || !selectedUserId) return
+    setAddingParticipant(true)
+    try {
+      const res = await fetch(`/api/admin/matching/sessions/${activeSession.id}/participants`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: selectedUserId }),
+      })
+      if (res.ok) {
+        setSelectedUserId('')
+        await loadParticipants(activeSession.id)
+      }
+    } finally {
+      setAddingParticipant(false)
+    }
+  }
+
+  async function handleRemoveParticipant(userId: string) {
+    if (!activeSession) return
+    setRemovingUserId(userId)
+    try {
+      const res = await fetch(
+        `/api/admin/matching/sessions/${activeSession.id}/participants/${userId}`,
+        { method: 'DELETE' },
+      )
+      if (res.ok) {
+        await loadParticipants(activeSession.id)
+      }
+    } finally {
+      setRemovingUserId(null)
+    }
+  }
 
   async function handleFreeze() {
     if (!activeSession) return
@@ -170,6 +244,91 @@ export default function AdminMatchingSession() {
             </button>
           </div>
           {freezeError && <p style={{ color: '#c00', fontSize: '0.75rem', marginTop: 4 }}>{freezeError}</p>}
+        </div>
+      )}
+
+      {!loading && activeSession && (
+        <div style={{ marginBottom: '1.5rem', padding: '0.8rem', border: '1px solid #333', borderRadius: 3 }}>
+          <div style={{ fontWeight: 600, marginBottom: '0.6rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            Участники ({participants.length})
+            <button
+              onClick={() => loadParticipants(activeSession.id)}
+              style={{ ...btn, fontSize: '0.7rem', padding: '2px 6px' }}
+            >
+              ↺
+            </button>
+          </div>
+
+          {participantsLoading && <p style={{ color: '#999', fontSize: '0.78rem' }}>Загрузка…</p>}
+
+          {!participantsLoading && participants.length === 0 && (
+            <p style={{ color: '#999', fontSize: '0.78rem' }}>Нет участников.</p>
+          )}
+
+          {!participantsLoading && participants.length > 0 && (
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.76rem', marginBottom: '0.75rem' }}>
+              <thead>
+                <tr style={{ borderBottom: '1px solid #ccc', textAlign: 'left' }}>
+                  <th style={{ padding: '3px 8px 3px 0' }}>Псевдоним</th>
+                  <th style={{ padding: '3px 8px' }}>Пользователь</th>
+                  <th style={{ padding: '3px 8px' }}>Вступил</th>
+                  <th style={{ padding: '3px 8px' }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {participants.map(p => (
+                  <tr key={p.userId} style={{ borderBottom: '1px solid #f0f0f0' }}>
+                    <td style={{ padding: '3px 8px 3px 0', fontWeight: 500 }}>{p.pseudonym}</td>
+                    <td style={{ padding: '3px 8px', color: '#555' }}>
+                      <a
+                        href={`/matching?as=${p.userId}`}
+                        style={{ color: '#333', textDecoration: 'underline' }}
+                        title={p.userId}
+                      >
+                        {p.name ?? p.userId.slice(0, 12) + '…'}
+                      </a>
+                    </td>
+                    <td style={{ padding: '3px 8px', color: '#999', whiteSpace: 'nowrap' }}>
+                      {new Date(p.joinedAt).toLocaleString('ru-RU', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                    </td>
+                    <td style={{ padding: '3px 8px' }}>
+                      <button
+                        onClick={() => handleRemoveParticipant(p.userId)}
+                        disabled={removingUserId === p.userId}
+                        style={{ ...btn, fontSize: '0.7rem', padding: '1px 6px', color: '#c00', borderColor: '#c00' }}
+                      >
+                        {removingUserId === p.userId ? '…' : 'Убрать'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+            <select
+              value={selectedUserId}
+              onChange={e => setSelectedUserId(e.target.value)}
+              style={{ ...fieldInput, width: 'auto', minWidth: 160, border: '1px solid #ccc', padding: '4px 6px', borderRadius: 2 }}
+            >
+              <option value="">— выбрать пользователя —</option>
+              {allUsers
+                .filter(u => !participants.some(p => p.userId === u.id))
+                .map(u => (
+                  <option key={u.id} value={u.id}>
+                    {u.name ?? u.id.slice(0, 12) + '…'}
+                  </option>
+                ))}
+            </select>
+            <button
+              onClick={handleAddParticipant}
+              disabled={!selectedUserId || addingParticipant}
+              style={{ ...btn, opacity: !selectedUserId || addingParticipant ? 0.5 : 1 }}
+            >
+              {addingParticipant ? 'Добавляю…' : 'Добавить'}
+            </button>
+          </div>
         </div>
       )}
 

--- a/components/nd/MatchingHeader.tsx
+++ b/components/nd/MatchingHeader.tsx
@@ -10,6 +10,7 @@ interface Participant {
 }
 
 interface Props {
+  sessionId: string
   sessionName: string
   sessionStatus: string
   targetGroupSize: number
@@ -70,6 +71,7 @@ function pseudonymColor(pseudonym: string) {
 }
 
 export default function MatchingHeader({
+  sessionId,
   sessionName,
   sessionStatus,
   targetGroupSize,
@@ -83,6 +85,18 @@ export default function MatchingHeader({
   userPseudonym,
 }: Props) {
   const { text: deadlineText, urgent } = useDeadlineText(deadlineAt)
+  const [leaving, setLeaving] = useState(false)
+
+  async function handleLeave() {
+    if (!window.confirm('Покинуть сессию? При следующем входе на страницу вы будете добавлены заново с новым псевдонимом.')) return
+    setLeaving(true)
+    try {
+      await fetch(`/api/matching/sessions/${sessionId}/leave`, { method: 'DELETE' })
+      window.location.href = '/'
+    } finally {
+      setLeaving(false)
+    }
+  }
 
   return (
     <>
@@ -159,7 +173,24 @@ export default function MatchingHeader({
           </div>
         </div>
 
-        {/* Right: participants popover */}
+        {/* Right: leave button + participants popover */}
+        <div className="flex items-center gap-2 shrink-0">
+        {sessionStatus === 'active' && !isImpersonating && (
+          <button
+            onClick={handleLeave}
+            disabled={leaving}
+            className="px-3 py-1.5 rounded-lg border text-sm transition-all hover:-translate-y-px"
+            style={{
+              borderColor: 'var(--border)',
+              background: 'var(--bg-input)',
+              color: 'var(--text-muted)',
+              cursor: leaving ? 'default' : 'pointer',
+              opacity: leaving ? 0.6 : 1,
+            }}
+          >
+            {leaving ? '…' : 'Покинуть'}
+          </button>
+        )}
         <Popover.Root>
           <Popover.Trigger asChild>
             <button
@@ -252,6 +283,7 @@ export default function MatchingHeader({
             </Popover.Content>
           </Popover.Portal>
         </Popover.Root>
+        </div>
       </header>
     </>
   )

--- a/docs/wiki/Group-Matching-Mode.md
+++ b/docs/wiki/Group-Matching-Mode.md
@@ -61,9 +61,13 @@ PK: `(session_id, user_id)`.
 | GET | `/api/matching/sessions` | Список всех сессий (только admin) |
 | POST | `/api/matching/sessions` | Создать сессию (только admin) |
 | POST | `/api/matching/sessions/:id/join` | Присоединиться к сессии (участник получает псевдоним) |
+| DELETE | `/api/matching/sessions/:id/leave` | Покинуть сессию (только активные сессии) |
 | POST | `/api/matching/sessions/:id/freeze` | Заморозить сессию (только admin) |
 | POST | `/api/matching/sessions/:id/heartbeat` | Обновить presence (участники; для admin — no-op) |
 | GET | `/api/matching/sessions/:id/audit-log` | Журнал admin_views для сессии (только admin) |
+| GET | `/api/admin/matching/sessions/:id/participants` | Список участников с именами (только admin) |
+| POST | `/api/admin/matching/sessions/:id/participants` | Добавить участника из базы пользователей (только admin, только active) |
+| DELETE | `/api/admin/matching/sessions/:id/participants/:userId` | Убрать участника из сессии (только admin, только active) |
 | GET | `/api/matching/stream?session=<id>` | SSE-канал с событиями сессии |
 | GET | `/api/matching/state?session=<id>&as=<userId>` | Текущее состояние (personalBooks, myMoves, scenarios) |
 | POST | `/api/matching/books` | Добавить книгу в личный список |
@@ -115,6 +119,22 @@ PK: `(session_id, user_id)`.
 - Мутации заблокированы (middleware возвращает 403 при попытке POST/PATCH/DELETE с `?as=`).
 - Каждый успешный просмотр записывается в `admin_views`.
 - Таблица просмотров видна в Админ-панели → Матчинг → «Журнал просмотров».
+
+## Управление участниками
+
+### Пользователь покидает сессию
+
+Кнопка «Покинуть» в шапке `/matching` видна только в активной сессии и только для своего аккаунта (скрыта при impersonation и frozen). При нажатии — confirm-диалог → `DELETE /api/matching/sessions/:id/leave` → редирект на `/`.
+
+После выхода запись в `matching_session_participants` удаляется. При следующем визите на `/matching` auto-join добавит пользователя обратно с новым псевдонимом (старые сигнапы и приоритеты сохраняются).
+
+### Администратор управляет составом
+
+Вкладка «Матчинг» в Админ-панели → блок «Участники» (только в активной сессии):
+- Таблица текущих участников: псевдоним, имя/id пользователя, время вступления, кнопка «Убрать»
+- Форма добавления: выпадающий список пользователей, не состоящих в сессии → «Добавить»
+
+Добавление работает по той же логике что и auto-join: присваивает уникальный животный псевдоним. Оба действия работают только для `status = active` и отправляют SSE-событие `state_changed` всем подключённым клиентам.
 
 ## Заморозка сессии
 


### PR DESCRIPTION
## Summary

- **Пользователь**: кнопка «Покинуть» в шапке `/matching` — удаляет запись из сессии, перенаправляет на `/`. При следующем визите — автовход с новым псевдонимом. Кнопка видна только в активной сессии, скрыта при impersonation и в замороженной.
- **Администратор**: блок «Участники» в Админ-панели → Матчинг → активная сессия: таблица с псевдонимами и именами, кнопка «Убрать» рядом с каждым, и форма добавления пользователя из выпадающего списка (фильтруются уже участвующие).
- Добавление/удаление работает только для активных сессий, broadcast обновляет realtime-состояние на странице матчинга.

## Test plan

- [ ] Кнопка «Покинуть» видна в шапке в активной сессии
- [ ] После подтверждения — страница редиректит на `/`, пользователь выпадает из участников
- [ ] Повторный заход на `/matching` → пользователь снова добавляется (с новым псевдонимом)
- [ ] Кнопка скрыта при frozen-сессии и при admin-impersonation
- [ ] Админка: блок «Участники» показывает таблицу с псевдонимами
- [ ] Кнопка «Убрать» удаляет участника, таблица обновляется
- [ ] Выпадающий список не содержит уже участвующих; «Добавить» вставляет с псевдонимом

🤖 Generated with [Claude Code](https://claude.com/claude-code)