### PR TITLE
fix: sanitize matching feed events

### DIFF
--- a/app/api/matching/feed/route.test.ts
+++ b/app/api/matching/feed/route.test.ts
@@ -40,7 +40,16 @@ function selectChain(rows: unknown[]) {
 describe('GET /api/matching/feed', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockFetchFeedForSession.mockResolvedValue([{ type: 'best', bookId: 'book-1' }])
+    mockFetchFeedForSession.mockResolvedValue([{
+      id: 1,
+      ts: 1,
+      type: 'best',
+      actor: { pseudonym: 'Лиса' },
+      bookId: 'book-1',
+      mutationKind: 'book_added',
+      before: null,
+      after: { coveredCount: 3, totalCount: 5, strongInterestCount: 2 },
+    }])
   })
 
   it('returns 401 for anonymous users', async () => {
@@ -67,7 +76,12 @@ describe('GET /api/matching/feed', () => {
     const body = await res.json()
 
     expect(res.status).toBe(200)
-    expect(body.events).toEqual([{ type: 'best', bookId: 'book-1' }])
+    expect(body.events).toEqual([expect.objectContaining({
+      type: 'best',
+      actor: { pseudonym: 'Лиса' },
+      bookId: 'book-1',
+    })])
+    expect(JSON.stringify(body.events)).not.toContain('userId')
     expect(mockFetchFeedForSession).toHaveBeenCalledWith('session-1')
   })
 

--- a/docs/wiki/API-and-Swagger.md
+++ b/docs/wiki/API-and-Swagger.md
@@ -40,7 +40,7 @@ API проекта описан в OpenAPI-файле и доступен чер
 | GET/PUT | `/api/priorities` | Читать и сохранять приоритеты. |
 | GET/POST | `/api/submissions` | Читать и создавать свои заявки. |
 | DELETE | `/api/submissions/{id}` | Удалить свою заявку. |
-| GET | `/api/matching/feed` | Лента значимых событий active matching-сессии (`best`, `leftout`) для участников и админов. |
+| GET | `/api/matching/feed` | Лента значимых событий active matching-сессии (`best`, `leftout`) для участников и админов; отдаёт псевдонимы и агрегаты без внутренних `userId`. |
 
 ## Основные admin endpoints
 

--- a/docs/wiki/Group-Matching-Mode.md
+++ b/docs/wiki/Group-Matching-Mode.md
@@ -103,7 +103,7 @@ PK: `(session_id, user_id)`. Unique: `(session_id, pseudonym)`.
 | POST | `/api/admin/matching/sessions/:id/participants` | Добавить участника из базы пользователей (только admin, только active) |
 | DELETE | `/api/admin/matching/sessions/:id/participants/:userId` | Убрать участника из сессии (только admin, только active) |
 | GET | `/api/matching/stream?session=<id>` | SSE-канал с событиями сессии |
-| GET | `/api/matching/feed?session=<id>` | In-memory лента событий сессии (`best`, `leftout`) |
+| GET | `/api/matching/feed?session=<id>` | Лента значимых событий сессии (`best`, `leftout`) из `matching_preference_events`; ответ содержит только псевдонимы и агрегаты без `userId` |
 | GET | `/api/matching/state?session=<id>&as=<userId>` | Текущее состояние (personalBooks, myMoves, legacy `scenarios`/`scenarioOverview`, новый `scenarioSetOverview`) |
 | POST | `/api/matching/books` | Добавить книгу в личный список и поставить её на первое место в персональном ранкинге |
 | DELETE | `/api/matching/books/:bookId` | Удалить книгу из личного списка |
@@ -116,7 +116,7 @@ PK: `(session_id, user_id)`. Unique: `(session_id, pseudonym)`.
 
 - **SSE-хаб** (`lib/matching/realtime/hub.ts`): in-memory, per-session, до 50 подписчиков. Monotonic `event_id`. Heartbeat `: ping` каждые 25 секунд.
 - **Presence** (`lib/matching/realtime/presence.ts`): in-memory, время последнего `heartbeat`. Пользователь считается online, если heartbeat был ≤55 секунд назад. Sweep каждые 10 секунд.
-- **Feed** (`lib/matching/realtime/feed.ts`): ring-buffer на 100 событий; классифицирует только события, которые меняют расклад: `best` («Новый лучший сценарий») и `leftout` («участник остался или осталась за бортом»). Feed in-memory, между рестартами процесса не сохраняется.
+- **Feed** (`lib/matching/realtime/feed.ts`): восстанавливает до 100 значимых событий из `matching_preference_events`; классифицирует только события, которые меняют расклад: `best` («Новый лучший сценарий») и `leftout` («участник остался или осталась за бортом»). Участникам отдаётся публичный DTO: псевдонимы вместо `userId`, а summary сценария содержит только агрегаты (`coveredCount`, `totalCount`, `strongInterestCount`).
 - **Adrift cause** (`lib/matching/adrift.ts`): in-memory причина, почему конкретный участник выпал из текущего leader-сценария. Если причина потеряна при рестарте, UI деградирует к мягкому состоянию «пока не собрался круг».
 - **Polling-фолбэк**: `MatchingRealtimeClient` переключается на polling `/api/matching/state` каждые 3 секунды, если SSE падает 3 раза и backoff ≥ 30 секунд.
 
@@ -378,7 +378,7 @@ Zero-sum ход — это действие, где один участник в
 | `lib/matching/middleware.ts` | Shared guards: auth, `?as=`, session freeze check, audit log |
 | `lib/matching/realtime/hub.ts` | In-memory SSE broadcast hub |
 | `lib/matching/realtime/presence.ts` | In-memory presence tracker |
-| `lib/matching/realtime/feed.ts` | Ring-buffer feed с классификацией событий |
+| `lib/matching/realtime/feed.ts` | Persistent feed с классификацией событий и публичным DTO без внутренних userId |
 | `components/nd/MatchingPersonalList.tsx` | Drag-and-drop список книг участника |
 | `components/nd/MatchingScenarios.tsx` | Карточки сценариев с цветовым кодированием |
 | `components/nd/MatchingMyMoves.tsx` | Секция «Мои ходы» |

--- a/lib/matching/realtime/__tests__/feed.test.ts
+++ b/lib/matching/realtime/__tests__/feed.test.ts
@@ -94,10 +94,19 @@ describe('matching realtime feed', () => {
         id: 1,
         ts: occurredAt.getTime(),
         type: 'best',
-        actor: { userId: 'u1', pseudonym: 'Лиса' },
+        actor: { pseudonym: 'Лиса' },
         bookId: 'book-1',
+        before: null,
+        after: {
+          coveredCount: 3,
+          totalCount: 5,
+          strongInterestCount: 3,
+        },
       }),
     ])
+    expect(JSON.stringify(events)).not.toContain('userId')
+    expect(JSON.stringify(events)).not.toContain('leftOutUserIds')
+    expect(JSON.stringify(events)).not.toContain('circleBookIds')
   })
 
   it('rebuilds newly-left-out events from leader snapshots', async () => {
@@ -118,12 +127,13 @@ describe('matching realtime feed', () => {
     expect(events).toEqual([
       expect.objectContaining({
         type: 'leftout',
-        actor: { userId: 'u1', pseudonym: 'Лиса' },
-        affected: { userId: 'u2', pseudonym: 'Белка' },
+        actor: { pseudonym: 'Лиса' },
+        affected: { pseudonym: 'Белка' },
         bookId: 'book-2',
         ts: occurredAt.getTime(),
       }),
     ])
+    expect(JSON.stringify(events)).not.toContain('userId')
   })
 
   it('ignores non-feed preference events', async () => {

--- a/lib/matching/realtime/feed.ts
+++ b/lib/matching/realtime/feed.ts
@@ -3,17 +3,42 @@ import { db } from '@/lib/db'
 import { matchingPreferenceEvents, matchingSessionParticipants } from '@/lib/db/schema'
 import {
   buildFeedEventsForMutation,
-  type FeedEventDraft,
   type MatchingMutationKind,
 } from '../feed-events'
 import type { MatchingScenario } from '../scenarios'
 
 export type FeedEventType = 'best' | 'leftout'
 
-export type FeedEvent = FeedEventDraft & {
+export interface PublicFeedActor {
+  pseudonym: string
+}
+
+export interface PublicFeedScenarioSummary {
+  coveredCount: number
+  totalCount: number
+  strongInterestCount: number
+}
+
+interface PublicFeedEventBase {
   id: number
   ts: number
+  actor: PublicFeedActor
+  bookId: string
+  mutationKind: MatchingMutationKind
 }
+
+export interface PublicBestFeedEvent extends PublicFeedEventBase {
+  type: 'best'
+  before: PublicFeedScenarioSummary | null
+  after: PublicFeedScenarioSummary | null
+}
+
+export interface PublicLeftoutFeedEvent extends PublicFeedEventBase {
+  type: 'leftout'
+  affected: PublicFeedActor
+}
+
+export type FeedEvent = PublicBestFeedEvent | PublicLeftoutFeedEvent
 
 const BUFFER_SIZE = 100
 
@@ -72,11 +97,30 @@ export async function fetchFeedForSession(
       now: row.occurredAt.getTime(),
     })
 
-    return drafts.map((draft) => ({
-      ...draft,
-      id: ++id,
-      ts: row.occurredAt.getTime(),
-    }))
+    return drafts.map((draft): FeedEvent => {
+      const base = {
+        id: ++id,
+        ts: row.occurredAt.getTime(),
+        actor: { pseudonym: draft.actor.pseudonym },
+        bookId: draft.bookId,
+        mutationKind: draft.mutationKind,
+      }
+
+      if (draft.type === 'best') {
+        return {
+          ...base,
+          type: 'best',
+          before: toPublicSummary(draft.before),
+          after: toPublicSummary(draft.after),
+        }
+      }
+
+      return {
+        ...base,
+        type: 'leftout',
+        affected: { pseudonym: draft.affected.pseudonym },
+      }
+    })
   })
 
   return persistentEvents.slice(-limit)
@@ -96,4 +140,17 @@ function isMatchingMutationKind(value: string): value is MatchingMutationKind {
 function asMatchingScenario(value: unknown): MatchingScenario | null {
   if (!value || typeof value !== 'object') return null
   return value as MatchingScenario
+}
+
+function toPublicSummary(summary: {
+  coveredCount: number
+  totalCount: number
+  strongInterestCount: number
+} | null): PublicFeedScenarioSummary | null {
+  if (!summary) return null
+  return {
+    coveredCount: summary.coveredCount,
+    totalCount: summary.totalCount,
+    strongInterestCount: summary.strongInterestCount,
+  }
 }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -671,13 +671,14 @@
       },
       "MatchingFeedEvent": {
         "type": "object",
-        "description": "In-memory событие matching-ленты. Сохраняются только события, которые изменили расклад.",
+        "description": "Публичное событие matching-ленты. Содержит псевдонимы участников и агрегаты сценария без внутренних userId.",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "number"
           },
           "ts": {
-            "$ref": "#/components/schemas/DateTime"
+            "type": "number",
+            "description": "Unix timestamp в миллисекундах"
           },
           "type": {
             "type": "string",
@@ -689,18 +690,76 @@
           "actor": {
             "type": "object",
             "properties": {
-              "userId": {
-                "type": "string"
-              },
               "pseudonym": {
                 "type": "string"
               }
-            }
+            },
+            "required": [
+              "pseudonym"
+            ]
+          },
+          "affected": {
+            "type": "object",
+            "description": "Только для событий leftout.",
+            "properties": {
+              "pseudonym": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "pseudonym"
+            ]
+          },
+          "mutationKind": {
+            "type": "string",
+            "enum": [
+              "book_added",
+              "book_removed",
+              "rank_changed",
+              "status_changed",
+              "catalog_signup_updated",
+              "priorities_updated"
+            ]
+          },
+          "before": {
+            "$ref": "#/components/schemas/MatchingFeedScenarioSummary"
+          },
+          "after": {
+            "$ref": "#/components/schemas/MatchingFeedScenarioSummary"
           },
           "bookId": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "id",
+          "ts",
+          "type",
+          "actor",
+          "bookId",
+          "mutationKind"
+        ]
+      },
+      "MatchingFeedScenarioSummary": {
+        "type": "object",
+        "nullable": true,
+        "description": "Агрегированное состояние сценария без внутренних списков userId/bookId.",
+        "properties": {
+          "coveredCount": {
+            "type": "number"
+          },
+          "totalCount": {
+            "type": "number"
+          },
+          "strongInterestCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "coveredCount",
+          "totalCount",
+          "strongInterestCount"
+        ]
       },
       "MatchingPreferenceEvent": {
         "type": "object",


### PR DESCRIPTION
Что сделано
- лента matching отдаёт публичный DTO без userId и внутренних массивов ids
- actor и affected в feed response содержат только pseudonym
- before/after summary оставляет только агрегаты coveredCount, totalCount, strongInterestCount
- OpenAPI и Wiki обновлены под новый контракт
- тесты закрепляют отсутствие userId во feed response

Проверки
- npm run lint
- npm run typecheck
- npm test
- npm run build
- npx jest --runTestsByPath lib/matching/realtime/__tests__/feed.test.ts app/api/matching/feed/route.test.ts --runInBand --no-coverage
- npx playwright test e2e/matching-reader-circles.spec.ts