### PR TITLE
feat(matching): показывать в админ-аналитике конкретные книги действия

### DIFF
--- a/app/api/priorities/route.test.ts
+++ b/app/api/priorities/route.test.ts
@@ -10,6 +10,7 @@ import {
   broadcastActiveMatchingStateChangeForParticipant,
   getActiveMatchingSessionIdForParticipant,
 } from '@/lib/matching/realtime/state-change'
+import { finalizeMatchingMutationEffects } from '@/lib/matching/mutation-effects'
 
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }))
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
@@ -39,6 +40,7 @@ const mockAuth = authModule.auth as jest.Mock
 const mockRecordUserActivity = activityModule.bestEffortRecordUserActivity as jest.Mock
 const mockBroadcastMatchingStateChange = broadcastActiveMatchingStateChangeForParticipant as jest.Mock
 const mockGetActiveSessionId = getActiveMatchingSessionIdForParticipant as jest.Mock
+const mockFinalizeEffects = finalizeMatchingMutationEffects as jest.Mock
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -161,5 +163,33 @@ describe('PUT /api/priorities', () => {
       kind: 'external_ranks_updated',
       bookIds: ['book-a', 'book-b'],
     })
+  })
+
+  it('при активной сессии пишет событие предпочтений с упорядоченным списком книг', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
+    mockGetActiveSessionId.mockResolvedValue('session-1')
+    ;(db.select as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue([{ id: 'book-a' }, { id: 'book-b' }]),
+      }),
+    })
+    ;(db.insert as jest.Mock).mockReturnValue({ values: jest.fn().mockResolvedValue(undefined) })
+    ;(db.delete as jest.Mock).mockReturnValue({ where: jest.fn().mockResolvedValue(undefined) })
+    ;(db.update as jest.Mock).mockReturnValue({
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockResolvedValue(undefined),
+    })
+
+    const res = await PUT(makePut({ bookIds: ['book-b', 'book-a'] }))
+
+    expect(res.status).toBe(200)
+    expect(mockFinalizeEffects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        kind: 'priorities_updated',
+        source: 'profile',
+        metadata: { rankedBookIds: ['book-b', 'book-a'] },
+      }),
+    )
   })
 })

--- a/app/api/priorities/route.ts
+++ b/app/api/priorities/route.ts
@@ -107,7 +107,7 @@ export async function PUT(req: NextRequest) {
       kind: 'priorities_updated',
       source: 'profile',
       before,
-      metadata: { bookIds: validBookIds },
+      metadata: { rankedBookIds: validBookIds },
     })
   }
   await broadcastActiveMatchingStateChangeForParticipant(userId, {

--- a/app/api/signup/route.test.ts
+++ b/app/api/signup/route.test.ts
@@ -11,6 +11,7 @@ import {
   broadcastActiveMatchingStateChangeForParticipant,
   getActiveMatchingSessionIdForParticipant,
 } from '@/lib/matching/realtime/state-change'
+import { finalizeMatchingMutationEffects } from '@/lib/matching/mutation-effects'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
 jest.mock('@/lib/signup-books', () => ({ upsertSignupByBookIds: jest.fn() }))
@@ -49,6 +50,7 @@ const mockInsert = dbModule.db.insert as jest.Mock
 const mockRecordUserActivity = activityModule.bestEffortRecordUserActivity as jest.Mock
 const mockBroadcastMatchingStateChange = broadcastActiveMatchingStateChangeForParticipant as jest.Mock
 const mockGetActiveSessionId = getActiveMatchingSessionIdForParticipant as jest.Mock
+const mockFinalizeEffects = finalizeMatchingMutationEffects as jest.Mock
 
 function makeRequest(body: object) {
   return new NextRequest('http://localhost/api/signup', {
@@ -58,8 +60,14 @@ function makeRequest(body: object) {
   })
 }
 
-function upsertResult(books: string[] = [], bookIds: string[] = books.map((_, i) => `book-${i + 1}`), isNew = false) {
-  return { isNew, addedBooks: books, addedBookIds: bookIds }
+function upsertResult(
+  books: string[] = [],
+  bookIds: string[] = books.map((_, i) => `book-${i + 1}`),
+  isNew = false,
+  newlyAddedBookIds: string[] = bookIds,
+  removedBookIds: string[] = [],
+) {
+  return { isNew, addedBooks: books, addedBookIds: bookIds, newlyAddedBookIds, removedBookIds }
 }
 
 describe('POST /api/signup', () => {
@@ -132,6 +140,27 @@ describe('POST /api/signup', () => {
       kind: 'catalog_signup_updated',
       selectedBookIds: ['book-a'],
     })
+  })
+
+  it('при активной сессии пишет событие предпочтений с дельтой добавленных/убранных книг', async () => {
+    mockAuth.mockResolvedValue({ user: { email: 'test@test.com', id: 'user-1' } })
+    mockGetActiveSessionId.mockResolvedValue('session-1')
+    // добавлена book-b, убрана book-x
+    mockUpsertSignupByBookIds.mockResolvedValue(
+      upsertResult(['Book A', 'Book B'], ['book-a', 'book-b'], false, ['book-b'], ['book-x']),
+    )
+
+    const res = await POST(makeRequest({ name: 'Test User', contacts: '@test', selectedBookIds: ['book-a', 'book-b'] }))
+
+    expect(res.status).toBe(200)
+    expect(mockFinalizeEffects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        kind: 'catalog_signup_updated',
+        source: 'catalog',
+        metadata: { addedBookIds: ['book-b'], removedBookIds: ['book-x'] },
+      }),
+    )
   })
 
   it('не принимает legacy selectedBooks по названиям', async () => {

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -115,7 +115,10 @@ export async function POST(req: NextRequest) {
       kind: 'catalog_signup_updated',
       source: 'catalog',
       before,
-      metadata: { selectedBookIds: result.addedBookIds },
+      metadata: {
+        addedBookIds: result.newlyAddedBookIds,
+        removedBookIds: result.removedBookIds,
+      },
     })
   }
   await broadcastActiveMatchingStateChangeForParticipant(pgUserId, {

--- a/components/nd/AdminMatchingSession.tsx
+++ b/components/nd/AdminMatchingSession.tsx
@@ -1,6 +1,12 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import {
+  type PreferenceEventMetadata,
+  eventDetail,
+  eventTypeLabel,
+  sourceLabel,
+} from '@/lib/matching/preference-event-display'
 
 interface MatchingSession {
   id: string
@@ -29,7 +35,7 @@ interface PreferenceEvent {
   eventType: string
   source: string
   bookId: string | null
-  metadata: { bookTitle?: string | null; selectedBookIds?: string[]; bookIds?: string[] } | null
+  metadata: PreferenceEventMetadata | null
   occurredAt: string
 }
 
@@ -608,32 +614,7 @@ function countPreferenceEvents(events: PreferenceEvent[]): Record<string, number
   }, {})
 }
 
-function eventTypeLabel(eventType: string): string {
-  if (eventType === 'book_added') return 'Добавлена книга'
-  if (eventType === 'book_removed') return 'Убрана книга'
-  if (eventType === 'rank_changed') return 'Ранги'
-  if (eventType === 'status_changed') return 'Статус'
-  if (eventType === 'catalog_signup_updated') return 'Список'
-  if (eventType === 'priorities_updated') return 'Приоритеты'
-  return eventType
-}
-
-function sourceLabel(source: string): string {
-  if (source === 'matching') return 'Матчинг'
-  if (source === 'catalog') return 'Каталог'
-  if (source === 'profile') return 'Профиль'
-  if (source === 'admin') return 'Админка'
-  return source
-}
-
 function displayParticipant(userId: string, participants: Participant[]): string {
   const participant = participants.find((item) => item.userId === userId)
   return participant?.pseudonym ?? `${userId.slice(0, 12)}…`
-}
-
-function eventDetail(event: PreferenceEvent): string {
-  if (event.metadata?.bookTitle) return event.metadata.bookTitle
-  if (event.metadata?.selectedBookIds) return `${event.metadata.selectedBookIds.length} книг`
-  if (event.metadata?.bookIds) return `${event.metadata.bookIds.length} книг`
-  return event.bookId ?? '—'
 }

--- a/docs/wiki/Group-Matching-Mode.md
+++ b/docs/wiki/Group-Matching-Mode.md
@@ -70,7 +70,7 @@ PK: `(session_id, user_id)`. Unique: `(session_id, pseudonym)`.
 | `source` | text | `matching`, `catalog`, `profile`, `admin` |
 | `book_id` | text FK → books? | Книга, если событие относится к одной книге |
 | `before` / `after` | jsonb? | Лидер-сценарий до/после изменения |
-| `metadata` | jsonb? | Snapshot деталей: название книги, список bookIds, статус |
+| `metadata` | jsonb? | Snapshot деталей с уже разрешёнными названиями книг. Для одиночных действий — `bookTitle`. Для `catalog_signup_updated` — дельта набора: `addedBookIds`/`removedBookIds` + читаемые `addedBookTitles`/`removedBookTitles`. Для `priorities_updated` — упорядоченный `rankedBookIds` + `rankedBookTitles`. Названия дописываются в `finalizeMatchingMutationEffects` через `bookTitleById`, поэтому админка показывает «какие именно книги» без собственного резолва id→title. Статусные события несут `status`. |
 | `occurred_at` | timestamp | Когда произошло |
 
 Событие пишется только если пользователь уже был участником этой сессии на момент изменения (`occurred_at >= joined_at`).

--- a/lib/matching/__tests__/mutation-effects.test.ts
+++ b/lib/matching/__tests__/mutation-effects.test.ts
@@ -112,6 +112,61 @@ describe('finalizeMatchingMutationEffects', () => {
     }))
   })
 
+  it('обогащает id-массивы метаданных названиями книг (catalog delta)', async () => {
+    mockFetchContext.mockResolvedValue({
+      ...afterContext,
+      bookTitleById: new Map([
+        ['book-1', 'Дюна'],
+        ['book-2', '1984'],
+      ]),
+    })
+
+    await finalizeMatchingMutationEffects({
+      sessionId: 'session-1',
+      targetUserId: 'target',
+      actorUserId: 'target',
+      bookId: null,
+      kind: 'catalog_signup_updated',
+      source: 'catalog',
+      before: null,
+      metadata: { addedBookIds: ['book-1'], removedBookIds: ['book-2'] },
+    })
+
+    expect(mockRecordEvent).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        addedBookIds: ['book-1'],
+        removedBookIds: ['book-2'],
+        addedBookTitles: ['Дюна'],
+        removedBookTitles: ['1984'],
+        bookTitle: null,
+      }),
+    }))
+  })
+
+  it('обогащает rankedBookIds, неизвестный id остаётся как есть', async () => {
+    mockFetchContext.mockResolvedValue({
+      ...afterContext,
+      bookTitleById: new Map([['book-1', 'Дюна']]),
+    })
+
+    await finalizeMatchingMutationEffects({
+      sessionId: 'session-1',
+      targetUserId: 'target',
+      actorUserId: 'target',
+      bookId: null,
+      kind: 'priorities_updated',
+      source: 'profile',
+      before: null,
+      metadata: { rankedBookIds: ['book-1', 'book-missing'] },
+    })
+
+    expect(mockRecordEvent).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        rankedBookTitles: ['Дюна', 'book-missing'],
+      }),
+    }))
+  })
+
   it('does nothing when the scenario context is unavailable', async () => {
     mockFetchContext.mockResolvedValue(null)
 

--- a/lib/matching/__tests__/preference-event-display.test.ts
+++ b/lib/matching/__tests__/preference-event-display.test.ts
@@ -1,0 +1,78 @@
+import {
+  eventDetail,
+  eventTypeLabel,
+  sourceLabel,
+  type PreferenceEventLike,
+} from '../preference-event-display'
+
+const event = (
+  eventType: string,
+  metadata: PreferenceEventLike['metadata'],
+  bookId: string | null = null,
+): PreferenceEventLike => ({ eventType, bookId, metadata })
+
+describe('eventTypeLabel', () => {
+  it('переименовывает catalog_signup_updated в «Изменён набор»', () => {
+    expect(eventTypeLabel('catalog_signup_updated')).toBe('Изменён набор')
+  })
+
+  it('переводит остальные известные типы', () => {
+    expect(eventTypeLabel('book_added')).toBe('Добавлена книга')
+    expect(eventTypeLabel('book_removed')).toBe('Убрана книга')
+    expect(eventTypeLabel('priorities_updated')).toBe('Приоритеты')
+  })
+
+  it('возвращает исходный код для неизвестного типа', () => {
+    expect(eventTypeLabel('mystery')).toBe('mystery')
+  })
+})
+
+describe('sourceLabel', () => {
+  it('переводит известные источники', () => {
+    expect(sourceLabel('catalog')).toBe('Каталог')
+    expect(sourceLabel('matching')).toBe('Матчинг')
+  })
+})
+
+describe('eventDetail', () => {
+  it('одиночное действие показывает название книги', () => {
+    expect(eventDetail(event('book_added', { bookTitle: 'Дюна' }, 'b1'))).toBe('Дюна')
+  })
+
+  it('изменение набора показывает добавленные (+) и убранные (−) книги', () => {
+    expect(
+      eventDetail(event('catalog_signup_updated', {
+        addedBookTitles: ['Дюна'],
+        removedBookTitles: ['1984'],
+      })),
+    ).toBe('+Дюна, −1984')
+  })
+
+  it('только добавление без удалений', () => {
+    expect(
+      eventDetail(event('catalog_signup_updated', { addedBookTitles: ['Дюна', 'Мы'] })),
+    ).toBe('+Дюна, +Мы')
+  })
+
+  it('приоритеты показывают нумерованный порядок', () => {
+    expect(
+      eventDetail(event('priorities_updated', { rankedBookTitles: ['Дюна', '1984', 'Мы'] })),
+    ).toBe('1. Дюна → 2. 1984 → 3. Мы')
+  })
+
+  it('исторические события без названий падают в счётчик', () => {
+    expect(eventDetail(event('catalog_signup_updated', { selectedBookIds: ['a', 'b', 'c'] }))).toBe('3 книг')
+    expect(eventDetail(event('priorities_updated', { bookIds: ['a', 'b'] }))).toBe('2 книг')
+  })
+
+  it('пустые массивы дельты не считаются действием и падают в fallback', () => {
+    expect(
+      eventDetail(event('catalog_signup_updated', { addedBookTitles: [], removedBookTitles: [] }, 'b9')),
+    ).toBe('b9')
+  })
+
+  it('без метаданных показывает bookId или тире', () => {
+    expect(eventDetail(event('x', null, 'b1'))).toBe('b1')
+    expect(eventDetail(event('x', null, null))).toBe('—')
+  })
+})

--- a/lib/matching/mutation-effects.ts
+++ b/lib/matching/mutation-effects.ts
@@ -38,6 +38,24 @@ export async function finalizeMatchingMutationEffects({
   const after = await captureMatchingMutationSnapshot(sessionId)
   if (!after) return
 
+  const titleFor = (id: string) => after.context.bookTitleById.get(id) ?? id
+
+  // Enrich any book-id arrays in metadata with human-readable titles so the
+  // admin UI can show *which* books were touched without its own id→title map.
+  const idArrayKeys: Array<[idKey: string, titleKey: string]> = [
+    ['addedBookIds', 'addedBookTitles'],
+    ['removedBookIds', 'removedBookTitles'],
+    ['rankedBookIds', 'rankedBookTitles'],
+  ]
+  const enrichedMetadata: Record<string, unknown> = { ...metadata }
+  for (const [idKey, titleKey] of idArrayKeys) {
+    const ids = metadata[idKey]
+    if (Array.isArray(ids)) {
+      enrichedMetadata[titleKey] = (ids as string[]).map(titleFor)
+    }
+  }
+  enrichedMetadata.bookTitle = bookId ? after.context.bookTitleById.get(bookId) ?? null : null
+
   await recordMatchingPreferenceEvent({
     sessionId,
     userId: targetUserId,
@@ -47,9 +65,6 @@ export async function finalizeMatchingMutationEffects({
     bookId,
     before: before?.context.overview.leader ?? null,
     after: after.context.overview.leader,
-    metadata: {
-      ...metadata,
-      bookTitle: bookId ? after.context.bookTitleById.get(bookId) ?? null : null,
-    },
+    metadata: enrichedMetadata,
   })
 }

--- a/lib/matching/preference-event-display.ts
+++ b/lib/matching/preference-event-display.ts
@@ -1,0 +1,69 @@
+// Pure display helpers for the admin "Аналитика изменений предпочтений" table.
+// Kept framework-free so they can be unit-tested without importing the client
+// component. Titles are resolved at write time (see lib/matching/mutation-effects.ts),
+// so the admin UI needs no id→title map of its own.
+
+export interface PreferenceEventMetadata {
+  bookTitle?: string | null
+  // Catalog signup delta (resolved titles).
+  addedBookTitles?: string[]
+  removedBookTitles?: string[]
+  // Priorities — ordered by rank (resolved titles).
+  rankedBookTitles?: string[]
+  status?: string | null
+  // Legacy/historical events stored only id arrays — kept for graceful fallback.
+  selectedBookIds?: string[]
+  bookIds?: string[]
+}
+
+export interface PreferenceEventLike {
+  eventType: string
+  bookId: string | null
+  metadata: PreferenceEventMetadata | null
+}
+
+export function eventTypeLabel(eventType: string): string {
+  if (eventType === 'book_added') return 'Добавлена книга'
+  if (eventType === 'book_removed') return 'Убрана книга'
+  if (eventType === 'rank_changed') return 'Ранги'
+  if (eventType === 'status_changed') return 'Статус'
+  if (eventType === 'catalog_signup_updated') return 'Изменён набор'
+  if (eventType === 'priorities_updated') return 'Приоритеты'
+  return eventType
+}
+
+export function sourceLabel(source: string): string {
+  if (source === 'matching') return 'Матчинг'
+  if (source === 'catalog') return 'Каталог'
+  if (source === 'profile') return 'Профиль'
+  if (source === 'admin') return 'Админка'
+  return source
+}
+
+export function eventDetail(event: PreferenceEventLike): string {
+  const m = event.metadata
+  if (m) {
+    // Single-book add/remove/status.
+    if (m.bookTitle) return m.bookTitle
+
+    // Catalog signup delta: which books were added (+) / removed (−).
+    const added = m.addedBookTitles ?? []
+    const removed = m.removedBookTitles ?? []
+    if (added.length > 0 || removed.length > 0) {
+      return [
+        ...added.map(title => `+${title}`),
+        ...removed.map(title => `−${title}`),
+      ].join(', ')
+    }
+
+    // Priorities: show the ranking order.
+    if (m.rankedBookTitles && m.rankedBookTitles.length > 0) {
+      return m.rankedBookTitles.map((title, index) => `${index + 1}. ${title}`).join(' → ')
+    }
+
+    // Historical events that stored only id arrays — fall back to a count.
+    if (m.selectedBookIds) return `${m.selectedBookIds.length} книг`
+    if (m.bookIds) return `${m.bookIds.length} книг`
+  }
+  return event.bookId ?? '—'
+}

--- a/lib/signup-books.test.ts
+++ b/lib/signup-books.test.ts
@@ -85,15 +85,22 @@ describe('signup-books', () => {
     ])
   })
 
-  it('upsertSignupByBookIds одной транзакцией удаляет старые и вставляет новые уникальные', async () => {
-    ;(db.select as jest.Mock).mockReturnValue({
-      from: jest.fn().mockReturnValue({
-        where: jest.fn().mockResolvedValue([
-          { id: 'book-a', title: 'Книга A' },
-          { id: 'book-b', title: 'Книга B' },
-        ]),
-      }),
-    })
+  const selectChain = (rows: unknown[]) => ({
+    from: jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue(rows) }),
+  })
+
+  it('upsertSignupByBookIds вычисляет дельту: удаляет ушедшие и вставляет новые уникальные', async () => {
+    ;(db.select as jest.Mock)
+      // resolveBooksByIds — каталог
+      .mockReturnValueOnce(selectChain([
+        { id: 'book-a', title: 'Книга A' },
+        { id: 'book-b', title: 'Книга B' },
+      ]))
+      // существующие записи внутри транзакции (было book-a и book-x)
+      .mockReturnValueOnce(selectChain([
+        { bookId: 'book-a' },
+        { bookId: 'book-x' },
+      ]))
     ;(db.delete as jest.Mock).mockReturnValue({
       where: jest.fn().mockResolvedValue(undefined),
     })
@@ -106,15 +113,26 @@ describe('signup-books', () => {
     const result = await upsertSignupByBookIds('user-1', ['book-a', 'book-a', 'book-b'])
 
     expect(db.transaction).toHaveBeenCalled()
-    expect(db.delete).toHaveBeenCalledTimes(1)
+    expect(db.delete).toHaveBeenCalledTimes(1) // book-x ушёл из набора
     expect(insertChain.values).toHaveBeenCalledWith([
-      { userId: 'user-1', bookId: 'book-a' },
-      { userId: 'user-1', bookId: 'book-b' },
+      { userId: 'user-1', bookId: 'book-b' }, // только реально новая книга
     ])
-    expect(result).toEqual({ isNew: false, addedBooks: ['Книга A', 'Книга B'], addedBookIds: ['book-a', 'book-b'] })
+    expect(result).toEqual({
+      isNew: false,
+      addedBooks: ['Книга A', 'Книга B'],
+      addedBookIds: ['book-a', 'book-b'],
+      newlyAddedBookIds: ['book-b'],
+      removedBookIds: ['book-x'],
+    })
   })
 
-  it('upsertSignupByBookIds с пустым списком только очищает записи пользователя', async () => {
+  it('upsertSignupByBookIds с пустым списком удаляет все записи пользователя', async () => {
+    // resolveBooksByIds([]) уходит в early-return без select, поэтому первый
+    // и единственный select — это выборка существующих записей в транзакции.
+    ;(db.select as jest.Mock).mockReturnValueOnce(selectChain([
+      { bookId: 'book-a' },
+      { bookId: 'book-b' },
+    ]))
     ;(db.delete as jest.Mock).mockReturnValue({
       where: jest.fn().mockResolvedValue(undefined),
     })
@@ -126,6 +144,8 @@ describe('signup-books', () => {
     expect(db.insert).not.toHaveBeenCalled()
     expect(result.addedBooks).toEqual([])
     expect(result.addedBookIds).toEqual([])
+    expect(result.newlyAddedBookIds).toEqual([])
+    expect(result.removedBookIds).toEqual(['book-a', 'book-b'])
   })
 
   it('upsertSignupByBookIds бросает BOOK_ID_NOT_FOUND если книги нет в каталоге', async () => {

--- a/lib/signup-books.ts
+++ b/lib/signup-books.ts
@@ -26,8 +26,10 @@ export interface UserSignup {
 
 export interface UpsertResult {
   isNew: boolean
-  addedBooks: string[]    // titles
-  addedBookIds: string[]
+  addedBooks: string[]    // titles — full resulting selection
+  addedBookIds: string[]  // full resulting selection (NOT a delta)
+  newlyAddedBookIds: string[] // delta: books added in this call
+  removedBookIds: string[]    // delta: books removed in this call
 }
 
 interface SignupBookInput {
@@ -118,6 +120,9 @@ async function upsertResolvedSignup(userId: string, selectedBooks: SignupBookInp
   const normalized = Array.from(unique.values())
   const newBookIds = normalized.map(b => b.id)
 
+  let newlyAddedBookIds: string[] = []
+  let removedBookIds: string[] = []
+
   await db.transaction(async (tx) => {
     // Fetch current signups to determine what changed
     const existing = await tx
@@ -128,6 +133,8 @@ async function upsertResolvedSignup(userId: string, selectedBooks: SignupBookInp
     const existingIds = new Set(existing.map(e => e.bookId))
     const toDelete = Array.from(existingIds).filter(id => !newBookIds.includes(id))
     const toAdd = newBookIds.filter(id => !existingIds.has(id))
+    newlyAddedBookIds = toAdd
+    removedBookIds = toDelete
 
     // Delete only removed books (preserves personal_status on remaining rows)
     if (toDelete.length > 0) {
@@ -145,7 +152,13 @@ async function upsertResolvedSignup(userId: string, selectedBooks: SignupBookInp
     }
   })
 
-  return { isNew: false, addedBooks: normalized.map(book => book.title), addedBookIds: normalized.map(book => book.id) }
+  return {
+    isNew: false,
+    addedBooks: normalized.map(book => book.title),
+    addedBookIds: normalized.map(book => book.id),
+    newlyAddedBookIds,
+    removedBookIds,
+  }
 }
 
 export async function upsertSignupByBookIds(userId: string, bookIds: string[]): Promise<UpsertResult> {


### PR DESCRIPTION
«Изменён набор» (бывш. «Список») теперь показывает дельту: какие книги
добавлены (+) и убраны (−), а не просто их количество. «Приоритеты»
показывают упорядоченный список книг по рангу.

- upsertSignupByBookIds возвращает реальную дельту (newlyAddedBookIds/
  removedBookIds), а не весь набор
- finalizeMatchingMutationEffects централизованно дописывает названия книг
  в metadata по bookTitleById (addedBookTitles/removedBookTitles/rankedBookTitles)
- роуты signup/priorities передают id-дельту вместо полного набора
- чистые display-хелперы вынесены в lib/matching/preference-event-display.ts
  и покрыты unit-тестом; fallback на «N книг» для исторических событий

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
