### PR TITLE
fix(matching): inline group size editor in design system style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -164,6 +164,17 @@ body {
   font-family: var(--nd-sans);
 }
 
+/* ── Inline number input: убрать браузерные стрелки ─────────────────────── */
+
+.nd-inline-number::-webkit-inner-spin-button,
+.nd-inline-number::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.nd-inline-number {
+  -moz-appearance: textfield;
+}
+
 /* ── Move item: плавное раскрытие блока «После добавления» ───────────────── */
 
 .nd-move-item {

--- a/components/nd/MatchingHeader.tsx
+++ b/components/nd/MatchingHeader.tsx
@@ -170,33 +170,48 @@ export default function MatchingHeader({
             style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}
           >
             {editingSize ? (
-              <span className="inline-flex items-center gap-1">
+              <span className="inline-flex items-baseline gap-1.5">
                 <span>Группы по</span>
                 <input
                   value={sizeValue}
                   onChange={(event) => setSizeValue(event.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSaveGroupSize(); if (e.key === 'Escape') { setSizeValue(String(targetGroupSize)); setEditingSize(false) } }}
                   type="number"
                   min={2}
-                  className="w-12 px-1 py-0.5 border"
+                  autoFocus
+                  className="nd-inline-number"
                   style={{
-                    borderRadius: 'var(--radius-sm)',
-                    borderColor: 'var(--border)',
-                    background: 'var(--bg-input)',
+                    width: '2.4em',
+                    font: 'inherit',
                     color: 'var(--text)',
+                    background: 'transparent',
+                    border: 'none',
+                    borderBottom: '1px solid var(--border-strong)',
+                    outline: 'none',
+                    padding: '0 0 1px',
+                    textAlign: 'center',
                   }}
                 />
                 <button
                   type="button"
                   onClick={handleSaveGroupSize}
                   disabled={savingSize}
-                  style={{ color: 'var(--text)', background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', font: 'inherit' }}
+                  style={{
+                    font: 'inherit',
+                    color: 'var(--accent)',
+                    background: 'none',
+                    border: 'none',
+                    cursor: savingSize ? 'default' : 'pointer',
+                    padding: 0,
+                    fontWeight: 500,
+                  }}
                 >
                   {savingSize ? '…' : 'Сохранить'}
                 </button>
                 <button
                   type="button"
                   onClick={() => { setSizeValue(String(targetGroupSize)); setEditingSize(false) }}
-                  style={{ color: 'var(--text-muted)', background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline', font: 'inherit' }}
+                  style={{ font: 'inherit', color: 'var(--text-muted)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
                 >
                   Отмена
                 </button>


### PR DESCRIPTION
## Summary
Поле «Группы по N» в режиме редактирования — приведено к дизайн-системе.

**Было**: браузерный number input со стрелками-спиннером, border со всех сторон

**Стало**:
- Стрелки скрыты через `.nd-inline-number` CSS (webkit + firefox)
- Поле: прозрачный фон, только нижняя линия `var(--border-strong)`, шрифт наследует размер меты (0.8rem) — вписывается в строку
- «Сохранить»: `var(--accent)`, weight 500
- «Отмена»: `var(--text-muted)`, тихий
- Enter/Escape как горячие клавиши

🤖 Generated with [Claude Code](https://claude.com/claude-code)