### PR TITLE
feat: add matching feature presentation

### DIFF
--- a/app/matching/presentation/page.tsx
+++ b/app/matching/presentation/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next'
+import MatchingFeaturePresentation from '@/components/nd/MatchingFeaturePresentation'
+
+export const metadata: Metadata = {
+  title: 'Презентация: читательские круги',
+  description: 'Упрощенный интерактивный рассказ о сценариях читательских кругов',
+}
+
+export default function MatchingPresentationPage() {
+  return <MatchingFeaturePresentation />
+}

--- a/components/nd/MatchingFeaturePresentation.module.css
+++ b/components/nd/MatchingFeaturePresentation.module.css
@@ -1,0 +1,501 @@
+.deck {
+  min-height: 100vh;
+  background:
+    linear-gradient(90deg, rgba(17, 17, 17, 0.035) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(17, 17, 17, 0.035) 1px, transparent 1px),
+    var(--bg);
+  background-size: 44px 44px;
+  color: var(--text);
+}
+
+.hero,
+.slide {
+  min-height: 100svh;
+  padding: 4.5rem clamp(1.25rem, 5vw, 5.5rem);
+  scroll-snap-align: start;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(360px, 1.08fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: center;
+  border-bottom: 2px solid var(--border-strong);
+}
+
+.heroText {
+  max-width: 760px;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  font-family: var(--nd-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.hero h1 {
+  margin: 0;
+  max-width: 980px;
+  font-family: var(--nd-serif);
+  font-size: clamp(3rem, 7vw, 7.4rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+
+.heroText > p:last-child,
+.slideInner > p,
+.twoColumn > p,
+.statementGrid p,
+.assumptionList p,
+.finalGrid p {
+  color: var(--text-secondary);
+  font-size: clamp(1.05rem, 1.35vw, 1.34rem);
+  line-height: 1.52;
+}
+
+.heroText > p:last-child {
+  max-width: 690px;
+  margin: 1.5rem 0 0;
+}
+
+.heroBoard {
+  animation: boardIn 680ms ease both;
+}
+
+.slide {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--hair);
+}
+
+.slideInner {
+  width: 100%;
+}
+
+.slide h2 {
+  margin: 0 0 2rem;
+  max-width: 1120px;
+  font-family: var(--nd-serif);
+  font-size: clamp(2.5rem, 5.4vw, 5.8rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.darkSlide {
+  background: var(--text);
+  color: var(--bg-input);
+}
+
+.darkSlide .eyebrow {
+  color: var(--accent-soft);
+}
+
+.darkSlide p {
+  color: var(--hair);
+}
+
+.twoColumn {
+  display: grid;
+  grid-template-columns: minmax(0, 0.75fr) minmax(420px, 1.25fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: start;
+}
+
+.statementGrid,
+.finalGrid,
+.solutionGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--border-strong);
+  border: 1px solid var(--border-strong);
+}
+
+.finalGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.solutionGrid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.statementGrid > div,
+.finalGrid > div,
+.solutionGrid > div {
+  min-height: 260px;
+  padding: clamp(1.25rem, 2.4vw, 2.25rem);
+  background: var(--bg-input);
+}
+
+.finalGrid > div {
+  background: var(--text);
+}
+
+.statementGrid b,
+.finalGrid b,
+.solutionGrid b {
+  display: block;
+  margin-bottom: 0.8rem;
+  font-family: var(--nd-serif);
+  font-size: clamp(1.5rem, 2.5vw, 2.3rem);
+  line-height: 1.05;
+}
+
+.solutionGrid b {
+  color: var(--accent);
+}
+
+.assumptionList {
+  display: grid;
+  gap: 1px;
+  border-top: 1px solid var(--border-strong);
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.assumptionList p {
+  margin: 0;
+  padding: 1.1rem 0;
+  border-top: 1px solid var(--hair);
+}
+
+.assumptionList p:first-child {
+  border-top: none;
+}
+
+.prototype {
+  border: 1px solid var(--border-strong);
+  background: var(--bg-input);
+  box-shadow: var(--shadow-card);
+}
+
+.prototypeHeader {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.2rem;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.prototypeHeader span {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-family: var(--nd-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.prototypeHeader b {
+  font-size: 1rem;
+}
+
+.prototype button,
+.moveCard button {
+  border: 1px solid var(--border-strong);
+  background: var(--text);
+  color: var(--bg-input);
+  padding: 0.72rem 1rem;
+  font-family: var(--nd-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.prototype button:hover,
+.moveCard button:hover {
+  background: var(--accent);
+  transform: translateY(-1px);
+}
+
+.moveCard button:disabled {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  cursor: default;
+  transform: none;
+}
+
+.prototypeGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.12fr) minmax(320px, 0.88fr);
+  min-height: 560px;
+}
+
+.panel {
+  min-width: 0;
+  border-right: 1px solid var(--hair);
+}
+
+.panel:last-child {
+  border-right: none;
+}
+
+.panelHead {
+  padding: 1rem 1.2rem;
+  border-bottom: 1px solid var(--hair);
+}
+
+.panelHead h3 {
+  margin: 0;
+  font-family: var(--nd-serif);
+  font-size: 1.2rem;
+}
+
+.panelHead p {
+  margin: 0.25rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.scenarioList {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+}
+
+.scenarioCard,
+.moveCard {
+  background: var(--bg);
+  border: 1px solid var(--hair);
+  padding: 1rem;
+}
+
+.scenarioCard:first-child {
+  border-color: var(--border-strong);
+  background: var(--accent-soft);
+}
+
+.scenarioHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.scenarioHeader h3 {
+  margin: 0;
+  font-family: var(--nd-mono);
+  font-size: 0.82rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.scenarioHeader span,
+.scenarioScore {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.coverage {
+  text-align: right;
+}
+
+.coverage b {
+  display: block;
+  font-family: var(--nd-serif);
+  font-size: 1.3rem;
+}
+
+.circleStack {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.8rem;
+}
+
+.circleCard {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  gap: 0.8rem;
+  align-items: start;
+  padding: 0.8rem;
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid var(--hair-soft);
+}
+
+.cover {
+  display: grid;
+  place-items: center;
+  width: 52px;
+  aspect-ratio: 0.7;
+  background: var(--text);
+  color: var(--bg-input);
+  font-family: var(--nd-serif);
+  font-weight: 700;
+  font-size: 0.78rem;
+  line-height: 1;
+}
+
+.circleCard h4,
+.moveCard h4 {
+  margin: 0;
+  font-family: var(--nd-serif);
+  font-size: 1.12rem;
+  line-height: 1.13;
+}
+
+.circleCard p,
+.moveCard p {
+  margin: 0.2rem 0 0;
+  color: var(--text-muted);
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.65rem;
+}
+
+.chip {
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: baseline;
+  padding: 0.28rem 0.48rem;
+  border: 1px solid var(--hair);
+  background: var(--bg-tag);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+}
+
+.chip b {
+  color: inherit;
+}
+
+.chip span {
+  color: var(--text-muted);
+}
+
+.strongChip {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--bg-input);
+}
+
+.strongChip span {
+  color: var(--accent);
+}
+
+.circleNote {
+  margin-top: 0.65rem;
+  color: var(--accent);
+  font-size: 0.82rem;
+}
+
+.leftOut {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
+  color: var(--text-muted);
+}
+
+.leftOut b {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.moveCard {
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr);
+  gap: 0.9rem;
+  margin: 1rem;
+  border-left: 3px solid var(--accent);
+  transition: background 180ms ease;
+}
+
+.moveCard:hover {
+  background: var(--accent-soft);
+}
+
+.moveDone {
+  border-left-color: var(--success);
+  background: var(--bg-tag-green);
+}
+
+.moveImpact {
+  display: grid;
+  gap: 0.2rem;
+  margin-top: 0.9rem;
+  padding-left: 0.8rem;
+  border-left: 2px solid var(--accent);
+  color: var(--text-secondary);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.moveImpact b {
+  color: var(--text);
+}
+
+.moveCard button {
+  margin-top: 0.9rem;
+  width: 100%;
+}
+
+@keyframes boardIn {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 980px) {
+  .hero,
+  .twoColumn,
+  .prototypeGrid,
+  .statementGrid,
+  .finalGrid,
+  .solutionGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    align-items: start;
+  }
+
+  .prototypeHeader {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .panel {
+    border-right: none;
+    border-bottom: 1px solid var(--hair);
+  }
+}
+
+@media (max-width: 640px) {
+  .hero,
+  .slide {
+    padding: 2.5rem 1rem;
+  }
+
+  .hero h1 {
+    font-size: 3.2rem;
+  }
+
+  .slide h2 {
+    font-size: 2.5rem;
+  }
+
+  .circleCard,
+  .moveCard {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .cover {
+    width: 44px;
+  }
+}

--- a/components/nd/MatchingFeaturePresentation.tsx
+++ b/components/nd/MatchingFeaturePresentation.tsx
@@ -1,0 +1,422 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import styles from './MatchingFeaturePresentation.module.css'
+
+type Participant = {
+  id: string
+  name: string
+}
+
+type Book = {
+  id: string
+  title: string
+  author: string
+  mark: string
+}
+
+type Member = {
+  participantId: string
+  rank: number
+}
+
+type Circle = {
+  bookId: string
+  members: Member[]
+  note?: string
+}
+
+type Scenario = {
+  id: string
+  title: string
+  label: string
+  coverage: string
+  score: string
+  circles: Circle[]
+  leftOut: string[]
+  explanation: string
+}
+
+const participants: Participant[] = [
+  { id: 'maria', name: 'Мария' },
+  { id: 'vanya', name: 'Ваня' },
+  { id: 'evgeny', name: 'Евгений' },
+  { id: 'artem', name: 'Артем' },
+  { id: 'julia', name: 'Юлия' },
+  { id: 'alex', name: 'Александр' },
+]
+
+const books: Book[] = [
+  { id: 'country', title: 'Моя любимая страна', author: 'Елена Костюченко', mark: 'МОЯ' },
+  { id: 'patriot', title: 'Патриот', author: 'Алексей Навальный', mark: 'ПАТ' },
+  { id: 'neolib', title: 'Краткая история неолиберализма', author: 'David Harvey', mark: 'НЕО' },
+  { id: 'consensus', title: 'Консенсус: принятие решений в свободном обществе', author: 'Peter Gelderloos', mark: 'КОН' },
+]
+
+const bookById = new Map(books.map((book) => [book.id, book]))
+const participantById = new Map(participants.map((participant) => [participant.id, participant]))
+
+const beforeScenarios: Scenario[] = [
+  {
+    id: 'before-best',
+    title: 'Сценарий 1',
+    label: 'лучший сейчас',
+    coverage: '6/6',
+    score: 'полное покрытие, но не максимум интереса',
+    circles: [
+      {
+        bookId: 'country',
+        members: [
+          { participantId: 'maria', rank: 1 },
+          { participantId: 'vanya', rank: 2 },
+          { participantId: 'evgeny', rank: 4 },
+        ],
+      },
+      {
+        bookId: 'patriot',
+        members: [
+          { participantId: 'artem', rank: 3 },
+          { participantId: 'julia', rank: 2 },
+          { participantId: 'alex', rank: 5 },
+        ],
+      },
+    ],
+    leftOut: [],
+    explanation: 'Алгоритм сначала выбирает сценарии, где занято больше людей. Здесь заняты все, поэтому этот сценарий наверху.',
+  },
+  {
+    id: 'before-desired',
+    title: 'Сценарий 2',
+    label: 'сильнее по желаниям',
+    coverage: '3/6',
+    score: 'лучшие ранги, но половина людей вне круга',
+    circles: [
+      {
+        bookId: 'neolib',
+        members: [
+          { participantId: 'artem', rank: 1 },
+          { participantId: 'alex', rank: 1 },
+          { participantId: 'evgeny', rank: 1 },
+        ],
+        note: 'Эти трое сильнее хотят именно эту книгу.',
+      },
+    ],
+    leftOut: ['maria', 'julia', 'vanya'],
+    explanation: 'Этот круг очень желанный, но если выбрать только его, Мария, Юлия и Ваня не попадают ни в один круг.',
+  },
+]
+
+const afterScenarios: Scenario[] = [
+  {
+    id: 'after-best',
+    title: 'Сценарий 1',
+    label: 'лучший после хода',
+    coverage: '6/6',
+    score: 'полное покрытие и выше суммарный интерес',
+    circles: [
+      {
+        bookId: 'consensus',
+        members: [
+          { participantId: 'maria', rank: 1 },
+          { participantId: 'julia', rank: 2 },
+          { participantId: 'vanya', rank: 2 },
+        ],
+        note: 'Ход Марии собирает второй круг.',
+      },
+      {
+        bookId: 'neolib',
+        members: [
+          { participantId: 'artem', rank: 1 },
+          { participantId: 'alex', rank: 1 },
+          { participantId: 'evgeny', rank: 1 },
+        ],
+      },
+    ],
+    leftOut: [],
+    explanation: 'Теперь покрытие остается полным, но люди чаще получают книги с высоким личным приоритетом.',
+  },
+]
+
+const moveParticipants: Member[] = [
+  { participantId: 'julia', rank: 2 },
+  { participantId: 'vanya', rank: 2 },
+]
+
+function interestLabel(rank: number) {
+  return rank <= 1 ? 'очень хочет' : 'хочет'
+}
+
+function Slide({
+  eyebrow,
+  title,
+  children,
+  tone = 'light',
+}: {
+  eyebrow: string
+  title: string
+  children: React.ReactNode
+  tone?: 'light' | 'dark'
+}) {
+  return (
+    <section className={`${styles.slide} ${tone === 'dark' ? styles.darkSlide : ''}`}>
+      <div className={styles.slideInner}>
+        <p className={styles.eyebrow}>{eyebrow}</p>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    </section>
+  )
+}
+
+function BookCover({ book }: { book: Book }) {
+  return (
+    <div className={styles.cover} aria-hidden="true">
+      <span>{book.mark}</span>
+    </div>
+  )
+}
+
+function Chip({ member }: { member: Member }) {
+  const participant = participantById.get(member.participantId)
+  const strong = member.rank <= 1
+
+  return (
+    <span
+      className={`${styles.chip} ${strong ? styles.strongChip : ''}`}
+      title={`${participant?.name}: книга на ${member.rank} месте`}
+    >
+      <b>{participant?.name}</b>
+      <span>{interestLabel(member.rank)}</span>
+    </span>
+  )
+}
+
+function CircleCard({ circle }: { circle: Circle }) {
+  const book = bookById.get(circle.bookId)
+  if (!book) return null
+
+  return (
+    <article className={styles.circleCard}>
+      <BookCover book={book} />
+      <div>
+        <h4>{book.title}</h4>
+        <p>{book.author}</p>
+        <div className={styles.chipRow}>
+          {circle.members.map((member) => (
+            <Chip key={`${circle.bookId}-${member.participantId}`} member={member} />
+          ))}
+        </div>
+        {circle.note && <div className={styles.circleNote}>{circle.note}</div>}
+      </div>
+    </article>
+  )
+}
+
+function ScenarioCard({ scenario }: { scenario: Scenario }) {
+  return (
+    <article className={styles.scenarioCard} title={scenario.explanation}>
+      <div className={styles.scenarioHeader}>
+        <div>
+          <h3>{scenario.title}</h3>
+          <span>{scenario.label}</span>
+        </div>
+        <div className={styles.coverage}>
+          <b>{scenario.coverage}</b>
+          <span>участников</span>
+        </div>
+      </div>
+      <div className={styles.scenarioScore}>{scenario.score}</div>
+      <div className={styles.circleStack}>
+        {scenario.circles.map((circle) => (
+          <CircleCard key={`${scenario.id}-${circle.bookId}`} circle={circle} />
+        ))}
+      </div>
+      {scenario.leftOut.length > 0 && (
+        <div className={styles.leftOut}>
+          <span>За бортом:</span>
+          {scenario.leftOut.map((id) => (
+            <b key={id}>{participantById.get(id)?.name}</b>
+          ))}
+        </div>
+      )}
+    </article>
+  )
+}
+
+function MiniPrototype() {
+  const [afterMove, setAfterMove] = useState(false)
+  const scenarios = afterMove ? afterScenarios : beforeScenarios
+  const heroText = useMemo(
+    () =>
+      afterMove
+        ? 'Мария добавила «Консенсус» на первое место. Лучшим стал другой сценарий.'
+        : 'Сейчас все заняты, но часть людей читает не самую желанную книгу.',
+    [afterMove]
+  )
+
+  return (
+    <div className={styles.prototype} data-testid="matching-presentation-prototype">
+      <div className={styles.prototypeHeader}>
+        <div>
+          <span>Сессия: пример на 6 участниках</span>
+          <b>{heroText}</b>
+        </div>
+        <button type="button" onClick={() => setAfterMove((value) => !value)}>
+          {afterMove ? 'Вернуть исходный расклад' : 'Мария добавляет «Консенсус»'}
+        </button>
+      </div>
+
+      <div className={styles.prototypeGrid}>
+        <section className={styles.panel}>
+          <div className={styles.panelHead}>
+            <h3>Читательские круги</h3>
+            <p>Показываем топ сценариев, а не все возможные комбинации.</p>
+          </div>
+          <div className={styles.scenarioList}>
+            {scenarios.map((scenario) => (
+              <ScenarioCard key={scenario.id} scenario={scenario} />
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.panel}>
+          <div className={styles.panelHead}>
+            <h3>Мои ходы</h3>
+            <p>Только действия, которые меняют лучший сценарий.</p>
+          </div>
+          <article className={`${styles.moveCard} ${afterMove ? styles.moveDone : ''}`}>
+            <BookCover book={bookById.get('consensus')!} />
+            <div>
+              <h4>Консенсус: принятие решений в свободном обществе</h4>
+              <p>Уже записались:</p>
+              <div className={styles.chipRow}>
+                {moveParticipants.map((member) => (
+                  <Chip key={member.participantId} member={member} />
+                ))}
+              </div>
+              <div className={styles.moveImpact}>
+                <b>После добавления</b>
+                <span>
+                  Лучшим сценарием станет: Консенсус + Краткая история неолиберализма.
+                </span>
+              </div>
+              <button type="button" onClick={() => setAfterMove(true)} disabled={afterMove}>
+                {afterMove ? 'Добавлено на первое место' : 'Хочу читать * на первое место'}
+              </button>
+            </div>
+          </article>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default function MatchingFeaturePresentation() {
+  return (
+    <main className={styles.deck}>
+      <section className={styles.hero}>
+        <div className={styles.heroText}>
+          <p className={styles.eyebrow}>Долгое наступление · matching</p>
+          <h1>Как показать влияние одного выбора на общий расклад чтения</h1>
+          <p>
+            Презентация фичи через пример Марии: почему один новый интерес может не просто
+            собрать круг, а улучшить распределение для всей сессии.
+          </p>
+        </div>
+        <div className={styles.heroBoard} aria-label="Схема читательских кругов">
+          <ScenarioCard scenario={beforeScenarios[0]} />
+        </div>
+      </section>
+
+      <Slide eyebrow="Проблема 1" title="Группы могут собраться вокруг не самых желанных книг">
+        <div className={styles.twoColumn}>
+          <p>
+            Формально все хорошо: шесть человек разбиты на две группы. Но Артем, Александр и
+            Евгений сильнее хотят читать «Краткую историю неолиберализма».
+          </p>
+          <ScenarioCard scenario={beforeScenarios[0]} />
+        </div>
+      </Slide>
+
+      <Slide eyebrow="Проблема 2" title="Без прозрачности участники верят администратору на слово">
+        <div className={styles.statementGrid}>
+          <div>
+            <b>Сейчас</b>
+            <p>«Кто-то посчитал, что так лучше».</p>
+          </div>
+          <div>
+            <b>Нужно</b>
+            <p>Псевдонимы, ранги и объяснение, почему сценарий оказался выше других.</p>
+          </div>
+          <div>
+            <b>Важно</b>
+            <p>Анонимность сохраняется: видны не реальные имена, а устойчивые псевдонимы.</p>
+          </div>
+        </div>
+      </Slide>
+
+      <Slide eyebrow="Проблема 3" title="Если все уже заняты, непонятно, зачем что-то менять">
+        <div className={styles.twoColumn}>
+          <p>
+            У Марии уже есть рабочий сценарий: она читает «Мою любимую страну», остальные тоже
+            распределены. Но она не видит, что ее ход может открыть более желанный расклад для
+            Артема, Александра и Евгения.
+          </p>
+          <ScenarioCard scenario={beforeScenarios[1]} />
+        </div>
+      </Slide>
+
+      <Slide eyebrow="Предпосылки" title="Лучший сценарий не всегда значит «всем идеально»">
+        <div className={styles.assumptionList}>
+          <p>Сначала максимизируем покрытие: меньше людей за бортом.</p>
+          <p>Если человек не выбрал книги, которые выбирают остальные, он может остаться вне круга.</p>
+          <p>Но если показать людям последствия их выбора, они могут добровольно сдвинуть расклад.</p>
+        </div>
+      </Slide>
+
+      <Slide eyebrow="Решение" title="Показываем не все варианты, а только полезную картину">
+        <div className={styles.solutionGrid}>
+          <div>
+            <b>1</b>
+            <p>Считаем топ сценариев и показываем, кто попадает в круги, а кто остается за бортом.</p>
+          </div>
+          <div>
+            <b>2</b>
+            <p>Показываем голоса через псевдонимы и ранги, чтобы не раскрывать реальные имена.</p>
+          </div>
+          <div>
+            <b>3</b>
+            <p>Лучший сценарий сортируется по покрытию, затем по силе интереса и качеству рангов.</p>
+          </div>
+          <div>
+            <b>4</b>
+            <p>В «Моих ходах» остаются только действия, которые меняют лучший сценарий.</p>
+          </div>
+        </div>
+      </Slide>
+
+      <Slide eyebrow="Интерактивный прототип" title="Мария видит, что ее ход меняет лучший сценарий">
+        <MiniPrototype />
+      </Slide>
+
+      <Slide eyebrow="Ключевой сигнал" title="Нужно объяснить не математику, а последствие" tone="dark">
+        <div className={styles.finalGrid}>
+          <div>
+            <b>Главный консерн</b>
+            <p>
+              Поймет ли пользователь, что другие хотят другую книгу, но без его действия этот круг
+              оставит часть людей за бортом?
+            </p>
+          </div>
+          <div>
+            <b>Решение в интерфейсе</b>
+            <p>
+              «Мои ходы» показывают только сильные действия: если поставить книгу на первое место,
+              лучший сценарий изменится. В карточке сразу видно, каким он станет.
+            </p>
+          </div>
+        </div>
+      </Slide>
+    </main>
+  )
+}

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -62,6 +62,25 @@ test.describe('Home submit book CTA layout', () => {
   })
 })
 
+test.describe('Matching feature presentation', () => {
+  test('interactive prototype shows how Maria changes the best scenario', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 950 })
+    await page.goto('/matching/presentation')
+    await expect(page.getByRole('heading', { name: /как показать влияние/i })).toBeVisible()
+
+    const prototype = page.getByTestId('matching-presentation-prototype')
+    await prototype.scrollIntoViewIfNeeded()
+    await expect(prototype.getByText(/сейчас все заняты/i)).toBeVisible()
+    await expect(prototype.getByText(/за бортом/i)).toBeVisible()
+
+    await prototype.getByRole('button', { name: /мария добавляет/i }).click()
+
+    await expect(prototype.getByText(/мария добавила/i)).toBeVisible()
+    await expect(prototype.getByText(/лучшим стал другой сценарий/i)).toBeVisible()
+    await expect(prototype.getByText(/консенсус \+ краткая история неолиберализма/i)).toBeVisible()
+  })
+})
+
 async function joinMatchingSessionAndAddBooks(page: Page, sessionId: string, bookIds: string[]) {
   const joinRes = await page.request.post(`/api/matching/sessions/${sessionId}/join`)
   expect(joinRes.ok()).toBe(true)


### PR DESCRIPTION
## Summary
- add a standalone /matching/presentation slide page for explaining reader-circle matching
- include a simplified interactive prototype showing Maria adding Consensus and changing the best scenario
- cover the three product problems: weaker book fit, admin trust, and unclear personal impact
- add a Playwright check for the interactive prototype

## Verification
- npm run lint
- npm run typecheck
- npm test -- --runInBand
- npm run build
- npm run test:e2e -- e2e/ui-states.spec.ts --grep "Matching feature presentation"