### PR TITLE
fix: replace in-memory adrift cause with persistent DB lookup

### DIFF
--- a/app/matching/page.tsx
+++ b/app/matching/page.tsx
@@ -19,7 +19,7 @@ import MatchingWelcome from '@/components/nd/MatchingWelcome'
 import { buildMoveImpact, sortMovesByImpact } from '@/lib/matching/move-impact'
 import { getOrCreatePseudonymReservation } from '@/lib/matching/pseudonym-reservations'
 import { fetchFeedForSession } from '@/lib/matching/realtime/feed'
-import { getAdriftCause, isViewerAdrift } from '@/lib/matching/adrift'
+import { fetchAdriftCauseForUser, isViewerAdrift } from '@/lib/matching/adrift'
 
 export default async function MatchingPage({
   searchParams,
@@ -170,8 +170,11 @@ export default async function MatchingPage({
   }]))
 
   const isReadOnly = activeSession.status === 'frozen'
-  const adriftCause = getAdriftCause(activeSession.id, viewingUserId)
-  const adrift = isViewerAdrift(scenarioSetOverview, viewingUserId)
+  const viewerIsAdrift = isViewerAdrift(scenarioSetOverview, viewingUserId)
+  const adriftCause = viewerIsAdrift
+    ? await fetchAdriftCauseForUser(activeSession.id, viewingUserId)
+    : null
+  const adrift = viewerIsAdrift
     ? {
         reason: adriftCause ? 'change' as const : 'never' as const,
         cause: adriftCause

--- a/lib/matching/__tests__/adrift.test.ts
+++ b/lib/matching/__tests__/adrift.test.ts
@@ -1,54 +1,141 @@
-import {
-  clearAdriftCause,
-  clearAdriftCausesForSession,
-  getAdriftCause,
-  rememberAdriftCause,
-  rememberAdriftCausesFromEvents,
-} from '../adrift'
-import type { AdriftCause, LeftoutFeedEventDraft } from '../feed-events'
+// Mock the DB module so the import chain doesn't require real env vars.
+// All tests pass their own dbClient via the third parameter.
+jest.mock('@/lib/db', () => ({ db: {} }))
+jest.mock('@/lib/db/schema', () => ({
+  matchingPreferenceEvents: {},
+  matchingSessionParticipants: {},
+}))
 
-const cause: AdriftCause = {
-  actor: { userId: 'actor', pseudonym: 'Actor' },
-  bookId: 'book-a',
-  mutationKind: 'book_added',
-  leaderBeforeId: 'before',
-  leaderAfterId: 'after',
-  at: 123,
+import { fetchAdriftCauseForUser, isViewerAdrift } from '../adrift'
+import type { ScenarioSetOverview } from '../scenarios'
+
+// Minimal Drizzle mock: returns the provided arrays in sequence on each .limit() call
+function makeDb(...results: unknown[][]): Parameters<typeof fetchAdriftCauseForUser>[2] {
+  let call = 0
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockImplementation(() => Promise.resolve(results[call++] ?? [])),
+  }
+  return chain as never
 }
 
-describe('adrift cause storage', () => {
-  afterEach(() => {
-    clearAdriftCausesForSession('session-a')
-    clearAdriftCausesForSession('session-b')
+function makeScenario(leftOutIds: string[]): object {
+  return {
+    id: 'scenario-' + leftOutIds.join('-'),
+    leftOut: leftOutIds.map((id) => ({ userId: id, pseudonym: id.toUpperCase() })),
+  }
+}
+
+const CAUSE_EVENT = {
+  actorUserId: 'actor-1',
+  eventType: 'book_removed',
+  bookId: 'book-a',
+  before: makeScenario([]),         // user-a NOT in leftOut before
+  after:  makeScenario(['user-a']), // user-a IN leftOut after → this is the cause
+  occurredAt: new Date('2026-01-02T10:00:00Z'),
+}
+
+const PARTICIPANT_ROW = [{ pseudonym: 'Лиса' }]
+
+describe('fetchAdriftCauseForUser', () => {
+  it('returns null when there are no events', async () => {
+    const result = await fetchAdriftCauseForUser('s1', 'user-a', makeDb([]))
+    expect(result).toBeNull()
   })
 
-  it('stores and clears a cause per session and user', () => {
-    rememberAdriftCause('session-a', 'u1', cause)
-    rememberAdriftCause('session-b', 'u1', { ...cause, bookId: 'book-b' })
+  it('returns the cause event where user first appeared in leftOut', async () => {
+    const result = await fetchAdriftCauseForUser('s1', 'user-a', makeDb(
+      [CAUSE_EVENT],    // 1st query: events
+      PARTICIPANT_ROW,  // 2nd query: participant lookup
+    ))
 
-    expect(getAdriftCause('session-a', 'u1')).toEqual(cause)
-    expect(getAdriftCause('session-b', 'u1')?.bookId).toBe('book-b')
-
-    clearAdriftCause('session-a', 'u1')
-
-    expect(getAdriftCause('session-a', 'u1')).toBeNull()
-    expect(getAdriftCause('session-b', 'u1')?.bookId).toBe('book-b')
+    expect(result).toMatchObject({
+      actor: { userId: 'actor-1', pseudonym: 'Лиса' },
+      bookId: 'book-a',
+      mutationKind: 'book_removed',
+      at: new Date('2026-01-02T10:00:00Z').getTime(),
+    })
   })
 
-  it('stores causes from leftout feed events', () => {
-    const events: LeftoutFeedEventDraft[] = [
-      {
-        type: 'leftout',
-        actor: cause.actor,
-        bookId: cause.bookId,
-        mutationKind: cause.mutationKind,
-        affected: { userId: 'u2', pseudonym: 'User 2' },
-        cause,
-      },
-    ]
+  it('picks the most recent cause when user went adrift more than once', async () => {
+    const olderCause = {
+      ...CAUSE_EVENT,
+      bookId: 'book-old',
+      occurredAt: new Date('2026-01-01T00:00:00Z'),
+    }
+    // Rows come newest-first; first match is the most recent transition into leftOut
+    const result = await fetchAdriftCauseForUser('s1', 'user-a', makeDb(
+      [CAUSE_EVENT, olderCause],
+      PARTICIPANT_ROW,
+    ))
 
-    rememberAdriftCausesFromEvents('session-a', events)
+    expect(result?.bookId).toBe('book-a') // not book-old
+  })
 
-    expect(getAdriftCause('session-a', 'u2')).toEqual(cause)
+  it('skips events where user was already in leftOut (continuous adrift)', async () => {
+    const alreadyAdrift = {
+      ...CAUSE_EVENT,
+      bookId: 'neutral-event',
+      before: makeScenario(['user-a']), // already leftOut before
+      after:  makeScenario(['user-a']), // still leftOut after
+      occurredAt: new Date('2026-01-03T00:00:00Z'),
+    }
+    // alreadyAdrift is newer but should be skipped; CAUSE_EVENT is the real trigger
+    const result = await fetchAdriftCauseForUser('s1', 'user-a', makeDb(
+      [alreadyAdrift, CAUSE_EVENT],
+      PARTICIPANT_ROW,
+    ))
+
+    expect(result?.bookId).toBe('book-a')
+  })
+
+  it('falls back to pseudonym "Участник" when actor has left the session', async () => {
+    const result = await fetchAdriftCauseForUser('s1', 'user-a', makeDb(
+      [CAUSE_EVENT],
+      [], // participant not found
+    ))
+
+    expect(result?.actor.pseudonym).toBe('Участник')
+  })
+
+  it('returns null when event type is not a known mutation kind', async () => {
+    const unknownKindEvent = { ...CAUSE_EVENT, eventType: 'unknown_kind' }
+    const result = await fetchAdriftCauseForUser('s1', 'user-a', makeDb(
+      [unknownKindEvent],
+    ))
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('isViewerAdrift', () => {
+  const overview = (leftOutIds: string[]): ScenarioSetOverview => ({
+    scenarios: [],
+    leader: {
+      id: 'l',
+      tier: 'leader',
+      circles: [],
+      leftOut: leftOutIds.map((id) => ({ userId: id, pseudonym: id })),
+      score: { coveredCount: 0, totalCount: 0, coverageRatio: 0, strongInterestCount: 0, rankedCount: 0, unrankedCount: 0, rankSum: 0, avgRank: null, worstRank: null },
+    },
+    totalCount: 1,
+    minGroupSize: 2,
+    maxGroupSize: 3,
+  })
+
+  it('returns true when viewer is in leader leftOut', () => {
+    expect(isViewerAdrift(overview(['u1', 'u2']), 'u1')).toBe(true)
+  })
+
+  it('returns false when viewer is not in leader leftOut', () => {
+    expect(isViewerAdrift(overview(['u2']), 'u1')).toBe(false)
+  })
+
+  it('returns false when there is no leader', () => {
+    const noLeader: ScenarioSetOverview = { scenarios: [], leader: null, totalCount: 0, minGroupSize: 2, maxGroupSize: 3 }
+    expect(isViewerAdrift(noLeader, 'u1')).toBe(false)
   })
 })

--- a/lib/matching/__tests__/mutation-effects.test.ts
+++ b/lib/matching/__tests__/mutation-effects.test.ts
@@ -1,28 +1,16 @@
 import { finalizeMatchingMutationEffects } from '../mutation-effects'
 import type { MatchingScenario } from '../scenarios'
 import { fetchScenarioContextForSession } from '../scenario-input'
-import { buildFeedEventsForMutation } from '../feed-events'
-import { clearAdriftCause, rememberAdriftCausesFromEvents } from '../adrift'
 import { recordMatchingPreferenceEvent } from '../preference-events'
 
 jest.mock('../scenario-input', () => ({
   fetchScenarioContextForSession: jest.fn(),
-}))
-jest.mock('../feed-events', () => ({
-  buildFeedEventsForMutation: jest.fn(),
-}))
-jest.mock('../adrift', () => ({
-  clearAdriftCause: jest.fn(),
-  rememberAdriftCausesFromEvents: jest.fn(),
 }))
 jest.mock('../preference-events', () => ({
   recordMatchingPreferenceEvent: jest.fn(),
 }))
 
 const mockFetchContext = fetchScenarioContextForSession as jest.Mock
-const mockBuildFeedEvents = buildFeedEventsForMutation as jest.Mock
-const mockClearAdrift = clearAdriftCause as jest.Mock
-const mockRememberAdrift = rememberAdriftCausesFromEvents as jest.Mock
 const mockRecordEvent = recordMatchingPreferenceEvent as jest.Mock
 
 function scenario(id: string, coveredCount: number, leftOut: MatchingScenario['leftOut']): MatchingScenario {
@@ -78,18 +66,10 @@ describe('finalizeMatchingMutationEffects', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockFetchContext.mockResolvedValue(afterContext)
-    mockBuildFeedEvents.mockReturnValue([
-      {
-        type: 'leftout',
-        actor: { userId: 'actor', pseudonym: 'Лиса' },
-        affected: { userId: 'target', pseudonym: 'Белка' },
-        bookId: 'book-1',
-      },
-    ])
     mockRecordEvent.mockResolvedValue(undefined)
   })
 
-  it('derives feed events, updates adrift state, and records persistent analytics', async () => {
+  it('records persistent analytics for a mutation', async () => {
     await finalizeMatchingMutationEffects({
       sessionId: 'session-1',
       targetUserId: 'target',
@@ -101,16 +81,6 @@ describe('finalizeMatchingMutationEffects', () => {
       metadata: { via: 'test' },
     })
 
-    expect(mockBuildFeedEvents).toHaveBeenCalledWith(expect.objectContaining({
-      actor: { userId: 'actor', pseudonym: 'Лиса' },
-      bookId: 'book-1',
-      kind: 'book_added',
-      leaderBefore: beforeLeader,
-      leaderAfter: afterLeader,
-    }))
-    expect(mockRememberAdrift).toHaveBeenCalledWith('session-1', [expect.objectContaining({ type: 'leftout' })])
-    expect(mockClearAdrift).toHaveBeenCalledWith('session-1', 'actor')
-    expect(mockClearAdrift).toHaveBeenCalledWith('session-1', 'target')
     expect(mockRecordEvent).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: 'session-1',
       userId: 'target',
@@ -135,7 +105,6 @@ describe('finalizeMatchingMutationEffects', () => {
       before: { context: contextWithLeader(beforeLeader) },
     })
 
-    expect(mockBuildFeedEvents).not.toHaveBeenCalled()
     expect(mockRecordEvent).toHaveBeenCalledWith(expect.objectContaining({
       actorUserId: 'admin',
       eventType: 'priorities_updated',

--- a/lib/matching/adrift.ts
+++ b/lib/matching/adrift.ts
@@ -1,38 +1,83 @@
-import type { AdriftCause, LeftoutFeedEventDraft } from './feed-events'
+import { and, desc, eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { matchingPreferenceEvents, matchingSessionParticipants } from '@/lib/db/schema'
+import { asMatchingScenario, isMatchingMutationKind } from './feed-events'
+import type { AdriftCause } from './feed-events'
 import type { ScenarioSetOverview } from './scenarios'
 
-const causesBySession = new Map<string, Map<string, AdriftCause>>()
+/** How many events to scan when searching for the adrift cause */
+const SEARCH_LIMIT = 200
 
-export function rememberAdriftCause(sessionId: string, userId: string, cause: AdriftCause): void {
-  let causes = causesBySession.get(sessionId)
-  if (!causes) {
-    causes = new Map()
-    causesBySession.set(sessionId, causes)
+/**
+ * Reads matching_preference_events to find the most recent event that caused
+ * userId to appear in the leader's leftOut list for the first time.
+ * Returns null if no such event is found.
+ *
+ * Only call this when isViewerAdrift() has already confirmed the user is adrift.
+ */
+export async function fetchAdriftCauseForUser(
+  sessionId: string,
+  userId: string,
+  dbClient: typeof db = db,
+): Promise<AdriftCause | null> {
+  const rows = await dbClient
+    .select({
+      actorUserId: matchingPreferenceEvents.actorUserId,
+      eventType: matchingPreferenceEvents.eventType,
+      bookId: matchingPreferenceEvents.bookId,
+      before: matchingPreferenceEvents.before,
+      after: matchingPreferenceEvents.after,
+      occurredAt: matchingPreferenceEvents.occurredAt,
+    })
+    .from(matchingPreferenceEvents)
+    .where(eq(matchingPreferenceEvents.sessionId, sessionId))
+    .orderBy(desc(matchingPreferenceEvents.occurredAt))
+    .limit(SEARCH_LIMIT)
+
+  // Walk newest-to-oldest: find the transition "not in leftOut → in leftOut"
+  for (const row of rows) {
+    const after = asMatchingScenario(row.after)
+    const before = asMatchingScenario(row.before)
+
+    const inAfterLeftOut = after?.leftOut.some((p) => p.userId === userId) ?? false
+    const inBeforeLeftOut = before?.leftOut.some((p) => p.userId === userId) ?? false
+
+    if (inAfterLeftOut && !inBeforeLeftOut) {
+      // Found the event that caused the user to become left out
+      if (!isMatchingMutationKind(row.eventType)) continue
+
+      const [participant] = await dbClient
+        .select({ pseudonym: matchingSessionParticipants.pseudonym })
+        .from(matchingSessionParticipants)
+        .where(
+          and(
+            eq(matchingSessionParticipants.sessionId, sessionId),
+            eq(matchingSessionParticipants.userId, row.actorUserId),
+          ),
+        )
+        .limit(1)
+
+      return {
+        actor: {
+          userId: row.actorUserId,
+          pseudonym: participant?.pseudonym ?? 'Участник',
+        },
+        bookId: row.bookId ?? '',
+        mutationKind: row.eventType,
+        leaderBeforeId: before?.id ?? null,
+        leaderAfterId: after?.id ?? null,
+        at: row.occurredAt.getTime(),
+      }
+    }
+
+    // Recovery event: user was in leftOut but recovered — stop searching
+    if (!inAfterLeftOut && inBeforeLeftOut) break
   }
-  causes.set(userId, cause)
+
+  return null
 }
 
-export function rememberAdriftCausesFromEvents(sessionId: string, events: LeftoutFeedEventDraft[]): void {
-  for (const event of events) {
-    rememberAdriftCause(sessionId, event.affected.userId, event.cause)
-  }
-}
-
-export function getAdriftCause(sessionId: string, userId: string): AdriftCause | null {
-  return causesBySession.get(sessionId)?.get(userId) ?? null
-}
-
-export function clearAdriftCause(sessionId: string, userId: string): void {
-  const causes = causesBySession.get(sessionId)
-  if (!causes) return
-  causes.delete(userId)
-  if (causes.size === 0) causesBySession.delete(sessionId)
-}
-
-export function clearAdriftCausesForSession(sessionId: string): void {
-  causesBySession.delete(sessionId)
-}
-
+/** Returns true if viewingUserId is in the leader scenario's leftOut list. */
 export function isViewerAdrift(overview: ScenarioSetOverview, viewingUserId: string): boolean {
   const leader = overview.leader
   return !!leader && leader.leftOut.some((participant) => participant.userId === viewingUserId)

--- a/lib/matching/feed-events.ts
+++ b/lib/matching/feed-events.ts
@@ -178,3 +178,19 @@ function leaderSignature(leader: MatchingScenario | null): string {
     leftOutIds,
   ].join('::')
 }
+
+export function isMatchingMutationKind(value: string): value is MatchingMutationKind {
+  return [
+    'book_added',
+    'book_removed',
+    'rank_changed',
+    'status_changed',
+    'catalog_signup_updated',
+    'priorities_updated',
+  ].includes(value)
+}
+
+export function asMatchingScenario(value: unknown): MatchingScenario | null {
+  if (!value || typeof value !== 'object') return null
+  return value as MatchingScenario
+}

--- a/lib/matching/mutation-effects.ts
+++ b/lib/matching/mutation-effects.ts
@@ -1,7 +1,5 @@
 import type { MatchingMutationKind } from './feed-events'
 import type { MatchingScenarioContext } from './scenario-input'
-import { buildFeedEventsForMutation } from './feed-events'
-import { clearAdriftCause, rememberAdriftCausesFromEvents } from './adrift'
 import { fetchScenarioContextForSession } from './scenario-input'
 import { recordMatchingPreferenceEvent } from './preference-events'
 
@@ -39,29 +37,6 @@ export async function finalizeMatchingMutationEffects({
 }: FinalizeMatchingMutationInput): Promise<void> {
   const after = await captureMatchingMutationSnapshot(sessionId)
   if (!after) return
-
-  const actor = after.context.participants.find((participant) => participant.userId === actorUserId)
-    ?? before?.context.participants.find((participant) => participant.userId === actorUserId)
-    ?? after.context.participants.find((participant) => participant.userId === targetUserId)
-    ?? before?.context.participants.find((participant) => participant.userId === targetUserId)
-
-  const effectiveBookId = bookId ?? ''
-  const feedEvents = effectiveBookId && actor
-    ? buildFeedEventsForMutation({
-        actor,
-        bookId: effectiveBookId,
-        kind,
-        leaderBefore: before?.context.overview.leader ?? null,
-        leaderAfter: after.context.overview.leader,
-      })
-    : []
-
-  rememberAdriftCausesFromEvents(sessionId, feedEvents.filter((event) => event.type === 'leftout'))
-
-  const leftOutAfter = new Set(after.context.overview.leader?.leftOut.map((participant) => participant.userId) ?? [])
-  for (const participant of after.context.participants) {
-    if (!leftOutAfter.has(participant.userId)) clearAdriftCause(sessionId, participant.userId)
-  }
 
   await recordMatchingPreferenceEvent({
     sessionId,

--- a/lib/matching/realtime/feed.ts
+++ b/lib/matching/realtime/feed.ts
@@ -2,10 +2,11 @@ import { and, desc, eq, inArray } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { matchingPreferenceEvents, matchingSessionParticipants } from '@/lib/db/schema'
 import {
+  asMatchingScenario,
   buildFeedEventsForMutation,
+  isMatchingMutationKind,
   type MatchingMutationKind,
 } from '../feed-events'
-import type { MatchingScenario } from '../scenarios'
 
 export type FeedEventType = 'best' | 'leftout'
 
@@ -124,22 +125,6 @@ export async function fetchFeedForSession(
   })
 
   return persistentEvents.slice(-limit)
-}
-
-function isMatchingMutationKind(value: string): value is MatchingMutationKind {
-  return [
-    'book_added',
-    'book_removed',
-    'rank_changed',
-    'status_changed',
-    'catalog_signup_updated',
-    'priorities_updated',
-  ].includes(value)
-}
-
-function asMatchingScenario(value: unknown): MatchingScenario | null {
-  if (!value || typeof value !== 'object') return null
-  return value as MatchingScenario
 }
 
 function toPublicSummary(summary: {


### PR DESCRIPTION
## Summary
- Adrift attribution («вы выпали из круга после того, как X убрал Y») хранилась в in-memory Map — на Vercel API-роут и рендер страницы разные инстансы, Map всегда пуста
- `fetchAdriftCauseForUser` читает причину из `matching_preference_events` (уже содержит `before`/`after` лидера), ищет новейшее событие-переход «не в leftOut → в leftOut»
- `mutation-effects.ts` упрощается вдвое: без Map больше не нужен `buildFeedEventsForMutation` и вся actor/feedEvents логика — остаётся только `recordMatchingPreferenceEvent`

## Test plan
- [ ] 709 unit-тестов проходят (в т.ч. переписанный `adrift.test.ts` с 9 тестами на DB-lookup)
- [ ] `npm run typecheck` — чисто
- [ ] `npm run lint` — чисто
- [ ] CI зелёный

🤖 Generated with [Claude Code](https://claude.com/claude-code)