### PR TITLE
fix(matching): трекать изменение приоритетов на странице /matching

### DIFF
--- a/app/api/matching/priorities/route.test.ts
+++ b/app/api/matching/priorities/route.test.ts
@@ -4,6 +4,7 @@
 import { PATCH } from './route'
 import * as authModule from '@/lib/auth'
 import { db } from '@/lib/db'
+import { finalizeMatchingMutationEffects } from '@/lib/matching/mutation-effects'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
 jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn() } }))
@@ -11,9 +12,15 @@ jest.mock('@/lib/db/schema', () => ({
   matchingSessions: {},
   bookPriorities: {},
 }))
+jest.mock('@/lib/matching/realtime/hub', () => ({ broadcast: jest.fn() }))
+jest.mock('@/lib/matching/mutation-effects', () => ({
+  captureMatchingMutationSnapshot: jest.fn().mockResolvedValue(null),
+  finalizeMatchingMutationEffects: jest.fn(),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockDb = db as jest.Mocked<typeof db>
+const mockFinalizeEffects = finalizeMatchingMutationEffects as jest.Mock
 
 function makeReq(body: object, asUserId?: string) {
   const suffix = asUserId ? `?as=${asUserId}` : ''
@@ -83,6 +90,50 @@ describe('PATCH /api/matching/priorities', () => {
     const json = await res.json()
     expect(json.ranks).toHaveLength(2)
     expect(mockDb.insert).toHaveBeenCalledTimes(2)
+  })
+
+  it('пишет событие priorities_updated с упорядоченным списком (source=matching)', async () => {
+    mockAuth.mockResolvedValue(userSession)
+    const sessionChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active' }]) }
+    const canonicalChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([{ bookId: 'b2', rank: 1 }, { bookId: 'b1', rank: 2 }]) }
+    mockDb.select = jest.fn()
+      .mockReturnValueOnce(sessionChain)
+      .mockReturnValueOnce(canonicalChain)
+    mockDb.insert = jest.fn().mockReturnValue({ values: jest.fn().mockReturnThis(), onConflictDoUpdate: jest.fn().mockResolvedValue([]) })
+
+    await PATCH(makeReq({ bookIds: ['b2', 'b1'] }))
+
+    expect(mockFinalizeEffects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 's1',
+        targetUserId: 'user1',
+        actorUserId: 'user1',
+        kind: 'priorities_updated',
+        source: 'matching',
+        metadata: { rankedBookIds: ['b2', 'b1'] },
+      }),
+    )
+  })
+
+  it('для impersonation: target — участник, actor — админ', async () => {
+    mockAuth.mockResolvedValue(adminSession)
+    const sessionChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), limit: jest.fn().mockResolvedValue([{ id: 's1', status: 'active' }]) }
+    const canonicalChain = { from: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([{ bookId: 'b2', rank: 1 }]) }
+    mockDb.select = jest.fn()
+      .mockReturnValueOnce(sessionChain)
+      .mockReturnValueOnce(canonicalChain)
+    mockDb.insert = jest.fn().mockReturnValue({ values: jest.fn().mockReturnThis(), onConflictDoUpdate: jest.fn().mockResolvedValue([]) })
+
+    await PATCH(makeReq({ bookIds: ['b2'] }, 'participant1'))
+
+    expect(mockFinalizeEffects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetUserId: 'participant1',
+        actorUserId: 'admin1',
+        kind: 'priorities_updated',
+        source: 'matching',
+      }),
+    )
   })
 
   it('lets admin reorder books for an impersonated participant', async () => {

--- a/app/api/matching/priorities/route.ts
+++ b/app/api/matching/priorities/route.ts
@@ -6,6 +6,10 @@ import { db } from '@/lib/db'
 import { matchingSessions, bookPriorities } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { broadcast } from '@/lib/matching/realtime/hub'
+import {
+  captureMatchingMutationSnapshot,
+  finalizeMatchingMutationEffects,
+} from '@/lib/matching/mutation-effects'
 
 export async function PATCH(req: NextRequest) {
   const session = await auth()
@@ -31,6 +35,9 @@ export async function PATCH(req: NextRequest) {
   const userId = asUserId ?? session.user.id
   const ordered = bookIds as string[]
 
+  // Snapshot the leader scenario before the change so analytics can show impact.
+  const before = await captureMatchingMutationSnapshot(activeSession.id)
+
   // Upsert each book with its new rank (1-indexed position)
   for (let i = 0; i < ordered.length; i++) {
     await db
@@ -49,6 +56,18 @@ export async function PATCH(req: NextRequest) {
     .where(eq(bookPriorities.userId, userId))
 
   broadcast(activeSession.id, 'state_changed', { kind: 'ranks_updated' })
+
+  // Persist analytics: reordering priorities from the /matching page.
+  await finalizeMatchingMutationEffects({
+    sessionId: activeSession.id,
+    targetUserId: userId,
+    actorUserId: session.user.id,
+    bookId: null,
+    kind: 'priorities_updated',
+    source: 'matching',
+    before,
+    metadata: { rankedBookIds: ordered },
+  })
 
   return NextResponse.json({ ranks: canonical }, { status: 200 })
 }

--- a/docs/wiki/Group-Matching-Mode.md
+++ b/docs/wiki/Group-Matching-Mode.md
@@ -97,7 +97,7 @@ PK: `(session_id, user_id)`. Unique: `(session_id, pseudonym)`.
 | GET | `/api/matching/state?session=<id>&as=<userId>` | Текущее состояние (personalBooks, myMoves, legacy `scenarios`/`scenarioOverview`, новый `scenarioSetOverview`) |
 | POST | `/api/matching/books` | Добавить книгу в личный список и поставить её на первое место в персональном ранкинге |
 | DELETE | `/api/matching/books/:bookId` | Удалить книгу из личного списка |
-| PATCH | `/api/matching/priorities` | Обновить порядок книг |
+| PATCH | `/api/matching/priorities` | Обновить порядок книг (drag-and-drop в «Моих книгах»). Пишет событие аналитики `priorities_updated` (`source: matching`) с упорядоченным `rankedBookIds`. |
 | PATCH | `/api/signup-books/:bookId/status` | Обновить personal_status книги (`reading` / `read` / `null`) |
 
 Для admin impersonation мутационные endpoints личного списка (`/api/matching/books`, `/api/matching/books/:bookId`, `/api/matching/priorities`, `/api/signup-books/:bookId/status`) поддерживают query `?as=<userId>`. Параметр работает только для админов; обычным пользователям возвращается `403`.


### PR DESCRIPTION
Перетаскивание книг в секции «Мои книги» идёт через PATCH
/api/matching/priorities, который только broadcast'ил ranks_updated и НЕ
писал событие аналитики. Теперь он, как и /api/priorities (профиль),
вызывает finalizeMatchingMutationEffects с kind=priorities_updated,
source=matching и metadata.rankedBookIds (порядок по рангу).

При impersonation target — участник (?as=), actor — админ.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
