### PR TITLE
feat(matching): имя(псевдоним) в аналитике + событие «Покинул:а сессию»

### DIFF
--- a/app/api/admin/matching/preference-events/route.test.ts
+++ b/app/api/admin/matching/preference-events/route.test.ts
@@ -19,6 +19,7 @@ function makeReq(query = '') {
 function mockSelect(events: unknown[]) {
   const chain = {
     from: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
     $dynamic: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
@@ -49,6 +50,10 @@ describe('GET /api/admin/matching/preference-events', () => {
         sessionId: 'session-1',
         userId: 'user-1',
         actorUserId: 'admin-1',
+        userName: 'Иван',
+        actorName: 'Админ',
+        userPseudonym: 'Белка',
+        actorPseudonym: null,
         eventType: 'priority_reordered',
         source: 'matching_feed',
         bookId: 'book-1',
@@ -65,6 +70,12 @@ describe('GET /api/admin/matching/preference-events', () => {
     expect(res.status).toBe(200)
     expect(data.events).toHaveLength(1)
     expect(data.events[0].id).toBe('event-1')
+    expect(data.events[0]).toMatchObject({
+      userName: 'Иван',
+      actorName: 'Админ',
+      userPseudonym: 'Белка',
+      actorPseudonym: null,
+    })
   })
 
   it('applies supported filters and caps limit', async () => {

--- a/app/api/admin/matching/preference-events/route.ts
+++ b/app/api/admin/matching/preference-events/route.ts
@@ -2,9 +2,10 @@ export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server'
 import { and, desc, eq, type SQL } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { matchingPreferenceEvents } from '@/lib/db/schema'
+import { matchingPreferenceEvents, matchingSessionParticipants, users } from '@/lib/db/schema'
 
 const DEFAULT_LIMIT = 100
 const MAX_LIMIT = 500
@@ -39,12 +40,25 @@ export async function GET(req: NextRequest) {
   if (source) conditions.push(eq(matchingPreferenceEvents.source, source))
   if (bookId) conditions.push(eq(matchingPreferenceEvents.bookId, bookId))
 
+  // Aliases so we can resolve display names for both the affected user and the
+  // actor. Names come from `users` (persist even after a participant leaves);
+  // pseudonyms come from `matching_session_participants` (null once they leave —
+  // for that case the pseudonym is stored in the event metadata at write time).
+  const eventUser = alias(users, 'event_user')
+  const eventActor = alias(users, 'event_actor')
+  const eventUserParticipant = alias(matchingSessionParticipants, 'event_user_participant')
+  const eventActorParticipant = alias(matchingSessionParticipants, 'event_actor_participant')
+
   let query = db
     .select({
       id: matchingPreferenceEvents.id,
       sessionId: matchingPreferenceEvents.sessionId,
       userId: matchingPreferenceEvents.userId,
       actorUserId: matchingPreferenceEvents.actorUserId,
+      userName: eventUser.name,
+      actorName: eventActor.name,
+      userPseudonym: eventUserParticipant.pseudonym,
+      actorPseudonym: eventActorParticipant.pseudonym,
       eventType: matchingPreferenceEvents.eventType,
       source: matchingPreferenceEvents.source,
       bookId: matchingPreferenceEvents.bookId,
@@ -54,6 +68,22 @@ export async function GET(req: NextRequest) {
       occurredAt: matchingPreferenceEvents.occurredAt,
     })
     .from(matchingPreferenceEvents)
+    .leftJoin(eventUser, eq(eventUser.id, matchingPreferenceEvents.userId))
+    .leftJoin(eventActor, eq(eventActor.id, matchingPreferenceEvents.actorUserId))
+    .leftJoin(
+      eventUserParticipant,
+      and(
+        eq(eventUserParticipant.sessionId, matchingPreferenceEvents.sessionId),
+        eq(eventUserParticipant.userId, matchingPreferenceEvents.userId),
+      ),
+    )
+    .leftJoin(
+      eventActorParticipant,
+      and(
+        eq(eventActorParticipant.sessionId, matchingPreferenceEvents.sessionId),
+        eq(eventActorParticipant.userId, matchingPreferenceEvents.actorUserId),
+      ),
+    )
     .$dynamic()
 
   if (conditions.length > 0) {

--- a/app/api/admin/matching/sessions/[id]/participants/[userId]/route.test.ts
+++ b/app/api/admin/matching/sessions/[id]/participants/[userId]/route.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import { DELETE } from './route'
+import * as authModule from '@/lib/auth'
+import { db } from '@/lib/db'
+import { recordParticipantLeftEvent } from '@/lib/matching/preference-events'
+import { broadcast } from '@/lib/matching/realtime/hub'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), delete: jest.fn() } }))
+jest.mock('@/lib/matching/preference-events', () => ({ recordParticipantLeftEvent: jest.fn() }))
+jest.mock('@/lib/matching/realtime/hub', () => ({ broadcast: jest.fn() }))
+
+const mockAuth = authModule.auth as jest.Mock
+const mockDb = db as jest.Mocked<typeof db>
+const mockRecordLeft = recordParticipantLeftEvent as jest.Mock
+const mockBroadcast = broadcast as jest.Mock
+
+const params = { params: { id: 'session-1', userId: 'user-1' } }
+
+function makeReq() {
+  return new NextRequest('http://localhost/api/admin/matching/sessions/session-1/participants/user-1', {
+    method: 'DELETE',
+  })
+}
+
+function mockSessionLookup(status: string | null) {
+  mockDb.select = jest.fn().mockReturnValue({
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue(status ? [{ id: 'session-1', status }] : []),
+  })
+}
+
+describe('DELETE /api/admin/matching/sessions/[id]/participants/[userId]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRecordLeft.mockResolvedValue(undefined)
+    mockDb.delete = jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue(undefined) })
+  })
+
+  it('403 без админ-сессии', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'u', isAdmin: false } })
+    const res = await DELETE(makeReq(), params)
+    expect(res.status).toBe(403)
+    expect(mockRecordLeft).not.toHaveBeenCalled()
+  })
+
+  it('пишет participant_left с source=admin и актором-админом ДО удаления', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'admin-1', isAdmin: true } })
+    mockSessionLookup('active')
+
+    const res = await DELETE(makeReq(), params)
+
+    expect(res.status).toBe(200)
+    expect(mockRecordLeft).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      userId: 'user-1',
+      actorUserId: 'admin-1',
+      source: 'admin',
+    })
+    const recordOrder = mockRecordLeft.mock.invocationCallOrder[0]
+    const deleteOrder = (mockDb.delete as jest.Mock).mock.invocationCallOrder[0]
+    expect(recordOrder).toBeLessThan(deleteOrder)
+    expect(mockBroadcast).toHaveBeenCalledWith('session-1', 'state_changed', {
+      userId: 'user-1',
+      kind: 'participant_left',
+    })
+  })
+
+  it('409 для неактивной сессии', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'admin-1', isAdmin: true } })
+    mockSessionLookup('frozen')
+
+    const res = await DELETE(makeReq(), params)
+
+    expect(res.status).toBe(409)
+    expect(mockRecordLeft).not.toHaveBeenCalled()
+    expect(mockDb.delete).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/admin/matching/sessions/[id]/participants/[userId]/route.ts
+++ b/app/api/admin/matching/sessions/[id]/participants/[userId]/route.ts
@@ -6,14 +6,16 @@ import { db } from '@/lib/db'
 import { matchingSessions, matchingSessionParticipants } from '@/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { broadcast } from '@/lib/matching/realtime/hub'
+import { recordParticipantLeftEvent } from '@/lib/matching/preference-events'
 
 interface Params { params: { id: string; userId: string } }
 
 export async function DELETE(_req: NextRequest, { params }: Params) {
   const session = await auth()
-  if (!session?.user?.isAdmin) {
+  if (!session?.user?.isAdmin || !session.user.id) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
+  const adminId = session.user.id
   const { id: sessionId, userId } = params
 
   const [matchingSession] = await db
@@ -28,6 +30,15 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   if (matchingSession.status !== 'active') {
     return NextResponse.json({ error: 'Session is not active' }, { status: 409 })
   }
+
+  // Record the analytics event BEFORE deleting the participant row (pseudonym
+  // snapshot + membership guard need the row to still exist). Actor = admin.
+  await recordParticipantLeftEvent({
+    sessionId,
+    userId,
+    actorUserId: adminId,
+    source: 'admin',
+  }).catch(() => {}) // analytics must never block the removal
 
   await db
     .delete(matchingSessionParticipants)

--- a/app/api/matching/sessions/[id]/leave/route.test.ts
+++ b/app/api/matching/sessions/[id]/leave/route.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import { DELETE } from './route'
+import * as authModule from '@/lib/auth'
+import { db } from '@/lib/db'
+import { recordParticipantLeftEvent } from '@/lib/matching/preference-events'
+import { broadcast } from '@/lib/matching/realtime/hub'
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), delete: jest.fn() } }))
+jest.mock('@/lib/matching/preference-events', () => ({ recordParticipantLeftEvent: jest.fn() }))
+jest.mock('@/lib/matching/realtime/hub', () => ({ broadcast: jest.fn() }))
+
+const mockAuth = authModule.auth as jest.Mock
+const mockDb = db as jest.Mocked<typeof db>
+const mockRecordLeft = recordParticipantLeftEvent as jest.Mock
+const mockBroadcast = broadcast as jest.Mock
+
+function makeReq() {
+  return new NextRequest('http://localhost/api/matching/sessions/session-1/leave', { method: 'DELETE' })
+}
+
+function mockSessionLookup(status: string | null) {
+  mockDb.select = jest.fn().mockReturnValue({
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue(status ? [{ id: 'session-1', status }] : []),
+  })
+}
+
+describe('DELETE /api/matching/sessions/[id]/leave', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRecordLeft.mockResolvedValue(undefined)
+    mockDb.delete = jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue(undefined) })
+  })
+
+  it('401 без авторизации', async () => {
+    mockAuth.mockResolvedValue(null)
+    const res = await DELETE(makeReq(), { params: { id: 'session-1' } })
+    expect(res.status).toBe(401)
+    expect(mockRecordLeft).not.toHaveBeenCalled()
+  })
+
+  it('пишет participant_left ДО удаления и шлёт broadcast', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
+    mockSessionLookup('active')
+
+    const res = await DELETE(makeReq(), { params: { id: 'session-1' } })
+
+    expect(res.status).toBe(200)
+    expect(mockRecordLeft).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      userId: 'user-1',
+      actorUserId: 'user-1',
+      source: 'matching',
+    })
+    // analytics-событие записано раньше удаления участника
+    const recordOrder = mockRecordLeft.mock.invocationCallOrder[0]
+    const deleteOrder = (mockDb.delete as jest.Mock).mock.invocationCallOrder[0]
+    expect(recordOrder).toBeLessThan(deleteOrder)
+    expect(mockBroadcast).toHaveBeenCalledWith('session-1', 'state_changed', {
+      userId: 'user-1',
+      kind: 'participant_left',
+    })
+  })
+
+  it('409 для неактивной сессии, без записи события', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' } })
+    mockSessionLookup('frozen')
+
+    const res = await DELETE(makeReq(), { params: { id: 'session-1' } })
+
+    expect(res.status).toBe(409)
+    expect(mockRecordLeft).not.toHaveBeenCalled()
+    expect(mockDb.delete).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/matching/sessions/[id]/leave/route.ts
+++ b/app/api/matching/sessions/[id]/leave/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { matchingSessions, matchingSessionParticipants } from '@/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { broadcast } from '@/lib/matching/realtime/hub'
+import { recordParticipantLeftEvent } from '@/lib/matching/preference-events'
 
 interface Params { params: { id: string } }
 
@@ -29,6 +30,15 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   if (matchingSession.status !== 'active') {
     return NextResponse.json({ error: 'Session is not active' }, { status: 409 })
   }
+
+  // Record the analytics event BEFORE deleting the participant row (pseudonym
+  // is captured there and the membership guard needs the row to still exist).
+  await recordParticipantLeftEvent({
+    sessionId,
+    userId,
+    actorUserId: userId,
+    source: 'matching',
+  }).catch(() => {}) // analytics must never block the leave action
 
   await db
     .delete(matchingSessionParticipants)

--- a/components/nd/AdminMatchingSession.tsx
+++ b/components/nd/AdminMatchingSession.tsx
@@ -5,6 +5,7 @@ import {
   type PreferenceEventMetadata,
   eventDetail,
   eventTypeLabel,
+  formatParticipant,
   sourceLabel,
 } from '@/lib/matching/preference-event-display'
 
@@ -32,6 +33,10 @@ interface PreferenceEvent {
   sessionId: string
   userId: string
   actorUserId: string
+  userName: string | null
+  actorName: string | null
+  userPseudonym: string | null
+  actorPseudonym: string | null
   eventType: string
   source: string
   bookId: string | null
@@ -512,8 +517,8 @@ export default function AdminMatchingSession() {
                       </td>
                       <td style={{ padding: '3px 8px', color: 'var(--text-body)' }}>{eventTypeLabel(event.eventType)}</td>
                       <td style={{ padding: '3px 8px', color: 'var(--text-secondary)' }}>{sourceLabel(event.source)}</td>
-                      <td style={{ padding: '3px 8px', color: 'var(--text-secondary)' }}>{displayParticipant(event.userId, participants)}</td>
-                      <td style={{ padding: '3px 8px', color: 'var(--text-secondary)' }}>{displayParticipant(event.actorUserId, participants)}</td>
+                      <td style={{ padding: '3px 8px', color: 'var(--text-secondary)' }}>{formatParticipant({ name: event.userName, pseudonym: event.userPseudonym ?? event.metadata?.pseudonym, userId: event.userId })}</td>
+                      <td style={{ padding: '3px 8px', color: 'var(--text-secondary)' }}>{formatParticipant({ name: event.actorName, pseudonym: event.actorPseudonym, userId: event.actorUserId })}</td>
                       <td style={{ padding: '3px 8px', color: 'var(--text-muted)' }}>{eventDetail(event)}</td>
                     </tr>
                   ))}
@@ -612,9 +617,4 @@ function countPreferenceEvents(events: PreferenceEvent[]): Record<string, number
     acc[event.eventType] = (acc[event.eventType] ?? 0) + 1
     return acc
   }, {})
-}
-
-function displayParticipant(userId: string, participants: Participant[]): string {
-  const participant = participants.find((item) => item.userId === userId)
-  return participant?.pseudonym ?? `${userId.slice(0, 12)}…`
 }

--- a/docs/wiki/Group-Matching-Mode.md
+++ b/docs/wiki/Group-Matching-Mode.md
@@ -66,14 +66,16 @@ PK: `(session_id, user_id)`. Unique: `(session_id, pseudonym)`.
 | `session_id` | text FK → matching_sessions | Сессия |
 | `user_id` | text FK → user | Чьи предпочтения изменились |
 | `actor_user_id` | text FK → user | Кто сделал изменение; для админки может отличаться от `user_id` |
-| `event_type` | text | `book_added`, `book_removed`, `status_changed`, `catalog_signup_updated`, `priorities_updated` |
+| `event_type` | text | `book_added`, `book_removed`, `status_changed`, `catalog_signup_updated`, `priorities_updated`, `participant_left` |
 | `source` | text | `matching`, `catalog`, `profile`, `admin` |
 | `book_id` | text FK → books? | Книга, если событие относится к одной книге |
 | `before` / `after` | jsonb? | Лидер-сценарий до/после изменения |
-| `metadata` | jsonb? | Snapshot деталей с уже разрешёнными названиями книг. Для одиночных действий — `bookTitle`. Для `catalog_signup_updated` — дельта набора: `addedBookIds`/`removedBookIds` + читаемые `addedBookTitles`/`removedBookTitles`. Для `priorities_updated` — упорядоченный `rankedBookIds` + `rankedBookTitles`. Названия дописываются в `finalizeMatchingMutationEffects` через `bookTitleById`, поэтому админка показывает «какие именно книги» без собственного резолва id→title. Статусные события несут `status`. |
+| `metadata` | jsonb? | Snapshot деталей с уже разрешёнными названиями книг. Для одиночных действий — `bookTitle`. Для `catalog_signup_updated` — дельта набора: `addedBookIds`/`removedBookIds` + читаемые `addedBookTitles`/`removedBookTitles`. Для `priorities_updated` — упорядоченный `rankedBookIds` + `rankedBookTitles`. Названия дописываются в `finalizeMatchingMutationEffects` через `bookTitleById`, поэтому админка показывает «какие именно книги» без собственного резолва id→title. Статусные события несут `status`. Событие `participant_left` несёт `pseudonym` (снимок, т.к. строка участника удаляется при выходе). |
 | `occurred_at` | timestamp | Когда произошло |
 
 Событие пишется только если пользователь уже был участником этой сессии на момент изменения (`occurred_at >= joined_at`).
+
+При выходе участника (`DELETE …/leave`) и при удалении участника админом (`DELETE …/participants/:userId`) **до** удаления строки пишется событие `participant_left` (`recordParticipantLeftEvent`): `source` = `matching` (сам ушёл) либо `admin` (удалил админ), а псевдоним сохраняется в `metadata.pseudonym`. Запись обязана идти до удаления — иначе теряется псевдоним и не проходит membership-guard.
 
 ### `admin_views`
 Аудит-лог просмотров участников администратором через `?as=` режим.
@@ -98,7 +100,7 @@ PK: `(session_id, user_id)`. Unique: `(session_id, pseudonym)`.
 | POST | `/api/matching/sessions/:id/freeze` | Заморозить сессию (только admin) |
 | POST | `/api/matching/sessions/:id/heartbeat` | Обновить presence (участники; для admin — no-op) |
 | GET | `/api/matching/sessions/:id/audit-log` | Журнал admin_views для сессии (только admin) |
-| GET | `/api/admin/matching/preference-events` | Аналитика изменений предпочтений; фильтры `sessionId`, `userId`, `actorUserId`, `eventType`, `source`, `bookId`, `limit` |
+| GET | `/api/admin/matching/preference-events` | Аналитика изменений предпочтений; фильтры `sessionId`, `userId`, `actorUserId`, `eventType`, `source`, `bookId`, `limit`. Каждое событие обогащено именами: `userName`/`actorName` (из `users`, есть даже у вышедших) и `userPseudonym`/`actorPseudonym` (из участников, `null` после выхода — тогда псевдоним берётся из `metadata.pseudonym`). Админка рисует «Имя (Псевдоним)». |
 | GET | `/api/admin/matching/sessions/:id/participants` | Список участников с именами (только admin) |
 | POST | `/api/admin/matching/sessions/:id/participants` | Добавить участника из базы пользователей (только admin, только active) |
 | DELETE | `/api/admin/matching/sessions/:id/participants/:userId` | Убрать участника из сессии (только admin, только active) |

--- a/lib/matching/__tests__/preference-event-display.test.ts
+++ b/lib/matching/__tests__/preference-event-display.test.ts
@@ -1,6 +1,7 @@
 import {
   eventDetail,
   eventTypeLabel,
+  formatParticipant,
   sourceLabel,
   type PreferenceEventLike,
 } from '../preference-event-display'
@@ -9,7 +10,8 @@ const event = (
   eventType: string,
   metadata: PreferenceEventLike['metadata'],
   bookId: string | null = null,
-): PreferenceEventLike => ({ eventType, bookId, metadata })
+  source?: string,
+): PreferenceEventLike => ({ eventType, bookId, metadata, source })
 
 describe('eventTypeLabel', () => {
   it('переименовывает catalog_signup_updated в «Изменён набор»', () => {
@@ -22,8 +24,34 @@ describe('eventTypeLabel', () => {
     expect(eventTypeLabel('priorities_updated')).toBe('Приоритеты')
   })
 
+  it('переводит participant_left', () => {
+    expect(eventTypeLabel('participant_left')).toBe('Покинул:а сессию')
+  })
+
   it('возвращает исходный код для неизвестного типа', () => {
     expect(eventTypeLabel('mystery')).toBe('mystery')
+  })
+})
+
+describe('formatParticipant', () => {
+  it('имя и псевдоним → «Имя (Псевдоним)»', () => {
+    expect(formatParticipant({ name: 'Иван', pseudonym: 'Белка', userId: 'u1' })).toBe('Иван (Белка)')
+  })
+
+  it('только имя', () => {
+    expect(formatParticipant({ name: 'Иван', pseudonym: null, userId: 'u1' })).toBe('Иван')
+  })
+
+  it('только псевдоним', () => {
+    expect(formatParticipant({ name: null, pseudonym: 'Белка', userId: 'u1' })).toBe('Белка')
+  })
+
+  it('ничего нет → короткий id', () => {
+    expect(formatParticipant({ name: null, pseudonym: null, userId: '24a75fbc-a1f9-1234' })).toBe('24a75fbc-a1f…')
+  })
+
+  it('пустые строки трактуются как отсутствие', () => {
+    expect(formatParticipant({ name: '  ', pseudonym: 'Белка', userId: 'u1' })).toBe('Белка')
   })
 })
 
@@ -69,6 +97,14 @@ describe('eventDetail', () => {
     expect(
       eventDetail(event('catalog_signup_updated', { addedBookTitles: [], removedBookTitles: [] }, 'b9')),
     ).toBe('b9')
+  })
+
+  it('participant_left: самостоятельный выход — тире', () => {
+    expect(eventDetail(event('participant_left', { pseudonym: 'Белка' }, null, 'matching'))).toBe('—')
+  })
+
+  it('participant_left: удаление админом помечается', () => {
+    expect(eventDetail(event('participant_left', { pseudonym: 'Белка' }, null, 'admin'))).toBe('удалён:а админом')
   })
 
   it('без метаданных показывает bookId или тире', () => {

--- a/lib/matching/__tests__/preference-events.test.ts
+++ b/lib/matching/__tests__/preference-events.test.ts
@@ -1,11 +1,11 @@
 /**
  * @jest-environment node
  */
-import { recordMatchingPreferenceEvent } from '../preference-events'
+import { recordMatchingPreferenceEvent, recordParticipantLeftEvent } from '../preference-events'
 
 jest.mock('@/lib/db', () => ({ db: {} }))
 
-function makeDb(participants: Array<{ joinedAt: Date }>) {
+function makeDb(participants: Array<{ joinedAt?: Date; pseudonym?: string }>) {
   const participantChain = {
     from: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
@@ -94,5 +94,42 @@ describe('recordMatchingPreferenceEvent', () => {
       after: null,
       metadata: null,
     }))
+  })
+})
+
+describe('recordParticipantLeftEvent', () => {
+  it('пишет событие participant_left со снимком псевдонима', async () => {
+    const { db, insertChain } = makeDb([
+      { pseudonym: 'Белка', joinedAt: new Date('2020-01-01T00:00:00Z') },
+    ])
+
+    await recordParticipantLeftEvent({
+      sessionId: 'session-1',
+      userId: 'user-1',
+      actorUserId: 'admin-1',
+      source: 'admin',
+    }, db as never)
+
+    expect(insertChain.values).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      userId: 'user-1',
+      actorUserId: 'admin-1',
+      eventType: 'participant_left',
+      source: 'admin',
+      metadata: { pseudonym: 'Белка' },
+    }))
+  })
+
+  it('не пишет событие, если участник уже не в сессии', async () => {
+    const { db } = makeDb([])
+
+    await recordParticipantLeftEvent({
+      sessionId: 'session-1',
+      userId: 'user-1',
+      actorUserId: 'user-1',
+      source: 'matching',
+    }, db as never)
+
+    expect(db.insert).not.toHaveBeenCalled()
   })
 })

--- a/lib/matching/preference-event-display.ts
+++ b/lib/matching/preference-event-display.ts
@@ -11,6 +11,8 @@ export interface PreferenceEventMetadata {
   // Priorities — ordered by rank (resolved titles).
   rankedBookTitles?: string[]
   status?: string | null
+  // participant_left — pseudonym snapshot (the participant row is deleted on leave).
+  pseudonym?: string | null
   // Legacy/historical events stored only id arrays — kept for graceful fallback.
   selectedBookIds?: string[]
   bookIds?: string[]
@@ -18,8 +20,26 @@ export interface PreferenceEventMetadata {
 
 export interface PreferenceEventLike {
   eventType: string
+  source?: string
   bookId: string | null
   metadata: PreferenceEventMetadata | null
+}
+
+export interface ParticipantIdentity {
+  name?: string | null
+  pseudonym?: string | null
+  userId: string
+}
+
+// Renders a participant as «Имя (Псевдоним)» with graceful fallbacks:
+// name + pseudonym → «Имя (Псевдоним)»; only one → that one; neither → short id.
+export function formatParticipant({ name, pseudonym, userId }: ParticipantIdentity): string {
+  const trimmedName = name?.trim() || null
+  const trimmedPseudonym = pseudonym?.trim() || null
+  if (trimmedName && trimmedPseudonym) return `${trimmedName} (${trimmedPseudonym})`
+  if (trimmedName) return trimmedName
+  if (trimmedPseudonym) return trimmedPseudonym
+  return `${userId.slice(0, 12)}…`
 }
 
 export function eventTypeLabel(eventType: string): string {
@@ -29,6 +49,7 @@ export function eventTypeLabel(eventType: string): string {
   if (eventType === 'status_changed') return 'Статус'
   if (eventType === 'catalog_signup_updated') return 'Изменён набор'
   if (eventType === 'priorities_updated') return 'Приоритеты'
+  if (eventType === 'participant_left') return 'Покинул:а сессию'
   return eventType
 }
 
@@ -41,6 +62,11 @@ export function sourceLabel(source: string): string {
 }
 
 export function eventDetail(event: PreferenceEventLike): string {
+  // Lifecycle event without a book: clarify admin removals.
+  if (event.eventType === 'participant_left') {
+    return event.source === 'admin' ? 'удалён:а админом' : '—'
+  }
+
   const m = event.metadata
   if (m) {
     // Single-book add/remove/status.

--- a/lib/matching/preference-events.ts
+++ b/lib/matching/preference-events.ts
@@ -64,3 +64,45 @@ export async function recordMatchingPreferenceEvent(
 
   return { recorded: true, eventId: created.id }
 }
+
+export interface RecordParticipantLeftEventInput {
+  sessionId: string
+  userId: string
+  actorUserId: string
+  source: 'matching' | 'admin'
+}
+
+/**
+ * Persists a `participant_left` analytics event. MUST be called BEFORE the
+ * participant row is deleted — it snapshots the pseudonym (lost on delete) and
+ * relies on the row still existing to pass the membership guard.
+ */
+export async function recordParticipantLeftEvent(
+  input: RecordParticipantLeftEventInput,
+  dbClient: DbClient = db,
+): Promise<void> {
+  const [participant] = await dbClient
+    .select({ pseudonym: matchingSessionParticipants.pseudonym })
+    .from(matchingSessionParticipants)
+    .where(
+      and(
+        eq(matchingSessionParticipants.sessionId, input.sessionId),
+        eq(matchingSessionParticipants.userId, input.userId),
+      ),
+    )
+    .limit(1)
+
+  if (!participant) return
+
+  await recordMatchingPreferenceEvent(
+    {
+      sessionId: input.sessionId,
+      userId: input.userId,
+      actorUserId: input.actorUserId,
+      eventType: 'participant_left',
+      source: input.source,
+      metadata: { pseudonym: participant.pseudonym },
+    },
+    dbClient,
+  )
+}


### PR DESCRIPTION
В колонках «Участник»/«Актор» вместо сырого id теперь «Имя (Псевдоним)»:
preference-events API обогащает каждое событие именами из users (есть даже
у вышедших участников) и псевдонимами из участников (fallback на
metadata.pseudonym). Graceful fallback: имя → псевдоним → короткий id.

Новое событие participant_left пишется при выходе участника (self-leave)
и при удалении админом — ДО удаления строки участника (снимок псевдонима +
membership-guard). source=matching/admin; деталь «удалён:а админом» для
admin-removal. feed игнорирует событие (нет bookId, не mutation-kind).

- recordParticipantLeftEvent — общий хелпер в preference-events.ts
- formatParticipant + лейбл participant_left в preference-event-display.ts
- покрыто unit-тестами: API-обогащение, хелпер, оба роута (порядок
  запись-до-удаления), display-форматирование

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
