### PR TITLE
test(e2e): убрать networkidle на каталоге админки после reload

### DIFF
--- a/e2e/admin-book-status.spec.ts
+++ b/e2e/admin-book-status.spec.ts
@@ -55,7 +55,10 @@ test.describe('AdminPanel — изменение статуса книги', () 
 
     // Переключаемся на вкладку "Каталог"
     await page.getByTestId('admin-tab-catalog').click()
-    await page.waitForLoadState('networkidle')
+    // НЕ networkidle: каталог рендерит обложки через next/image; недоступный
+    // внешний хост (imwerden.de) держит запрос /_next/image открытым и idle
+    // никогда не наступает. Дальнейшие expect(...).toBeVisible() сами ждут гидрацию.
+    await page.waitForLoadState('domcontentloaded')
 
     // Находим строку нашей книги
     const bookRow = page.getByTestId(`admin-book-row-${book.id}`)
@@ -69,9 +72,11 @@ test.describe('AdminPanel — изменение статуса книги', () 
 
     await expect(bookRow).toContainText('Reading')
 
-    // Ключевая проверка: перезагрузка → статус должен сохраниться
+    // Ключевая проверка: перезагрузка → статус должен сохраниться.
+    // После reload восстанавливается ?tab=catalog, поэтому ждём только
+    // domcontentloaded (см. коммент выше про обложки и networkidle).
     await page.reload()
-    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('domcontentloaded')
     await page.getByTestId('admin-tab-catalog').click()
 
     const bookRowAfterReload = page.getByTestId(`admin-book-row-${book.id}`)

--- a/e2e/admin-books-catalog.spec.ts
+++ b/e2e/admin-books-catalog.spec.ts
@@ -88,9 +88,12 @@ test.describe('AdminPanel — вкладка «Каталог»', () => {
     const publishedSection = page.getByTestId('admin-catalog-section-published')
     await expect(publishedSection.getByTestId(`admin-book-row-${createdBookId}`)).toBeVisible({ timeout: 5000 })
 
-    // Reload — должна остаться опубликованной
+    // Reload — должна остаться опубликованной.
+    // НЕ networkidle: после reload восстанавливается ?tab=catalog, каталог
+    // рендерит обложки через next/image; недоступный внешний хост (imwerden.de)
+    // держит /_next/image открытым → idle не наступает. expect ниже ждёт гидрацию.
     await page.reload()
-    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('domcontentloaded')
     await page.getByTestId('admin-tab-catalog').click()
     await expect(
       page.getByTestId('admin-catalog-section-published').getByTestId(`admin-book-row-${createdBookId}`)
@@ -116,9 +119,9 @@ test.describe('AdminPanel — вкладка «Каталог»', () => {
       page.getByTestId('admin-catalog-section-hidden').getByTestId(`admin-book-row-${createdBookId}`)
     ).toBeVisible({ timeout: 5000 })
 
-    // Reload — скрыта осталась
+    // Reload — скрыта осталась (см. коммент выше: domcontentloaded, не networkidle)
     await page.reload()
-    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('domcontentloaded')
     await page.getByTestId('admin-tab-catalog').click()
     await expect(
       page.getByTestId('admin-catalog-section-hidden').getByTestId(`admin-book-row-${createdBookId}`)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,6 +57,11 @@ if (!Object.keys(TEST_ENV).length && !process.env.CI) {
   )
 }
 
+// Порт сервера под тесты. По умолчанию 3000; можно переопределить через
+// PLAYWRIGHT_PORT, если 3000 занят другим локальным процессом.
+const PORT = process.env.PLAYWRIGHT_PORT || '3000'
+const BASE_URL = `http://127.0.0.1:${PORT}`
+
 export default defineConfig({
   testDir: './e2e',
   globalSetup: require.resolve('./e2e/global-setup'),
@@ -81,7 +86,7 @@ export default defineConfig({
     ? [['list'], ['allure-playwright', { outputFolder: 'allure-results', suiteTitle: false }]]
     : 'list',
   use: {
-    baseURL: 'http://127.0.0.1:3000',
+    baseURL: BASE_URL,
     trace: 'on-first-retry',
   },
   projects: [
@@ -98,8 +103,8 @@ export default defineConfig({
     // билд сразу. Сборка делается отдельным шагом в CI (.github/workflows/
     // ci.yml, job e2e) перед запуском Playwright.
     // Локально оставляем dev для быстрого hot-reload цикла.
-    command: process.env.CI ? 'npm run start' : 'npm run dev',
-    url: 'http://127.0.0.1:3000',
+    command: process.env.CI ? `npm run start -- -p ${PORT}` : `npm run dev -- -p ${PORT}`,
+    url: BASE_URL,
     // На CI всегда поднимаем свежий сервер; локально переиспользуем
     // уже запущенный dev, если он есть.
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
Ночной E2E падал по таймауту 120с на page.waitForLoadState('networkidle')
после page.reload() в admin-book-status и admin-books-catalog.

Причина: активная вкладка персистится в URL (?tab=catalog), поэтому после
reload каталог сразу рендерит обложки через next/image. Часть книг имеет
внешние обложки (imwerden.de); когда хост недоступен в CI, серверный
image-оптимизатор держит запрос /_next/image открытым → networkidle
никогда не наступает. Это хрупкость теста, не баг продукта (onError-
fallback в CoverImage в браузере работает).

Замена на domcontentloaded; гидрацию дожидаются последующие
expect(...).toBeVisible()/.click() через auto-wait Playwright.

Заодно: PLAYWRIGHT_PORT для переопределения порта локального сервера,
когда 3000 занят.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
