### PR TITLE
fix(matching): align catalog grid + visible drag handle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -188,6 +188,16 @@ body {
   margin-top: 0.6rem;
 }
 
+/* ── Drag handle visibility ───────────────────────────────────────────────── */
+
+.nd-drag-handle {
+  opacity: 0.28;
+  transition: opacity 0.15s ease;
+}
+.nd-catalog-row:hover .nd-drag-handle {
+  opacity: 0.55;
+}
+
 /* ── Catalog row hover ────────────────────────────────────────────────────── */
 
 .nd-catalog-row {

--- a/components/nd/MatchingImpactWorkspace.tsx
+++ b/components/nd/MatchingImpactWorkspace.tsx
@@ -65,7 +65,7 @@ export default function MatchingImpactWorkspace({
   const scenarioCount = overview.scenarios.length
 
   return (
-    <div className="grid gap-4 h-full min-h-0" style={{ gridTemplateColumns: 'minmax(0, 1.15fr) minmax(0, 0.85fr)' }}>
+    <div className="grid h-full min-h-0" style={{ gridTemplateColumns: 'minmax(0, 1.18fr) minmax(0, 0.82fr)', gap: '1.1rem' }}>
       <section data-testid="matching-reader-circles-panel" style={panel}>
         <div style={panelHeadStyle}>
           <h2 style={h2Style}>

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -123,8 +123,8 @@ function SortableRow({ book, index, frozen, isFirst, onClick, onRemove }: Sortab
             {...listeners}
             aria-label={`Перетащить книгу ${book.title}`}
             onClick={(e) => e.stopPropagation()}
-            className="cursor-grab select-none touch-none"
-            style={{ color: 'var(--text-muted)', opacity: 0, fontSize: '0.8rem', background: 'none', border: 'none', padding: 0 }}
+            className="nd-drag-handle cursor-grab select-none touch-none"
+            style={{ color: 'var(--text-muted)', fontSize: '1rem', background: 'none', border: 'none', padding: 0, lineHeight: 1 }}
           >
             ⠿
           </button>


### PR DESCRIPTION
## Summary
- **Grid alignment**: `MatchingImpactWorkspace` теперь использует те же `1.18fr/0.82fr` и `gap:1.1rem` что и нижний каталог → колонки визуально совпадают
- **Drag handle**: иконка `⠿` в «Мои книги» всегда видна (opacity 0.28), ярче при ховере (0.55) — было невидимо (opacity:0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)