### PR TITLE
refactor: remove in-memory matching feed buffer

### DIFF
--- a/lib/matching/__tests__/mutation-effects.test.ts
+++ b/lib/matching/__tests__/mutation-effects.test.ts
@@ -2,7 +2,6 @@ import { finalizeMatchingMutationEffects } from '../mutation-effects'
 import type { MatchingScenario } from '../scenarios'
 import { fetchScenarioContextForSession } from '../scenario-input'
 import { buildFeedEventsForMutation } from '../feed-events'
-import { appendFeed } from '../realtime/feed'
 import { clearAdriftCause, rememberAdriftCausesFromEvents } from '../adrift'
 import { recordMatchingPreferenceEvent } from '../preference-events'
 
@@ -11,9 +10,6 @@ jest.mock('../scenario-input', () => ({
 }))
 jest.mock('../feed-events', () => ({
   buildFeedEventsForMutation: jest.fn(),
-}))
-jest.mock('../realtime/feed', () => ({
-  appendFeed: jest.fn(),
 }))
 jest.mock('../adrift', () => ({
   clearAdriftCause: jest.fn(),
@@ -25,7 +21,6 @@ jest.mock('../preference-events', () => ({
 
 const mockFetchContext = fetchScenarioContextForSession as jest.Mock
 const mockBuildFeedEvents = buildFeedEventsForMutation as jest.Mock
-const mockAppendFeed = appendFeed as jest.Mock
 const mockClearAdrift = clearAdriftCause as jest.Mock
 const mockRememberAdrift = rememberAdriftCausesFromEvents as jest.Mock
 const mockRecordEvent = recordMatchingPreferenceEvent as jest.Mock
@@ -94,7 +89,7 @@ describe('finalizeMatchingMutationEffects', () => {
     mockRecordEvent.mockResolvedValue(undefined)
   })
 
-  it('appends feed events, updates adrift state, and records persistent analytics', async () => {
+  it('derives feed events, updates adrift state, and records persistent analytics', async () => {
     await finalizeMatchingMutationEffects({
       sessionId: 'session-1',
       targetUserId: 'target',
@@ -113,7 +108,6 @@ describe('finalizeMatchingMutationEffects', () => {
       leaderBefore: beforeLeader,
       leaderAfter: afterLeader,
     }))
-    expect(mockAppendFeed).toHaveBeenCalledWith('session-1', expect.objectContaining({ type: 'leftout' }))
     expect(mockRememberAdrift).toHaveBeenCalledWith('session-1', [expect.objectContaining({ type: 'leftout' })])
     expect(mockClearAdrift).toHaveBeenCalledWith('session-1', 'actor')
     expect(mockClearAdrift).toHaveBeenCalledWith('session-1', 'target')
@@ -163,6 +157,5 @@ describe('finalizeMatchingMutationEffects', () => {
     })
 
     expect(mockRecordEvent).not.toHaveBeenCalled()
-    expect(mockAppendFeed).not.toHaveBeenCalled()
   })
 })

--- a/lib/matching/mutation-effects.ts
+++ b/lib/matching/mutation-effects.ts
@@ -1,7 +1,6 @@
 import type { MatchingMutationKind } from './feed-events'
 import type { MatchingScenarioContext } from './scenario-input'
 import { buildFeedEventsForMutation } from './feed-events'
-import { appendFeed } from './realtime/feed'
 import { clearAdriftCause, rememberAdriftCausesFromEvents } from './adrift'
 import { fetchScenarioContextForSession } from './scenario-input'
 import { recordMatchingPreferenceEvent } from './preference-events'
@@ -57,7 +56,6 @@ export async function finalizeMatchingMutationEffects({
       })
     : []
 
-  for (const event of feedEvents) appendFeed(sessionId, event)
   rememberAdriftCausesFromEvents(sessionId, feedEvents.filter((event) => event.type === 'leftout'))
 
   const leftOutAfter = new Set(after.context.overview.leader?.leftOut.map((participant) => participant.userId) ?? [])

--- a/lib/matching/realtime/__tests__/feed.test.ts
+++ b/lib/matching/realtime/__tests__/feed.test.ts
@@ -1,5 +1,4 @@
-import { appendFeed, fetchFeedForSession, getFeed } from '../feed'
-import type { FeedScenarioSummary } from '../../feed-events'
+import { fetchFeedForSession } from '../feed'
 
 jest.mock('@/lib/db', () => ({ db: {} }))
 jest.mock('@/lib/db/schema', () => ({
@@ -20,132 +19,75 @@ jest.mock('@/lib/db/schema', () => ({
   },
 }))
 
-function summary(coveredCount: number): FeedScenarioSummary {
+function scenario(coveredCount: number, leftOutUserIds: string[] = []) {
   return {
-    scenarioId: `scenario-${coveredCount}`,
-    coveredCount,
-    totalCount: 5,
-    strongInterestCount: coveredCount,
-    circleBookIds: [`book-${coveredCount}`],
-    leftOutUserIds: [],
+    id: `scenario-${coveredCount}-${leftOutUserIds.join('-')}`,
+    tier: 'leader',
+    circles: [
+      {
+        id: `circle-${coveredCount}`,
+        bookId: `book-${coveredCount}`,
+        members: [],
+        minSize: 3,
+        maxSize: 3,
+        wantsCount: coveredCount,
+        avgRank: 1,
+        worstRank: 1,
+        unrankedCount: 0,
+      },
+    ],
+    leftOut: leftOutUserIds.map((userId) => ({ userId, pseudonym: userId === 'u2' ? 'Белка' : 'Кит' })),
+    score: {
+      coveredCount,
+      totalCount: 5,
+      coverageRatio: coveredCount / 5,
+      strongInterestCount: coveredCount,
+      rankedCount: coveredCount,
+      unrankedCount: 0,
+      rankSum: coveredCount,
+      avgRank: 1,
+      worstRank: 1,
+    },
   }
 }
 
-function cause(bookId: string) {
-  return {
-    actor: { userId: 'u2', pseudonym: 'Кит' },
-    bookId,
-    mutationKind: 'book_added' as const,
-    leaderBeforeId: null,
-    leaderAfterId: 'scenario-1',
-    at: 1,
-  }
+function mockDbClient(preferenceRows: unknown[], participantRows: unknown[] = []) {
+  const select = jest.fn()
+    .mockReturnValueOnce({
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue(preferenceRows),
+    })
+    .mockReturnValueOnce({
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockResolvedValue(participantRows),
+    })
+
+  return { select }
 }
 
 describe('matching realtime feed', () => {
-  it('stores feed events per session in insertion order', () => {
-    appendFeed('session-feed-a', {
-      type: 'best',
-      actor: { userId: 'u1', pseudonym: 'Лиса' },
-      bookId: 'book-1',
-      mutationKind: 'book_added',
-      before: null,
-      after: summary(3),
-      addedCircleBookIds: ['book-1'],
-      removedCircleBookIds: [],
-    })
-    appendFeed('session-feed-a', {
-      type: 'leftout',
-      actor: { userId: 'u2', pseudonym: 'Кит' },
-      bookId: 'book-2',
-      mutationKind: 'book_added',
-      affected: { userId: 'u3', pseudonym: 'Белка' },
-      cause: cause('book-2'),
-    })
+  it('returns an empty feed when there are no persistent preference events', async () => {
+    const events = await fetchFeedForSession('session-empty', 100, mockDbClient([]) as never)
 
-    const events = getFeed('session-feed-a')
-
-    expect(events).toHaveLength(2)
-    expect(events[0]).toEqual(expect.objectContaining({ type: 'best', bookId: 'book-1' }))
-    expect(events[1]).toEqual(expect.objectContaining({ type: 'leftout', bookId: 'book-2' }))
-  })
-
-  it('keeps the latest 100 events', () => {
-    for (let i = 0; i < 105; i++) {
-      appendFeed('session-feed-cap', {
-        type: 'best',
-        actor: { userId: `u${i}`, pseudonym: `Псевдо ${i}` },
-        bookId: `book-${i}`,
-        mutationKind: 'book_added',
-        before: null,
-        after: summary(i),
-        addedCircleBookIds: [`book-${i}`],
-        removedCircleBookIds: [],
-      })
-    }
-
-    const events = getFeed('session-feed-cap')
-
-    expect(events).toHaveLength(100)
-    expect(events[0].bookId).toBe('book-5')
-    expect(events[99].bookId).toBe('book-104')
-  })
-
-  it('returns a defensive copy', () => {
-    appendFeed('session-feed-copy', {
-      type: 'best',
-      actor: { userId: 'u1', pseudonym: 'Лиса' },
-      bookId: 'book-1',
-      mutationKind: 'book_added',
-      before: null,
-      after: summary(1),
-      addedCircleBookIds: ['book-1'],
-      removedCircleBookIds: [],
-    })
-
-    const events = getFeed('session-feed-copy')
-    events.length = 0
-
-    expect(getFeed('session-feed-copy')).toHaveLength(1)
+    expect(events).toEqual([])
   })
 
   it('rebuilds feed events from persistent preference events', async () => {
     const occurredAt = new Date('2026-06-03T07:00:00Z')
-    const select = jest.fn()
-      .mockReturnValueOnce({
-        from: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockResolvedValue([{
-          id: 'preference-event-1',
-          actorUserId: 'u1',
-          eventType: 'book_added',
-          bookId: 'book-1',
-          before: null,
-          after: {
-            id: 'scenario-1',
-            tier: 'leader',
-            circles: [{ id: 'circle-1', bookId: 'book-1', members: [], size: 3 }],
-            leftOut: [],
-            score: {
-              coveredCount: 3,
-              totalCount: 5,
-              strongInterestCount: 2,
-              avgRank: 1,
-              worstRank: 2,
-              unrankedCount: 0,
-              rankSum: 3,
-            },
-          },
-          occurredAt,
-        }]),
-      })
-      .mockReturnValueOnce({
-        from: jest.fn().mockReturnThis(),
-        where: jest.fn().mockResolvedValue([{ userId: 'u1', pseudonym: 'Лиса' }]),
-      })
-
-    const events = await fetchFeedForSession('session-persistent', 100, { select } as never)
+    const events = await fetchFeedForSession('session-persistent', 100, mockDbClient(
+      [{
+        id: 'preference-event-1',
+        actorUserId: 'u1',
+        eventType: 'book_added',
+        bookId: 'book-1',
+        before: null,
+        after: scenario(3),
+        occurredAt,
+      }],
+      [{ userId: 'u1', pseudonym: 'Лиса' }],
+    ) as never)
 
     expect(events).toEqual([
       expect.objectContaining({
@@ -156,5 +98,56 @@ describe('matching realtime feed', () => {
         bookId: 'book-1',
       }),
     ])
+  })
+
+  it('rebuilds newly-left-out events from leader snapshots', async () => {
+    const occurredAt = new Date('2026-06-03T07:05:00Z')
+    const events = await fetchFeedForSession('session-leftout', 100, mockDbClient(
+      [{
+        id: 'preference-event-2',
+        actorUserId: 'u1',
+        eventType: 'book_removed',
+        bookId: 'book-2',
+        before: scenario(4, []),
+        after: scenario(3, ['u2']),
+        occurredAt,
+      }],
+      [{ userId: 'u1', pseudonym: 'Лиса' }],
+    ) as never)
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'leftout',
+        actor: { userId: 'u1', pseudonym: 'Лиса' },
+        affected: { userId: 'u2', pseudonym: 'Белка' },
+        bookId: 'book-2',
+        ts: occurredAt.getTime(),
+      }),
+    ])
+  })
+
+  it('ignores non-feed preference events', async () => {
+    const events = await fetchFeedForSession('session-ignored', 100, mockDbClient([
+      {
+        id: 'preference-event-3',
+        actorUserId: 'u1',
+        eventType: 'unknown',
+        bookId: 'book-1',
+        before: null,
+        after: scenario(3),
+        occurredAt: new Date('2026-06-03T07:10:00Z'),
+      },
+      {
+        id: 'preference-event-4',
+        actorUserId: 'u1',
+        eventType: 'book_added',
+        bookId: null,
+        before: null,
+        after: scenario(3),
+        occurredAt: new Date('2026-06-03T07:11:00Z'),
+      },
+    ]) as never)
+
+    expect(events).toEqual([])
   })
 })

--- a/lib/matching/realtime/feed.ts
+++ b/lib/matching/realtime/feed.ts
@@ -17,31 +17,6 @@ export type FeedEvent = FeedEventDraft & {
 
 const BUFFER_SIZE = 100
 
-const buffers = new Map<string, FeedEvent[]>()
-const idCounters = new Map<string, number>()
-
-function nextId(sessionId: string): number {
-  const n = (idCounters.get(sessionId) ?? 0) + 1
-  idCounters.set(sessionId, n)
-  return n
-}
-
-export function appendFeed(sessionId: string, event: FeedEventDraft): FeedEvent {
-  let buf = buffers.get(sessionId)
-  if (!buf) {
-    buf = []
-    buffers.set(sessionId, buf)
-  }
-  const entry: FeedEvent = { ...event, id: nextId(sessionId), ts: Date.now() }
-  buf.push(entry)
-  if (buf.length > BUFFER_SIZE) buf.shift()
-  return entry
-}
-
-export function getFeed(sessionId: string): FeedEvent[] {
-  return [...(buffers.get(sessionId) ?? [])]
-}
-
 export async function fetchFeedForSession(
   sessionId: string,
   limit = BUFFER_SIZE,
@@ -62,7 +37,7 @@ export async function fetchFeedForSession(
     .orderBy(desc(matchingPreferenceEvents.occurredAt))
     .limit(limit)
 
-  if (rows.length === 0) return getFeed(sessionId)
+  if (rows.length === 0) return []
 
   const actorIds = Array.from(new Set(rows.map((row) => row.actorUserId)))
   const participants = actorIds.length > 0


### PR DESCRIPTION
## Что сделано
- удалён in-memory buffer ленты matching
- fetchFeedForSession теперь единственный источник ленты и читает persistent matching_preference_events
- finalizeMatchingMutationEffects больше не пишет во второй источник правды
- тесты ленты переписаны на восстановление событий из persistent preference log

## Проверки
- npm run lint
- npm run typecheck
- npm test
- npm run build
- npx playwright test e2e/matching-reader-circles.spec.ts