### PR TITLE
fix: persist matching feed and polish scenario hints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
           SKIP_ENV_VALIDATION: 'true'
 
       - name: Upload coverage to Codecov
+        timeout-minutes: 2
+        continue-on-error: true
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info

--- a/app/api/matching/feed/route.test.ts
+++ b/app/api/matching/feed/route.test.ts
@@ -5,7 +5,7 @@ import { GET } from './route'
 import { NextRequest } from 'next/server'
 import * as authModule from '@/lib/auth'
 import { db } from '@/lib/db'
-import { getFeed } from '@/lib/matching/realtime/feed'
+import { fetchFeedForSession } from '@/lib/matching/realtime/feed'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
 jest.mock('@/lib/db', () => ({ db: { select: jest.fn() } }))
@@ -17,12 +17,12 @@ jest.mock('@/lib/db/schema', () => ({
   },
 }))
 jest.mock('@/lib/matching/realtime/feed', () => ({
-  getFeed: jest.fn(),
+  fetchFeedForSession: jest.fn(),
 }))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockDb = db as jest.Mocked<typeof db>
-const mockGetFeed = getFeed as jest.Mock
+const mockFetchFeedForSession = fetchFeedForSession as jest.Mock
 
 function makeReq(sessionId?: string) {
   const suffix = sessionId ? `?session=${sessionId}` : ''
@@ -40,7 +40,7 @@ function selectChain(rows: unknown[]) {
 describe('GET /api/matching/feed', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGetFeed.mockReturnValue([{ type: 'best', bookId: 'book-1' }])
+    mockFetchFeedForSession.mockResolvedValue([{ type: 'best', bookId: 'book-1' }])
   })
 
   it('returns 401 for anonymous users', async () => {
@@ -68,7 +68,7 @@ describe('GET /api/matching/feed', () => {
 
     expect(res.status).toBe(200)
     expect(body.events).toEqual([{ type: 'best', bookId: 'book-1' }])
-    expect(mockGetFeed).toHaveBeenCalledWith('session-1')
+    expect(mockFetchFeedForSession).toHaveBeenCalledWith('session-1')
   })
 
   it('returns feed events for session participants', async () => {

--- a/app/api/matching/feed/route.ts
+++ b/app/api/matching/feed/route.ts
@@ -5,7 +5,7 @@ import { and, eq } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { matchingSessionParticipants, matchingSessions } from '@/lib/db/schema'
-import { getFeed } from '@/lib/matching/realtime/feed'
+import { fetchFeedForSession } from '@/lib/matching/realtime/feed'
 
 export async function GET(req: NextRequest) {
   const session = await auth()
@@ -37,5 +37,5 @@ export async function GET(req: NextRequest) {
     if (!participant) return NextResponse.json({ error: 'Not a participant' }, { status: 403 })
   }
 
-  return NextResponse.json({ events: getFeed(sessionId) })
+  return NextResponse.json({ events: await fetchFeedForSession(sessionId) })
 }

--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -13,13 +13,12 @@ import type { MyMoveBook } from '@/lib/matching/my-moves'
 import MatchingPersonalList from '@/components/nd/MatchingPersonalList'
 import type { BookParticipant } from '@/components/nd/MatchingPersonalList'
 import MatchingImpactWorkspace from '@/components/nd/MatchingImpactWorkspace'
-import MatchingRankNudge from '@/components/nd/MatchingRankNudge'
 import MatchingRealtimeWrapper from '@/components/nd/MatchingRealtimeWrapper'
 import MatchingHeader from '@/components/nd/MatchingHeader'
 import MatchingWelcome from '@/components/nd/MatchingWelcome'
 import { buildMoveImpact, sortMovesByImpact } from '@/lib/matching/move-impact'
 import { getOrCreatePseudonymReservation } from '@/lib/matching/pseudonym-reservations'
-import { getFeed } from '@/lib/matching/realtime/feed'
+import { fetchFeedForSession } from '@/lib/matching/realtime/feed'
 import { getAdriftCause, isViewerAdrift } from '@/lib/matching/adrift'
 
 export default async function MatchingPage({
@@ -111,7 +110,6 @@ export default async function MatchingPage({
     : null
 
   // Fetch per-book participant signups for chips in the popup (all catalog books, not just user's list)
-  const inListBookIds = personalBooks.filter((b) => b.isInList).map((b) => b.bookId)
   const bookParticipants: BookParticipant[] =
     participantUserIds.length > 0
       ? await db
@@ -156,7 +154,7 @@ export default async function MatchingPage({
       : emptyScenarioSetOverview(scenarioParticipants, activeSession.minGroupSize, activeSession.maxGroupSize)
 
   const bookTitleById = new Map(personalBooks.map((book) => [book.bookId, book.title]))
-  const feedEvents = getFeed(activeSession.id)
+  const feedEvents = await fetchFeedForSession(activeSession.id)
   const feedBookTitles = Object.fromEntries(bookTitleById)
   const myMovesWithImpact = addMoveImpacts(
     myMoves,
@@ -252,12 +250,6 @@ export default async function MatchingPage({
             </p>
           )}
         </div>
-
-        {!isImpersonating && (
-          <MatchingRankNudge
-            show={inListBookIds.length > 0 && personalBooks.filter((b) => b.isInList).every((b) => b.rank === null)}
-          />
-        )}
 
         {/* Two-column grid aligned with top row — MatchingPersonalList renders a fragment with two sections */}
         <div

--- a/components/nd/MatchingImpactWorkspace.tsx
+++ b/components/nd/MatchingImpactWorkspace.tsx
@@ -120,7 +120,7 @@ export default function MatchingImpactWorkspace({
             viewingUserId={viewingUserId}
             previewOpen={previewMove !== null}
             previewMove={visiblePreviewMove}
-            highlightedUserIds={previewBeneficiaryIds}
+            highlightedUserIds={previewMove ? previewBeneficiaryIds : []}
           />
         </div>
       </section>

--- a/components/nd/MatchingScenarios.test.tsx
+++ b/components/nd/MatchingScenarios.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react'
+import MatchingScenarios from './MatchingScenarios'
+import type { MatchingScenario, ScenarioSetOverview } from '@/lib/matching/scenarios'
+
+jest.mock('./CoverImage', () => function MockCoverImage() {
+  return <div data-testid="cover-image" />
+})
+
+const score = {
+  coveredCount: 3,
+  totalCount: 4,
+  coverageRatio: 0.75,
+  strongInterestCount: 1,
+  rankedCount: 1,
+  unrankedCount: 0,
+  rankSum: 1,
+  avgRank: 1,
+  worstRank: 1,
+}
+
+function scenario(id: string, tier: MatchingScenario['tier'], leftOutUserIds: string[]): MatchingScenario {
+  return {
+    id,
+    tier,
+    circles: [{
+      id: `${id}-circle`,
+      bookId: 'book-1',
+      members: [{ userId: 'user-1', pseudonym: 'Лиса', rank: 1, interest: 'очень хочу' }],
+      minSize: 3,
+      maxSize: 3,
+      wantsCount: 1,
+      avgRank: 1,
+      worstRank: 1,
+      unrankedCount: 0,
+    }],
+    leftOut: leftOutUserIds.map((userId) => ({ userId, pseudonym: userId === 'viewer' ? 'Пчела' : 'Кит' })),
+    score,
+  }
+}
+
+function renderScenarios(scenarios: MatchingScenario[]) {
+  const overview: ScenarioSetOverview = {
+    scenarios,
+    leader: scenarios[0] ?? null,
+    totalCount: 4,
+    minGroupSize: 3,
+    maxGroupSize: 3,
+  }
+
+  render(
+    <MatchingScenarios
+      overview={overview}
+      bookById={new Map([[
+        'book-1',
+        {
+          id: 'book-1',
+          bookId: 'book-1',
+          title: 'Книга',
+          author: 'Автор',
+          description: 'Описание',
+          coverUrl: null,
+          pages: null,
+          publishedDate: '',
+          tags: [],
+          textUrl: '',
+          whyRead: null,
+          recommendationLink: null,
+        },
+      ]])}
+      bookParticipants={[]}
+      viewingUserId="viewer"
+    />,
+  )
+}
+
+describe('MatchingScenarios', () => {
+  it('marks only the leader scenario when the viewer is left out', () => {
+    renderScenarios([
+      scenario('leader', 'leader', []),
+      scenario('alternative', 'full-coverage', ['viewer']),
+    ])
+
+    const alternative = screen.getByText('Сценарий 2').closest('li')
+
+    expect(alternative).toHaveAttribute('data-viewer-left-out', 'false')
+  })
+
+  it('marks the leader scenario when the viewer is left out of the leader', () => {
+    renderScenarios([
+      scenario('leader', 'leader', ['viewer']),
+      scenario('alternative', 'full-coverage', []),
+    ])
+
+    const leader = screen.getByText('Сценарий 1').closest('li')
+
+    expect(leader).toHaveAttribute('data-viewer-left-out', 'true')
+  })
+})

--- a/components/nd/MatchingScenarios.tsx
+++ b/components/nd/MatchingScenarios.tsx
@@ -148,6 +148,7 @@ function ScenarioSetCard({
   const isLinking = (isLeader || isPreview) && highlightedUserIds.length > 0
   const highlightedUserIdSet = new Set(highlightedUserIds)
   const hasViewerLeftOut = scenario.leftOut.some((participant) => participant.userId === viewingUserId)
+  const shouldWarnViewerLeftOut = isLeader && hasViewerLeftOut
   const scoreTitle = [
     `Покрытие: ${scenario.score.coveredCount}/${scenario.score.totalCount}`,
     `Очень хотят: ${scenario.score.strongInterestCount}`,
@@ -169,10 +170,11 @@ function ScenarioSetCard({
           : isLeader ? 'var(--accent-soft)' : highlighted ? 'rgba(192, 96, 58, 0.04)' : 'var(--bg-input)',
         borderRadius: 'var(--radius-card)',
         boxShadow: isPreview ? '0 10px 26px rgba(85, 55, 28, 0.10)' : isLeader ? 'none' : '0 1px 2px rgba(50,38,24,.04)',
-        borderLeft: hasViewerLeftOut ? '3px solid var(--status-warn)' : undefined,
+        borderLeft: shouldWarnViewerLeftOut ? '3px solid var(--status-warn)' : undefined,
         padding: '0.85rem 1rem',
       }}
       data-highlighted={highlighted ? 'true' : 'false'}
+      data-viewer-left-out={shouldWarnViewerLeftOut ? 'true' : 'false'}
     >
       {/* Header row */}
       <div className="flex flex-wrap items-center gap-2 mb-3">

--- a/docs/wiki/Quality-CI-Allure-and-Codecov.md
+++ b/docs/wiki/Quality-CI-Allure-and-Codecov.md
@@ -12,7 +12,7 @@
 
 Бежит на каждый pull request. Состоит из двух параллельных job (`quality`, `build`) и финального gate-job `ci`, который требует, чтобы оба прошли. Это единственная required-проверка branch protection — мерж ждёт только её (~80 секунд).
 
-- **`quality`** — `npm ci`, ESLint, secret scan, TypeScript typecheck, Jest unit-тесты с coverage, загрузка coverage в Codecov.
+- **`quality`** — `npm ci`, ESLint, secret scan, TypeScript typecheck, Jest unit-тесты с coverage, загрузка coverage в Codecov. Codecov не является блокирующей проверкой: upload имеет короткий timeout и `continue-on-error`, чтобы внешний сервис не держал merge-gate.
 - **`build`** — проверка, что `next build` проходит с прод-секретами.
 
 ### `E2E (nightly)` — Playwright, НЕ блокирует мерж
@@ -58,7 +58,7 @@ Codecov показывает покрытие unit-тестами:
 
 - project target: 80%;
 - patch target: 70%;
-- CI не падает, если сам Codecov временно недоступен.
+- CI не падает, если сам Codecov временно недоступен или upload завис: обязательный gate держат Jest coverage thresholds, lint, secret scan, typecheck и build.
 
 ## Playwright E2E
 

--- a/e2e/matching-reader-circles.spec.ts
+++ b/e2e/matching-reader-circles.spec.ts
@@ -45,6 +45,27 @@ test('matching shows welcome screen until the reader explicitly joins', async ({
   await expect(page.getByRole('heading', { name: 'Читательские круги' })).toBeVisible()
 })
 
+test('matching catalog does not show the rank nudge banner', async ({
+  page,
+  createMatchingSession,
+  createTestBook,
+  loginAsUser,
+}) => {
+  const session = await createMatchingSession({ minGroupSize: 3, maxGroupSize: 3 })
+  const book = await createTestBook({
+    title: `E2E Unranked Book ${test.info().testId}`,
+    author: 'Nudge Author',
+  })
+
+  await loginAsUser({ name: 'E2E Nudge Reader' })
+  await page.request.post(`/api/matching/sessions/${session.id}/join`)
+  await page.request.post('/api/matching/books', { data: { bookId: book.id } })
+
+  await page.goto('/matching')
+  await expect(page.getByTestId('matching-catalog-panel')).toBeVisible()
+  await expect(page.getByText('Расставь ранги, чтобы улучшить выбор сценариев')).not.toBeVisible()
+})
+
 test('matching shows reader circles, move hints, and full book details modal', async ({
   page,
   createMatchingSession,
@@ -131,6 +152,9 @@ test('matching shows reader circles, move hints, and full book details modal', a
     return Number.parseFloat(maxHeight)
   }).toBeGreaterThan(0)
   await expect(circlesPanel.getByText(firstPseudonym).first()).toHaveCSS('color', 'rgb(192, 96, 58)')
+  await circlesPanel.hover()
+  await expect(circlesPanel.locator('.nd-scenario-preview-slot')).not.toHaveClass(/is-open/)
+  await expect(circlesPanel.locator('.nd-scenario-current').first().locator('.nd-chip-text').first()).toHaveCSS('opacity', '1')
 
   await movesPanel.getByRole('button', { name: moveBook.title, exact: true }).first().click()
   let dialog = page.getByRole('dialog', { name: moveBook.title })
@@ -171,6 +195,9 @@ test('matching shows reader circles, move hints, and full book details modal', a
   await addMoveResponse
 
   await expect(catalogMine).toContainText(moveBook.title, { timeout: 15_000 })
+  await page.reload()
+  await expect(page.getByText('Лента')).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByTestId('matching-feed')).not.toBeVisible()
   await expect(page.getByRole('heading', { name: 'Сценарий 1' })).toBeVisible()
   await expect(page.getByRole('button', { name: moveBook.title, exact: true })).toBeVisible()
   await expect(page.getByText('Покрытие: все 3').first()).toBeVisible()

--- a/lib/matching/realtime/__tests__/feed.test.ts
+++ b/lib/matching/realtime/__tests__/feed.test.ts
@@ -1,5 +1,24 @@
-import { appendFeed, getFeed } from '../feed'
+import { appendFeed, fetchFeedForSession, getFeed } from '../feed'
 import type { FeedScenarioSummary } from '../../feed-events'
+
+jest.mock('@/lib/db', () => ({ db: {} }))
+jest.mock('@/lib/db/schema', () => ({
+  matchingPreferenceEvents: {
+    id: 'matchingPreferenceEvents.id',
+    actorUserId: 'matchingPreferenceEvents.actorUserId',
+    eventType: 'matchingPreferenceEvents.eventType',
+    bookId: 'matchingPreferenceEvents.bookId',
+    before: 'matchingPreferenceEvents.before',
+    after: 'matchingPreferenceEvents.after',
+    occurredAt: 'matchingPreferenceEvents.occurredAt',
+    sessionId: 'matchingPreferenceEvents.sessionId',
+  },
+  matchingSessionParticipants: {
+    sessionId: 'matchingSessionParticipants.sessionId',
+    userId: 'matchingSessionParticipants.userId',
+    pseudonym: 'matchingSessionParticipants.pseudonym',
+  },
+}))
 
 function summary(coveredCount: number): FeedScenarioSummary {
   return {
@@ -88,5 +107,54 @@ describe('matching realtime feed', () => {
     events.length = 0
 
     expect(getFeed('session-feed-copy')).toHaveLength(1)
+  })
+
+  it('rebuilds feed events from persistent preference events', async () => {
+    const occurredAt = new Date('2026-06-03T07:00:00Z')
+    const select = jest.fn()
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue([{
+          id: 'preference-event-1',
+          actorUserId: 'u1',
+          eventType: 'book_added',
+          bookId: 'book-1',
+          before: null,
+          after: {
+            id: 'scenario-1',
+            tier: 'leader',
+            circles: [{ id: 'circle-1', bookId: 'book-1', members: [], size: 3 }],
+            leftOut: [],
+            score: {
+              coveredCount: 3,
+              totalCount: 5,
+              strongInterestCount: 2,
+              avgRank: 1,
+              worstRank: 2,
+              unrankedCount: 0,
+              rankSum: 3,
+            },
+          },
+          occurredAt,
+        }]),
+      })
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue([{ userId: 'u1', pseudonym: 'Лиса' }]),
+      })
+
+    const events = await fetchFeedForSession('session-persistent', 100, { select } as never)
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        id: 1,
+        ts: occurredAt.getTime(),
+        type: 'best',
+        actor: { userId: 'u1', pseudonym: 'Лиса' },
+        bookId: 'book-1',
+      }),
+    ])
   })
 })

--- a/lib/matching/realtime/feed.ts
+++ b/lib/matching/realtime/feed.ts
@@ -1,4 +1,12 @@
-import type { FeedEventDraft } from '../feed-events'
+import { and, desc, eq, inArray } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { matchingPreferenceEvents, matchingSessionParticipants } from '@/lib/db/schema'
+import {
+  buildFeedEventsForMutation,
+  type FeedEventDraft,
+  type MatchingMutationKind,
+} from '../feed-events'
+import type { MatchingScenario } from '../scenarios'
 
 export type FeedEventType = 'best' | 'leftout'
 
@@ -32,4 +40,85 @@ export function appendFeed(sessionId: string, event: FeedEventDraft): FeedEvent 
 
 export function getFeed(sessionId: string): FeedEvent[] {
   return [...(buffers.get(sessionId) ?? [])]
+}
+
+export async function fetchFeedForSession(
+  sessionId: string,
+  limit = BUFFER_SIZE,
+  dbClient: typeof db = db,
+): Promise<FeedEvent[]> {
+  const rows = await dbClient
+    .select({
+      id: matchingPreferenceEvents.id,
+      actorUserId: matchingPreferenceEvents.actorUserId,
+      eventType: matchingPreferenceEvents.eventType,
+      bookId: matchingPreferenceEvents.bookId,
+      before: matchingPreferenceEvents.before,
+      after: matchingPreferenceEvents.after,
+      occurredAt: matchingPreferenceEvents.occurredAt,
+    })
+    .from(matchingPreferenceEvents)
+    .where(eq(matchingPreferenceEvents.sessionId, sessionId))
+    .orderBy(desc(matchingPreferenceEvents.occurredAt))
+    .limit(limit)
+
+  if (rows.length === 0) return getFeed(sessionId)
+
+  const actorIds = Array.from(new Set(rows.map((row) => row.actorUserId)))
+  const participants = actorIds.length > 0
+    ? await dbClient
+      .select({
+        userId: matchingSessionParticipants.userId,
+        pseudonym: matchingSessionParticipants.pseudonym,
+      })
+      .from(matchingSessionParticipants)
+      .where(
+        and(
+          eq(matchingSessionParticipants.sessionId, sessionId),
+          inArray(matchingSessionParticipants.userId, actorIds),
+        ),
+      )
+    : []
+  const pseudonymByUserId = new Map(participants.map((participant) => [participant.userId, participant.pseudonym]))
+
+  let id = 0
+  const persistentEvents = [...rows].reverse().flatMap((row) => {
+    if (!row.bookId || !isMatchingMutationKind(row.eventType)) return []
+
+    const drafts = buildFeedEventsForMutation({
+      actor: {
+        userId: row.actorUserId,
+        pseudonym: pseudonymByUserId.get(row.actorUserId) ?? 'Участник',
+      },
+      bookId: row.bookId,
+      kind: row.eventType,
+      leaderBefore: asMatchingScenario(row.before),
+      leaderAfter: asMatchingScenario(row.after),
+      now: row.occurredAt.getTime(),
+    })
+
+    return drafts.map((draft) => ({
+      ...draft,
+      id: ++id,
+      ts: row.occurredAt.getTime(),
+    }))
+  })
+
+  return persistentEvents.slice(-limit)
+}
+
+function isMatchingMutationKind(value: string): value is MatchingMutationKind {
+  return [
+    'book_added',
+    'book_removed',
+    'rank_changed',
+    'status_changed',
+    'catalog_signup_updated',
+    'priorities_updated',
+  ].includes(value)
+}
+
+function asMatchingScenario(value: unknown): MatchingScenario | null {
+  if (!value || typeof value !== 'object') return null
+  return value as MatchingScenario
 }


### PR DESCRIPTION
## Что сделано
- лента matching теперь восстанавливается из persistent matching_preference_events, а не только из process-memory buffer
- убрана случайная плашка "Расставь ранги..." из каталога matching
- warning-полоска "вы за бортом" показывается только на лучшем сценарии
- подсветка/приглушение участников применяется только при активном preview хода

## Проверки
- npm run lint
- npm run typecheck
- npm test
- npm run build
- npx playwright test e2e/matching-reader-circles.spec.ts
- npx playwright test e2e/ui-states.spec.ts