### PR TITLE
fix: sync matching priorities flag

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -43,6 +43,7 @@ export default async function AdminPage() {
   for (const row of allPriorityRows) {
     if (!bookPrioritiesMap[row.userId]) bookPrioritiesMap[row.userId] = []
     bookPrioritiesMap[row.userId].push({ bookId: row.bookId, bookName: row.bookName, rank: row.rank })
+    prioritiesSetMap[row.userId] = true
   }
   for (const pgId of Object.keys(bookPrioritiesMap)) {
     bookPrioritiesMap[pgId].sort((a, b) => a.rank - b.rank)

--- a/app/api/matching/books/route.test.ts
+++ b/app/api/matching/books/route.test.ts
@@ -8,7 +8,7 @@ import * as mutationEffects from '@/lib/matching/mutation-effects'
 import { bookPriorities, signupBooks } from '@/lib/db/schema'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
-jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn() } }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn(), update: jest.fn() } }))
 jest.mock('@/lib/matching/mutation-effects', () => ({
   captureMatchingMutationSnapshot: jest.fn(),
   finalizeMatchingMutationEffects: jest.fn(),
@@ -18,6 +18,7 @@ jest.mock('@/lib/db/schema', () => ({
   matchingSessions: {},
   signupBooks: {},
   bookPriorities: { userId: 'bookPriorities.userId', bookId: 'bookPriorities.bookId', rank: 'bookPriorities.rank' },
+  users: { id: 'users.id' },
 }))
 
 const mockAuth = authModule.auth as jest.Mock
@@ -42,6 +43,10 @@ describe('POST /api/matching/books', () => {
     jest.clearAllMocks()
     mockCaptureSnapshot.mockResolvedValue({ context: { overview: { leader: null } } })
     mockFinalizeEffects.mockResolvedValue(undefined)
+    mockDb.update = jest.fn().mockReturnValue({
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockResolvedValue([]),
+    })
   })
 
   it('returns 401 when not authenticated', async () => {
@@ -93,6 +98,8 @@ describe('POST /api/matching/books', () => {
     mockDb.insert = jest.fn((table) => (
       table === signupBooks ? insertChain : priorityInsertChain
     )) as unknown as typeof mockDb.insert
+    const updateChain = { set: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) }
+    mockDb.update = jest.fn().mockReturnValue(updateChain)
 
     const res = await POST(makeReq({ bookId: 'b1' }))
 
@@ -102,6 +109,7 @@ describe('POST /api/matching/books', () => {
     expect(priorityInsertChain.values).toHaveBeenNthCalledWith(1, { userId: 'user1', bookId: 'b1', rank: 1 })
     expect(priorityInsertChain.values).toHaveBeenNthCalledWith(2, { userId: 'user1', bookId: 'b2', rank: 2 })
     expect(priorityInsertChain.values).toHaveBeenNthCalledWith(3, { userId: 'user1', bookId: 'b3', rank: 3 })
+    expect(updateChain.set).toHaveBeenCalledWith({ prioritiesSet: true })
     expect(mockFinalizeEffects).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: 's1',
       targetUserId: 'user1',

--- a/app/api/matching/books/route.ts
+++ b/app/api/matching/books/route.ts
@@ -3,7 +3,7 @@ export const dynamic = 'force-dynamic'
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { matchingSessions, signupBooks, bookPriorities } from '@/lib/db/schema'
+import { matchingSessions, signupBooks, bookPriorities, users } from '@/lib/db/schema'
 import { asc, eq } from 'drizzle-orm'
 import { bumpSessionState } from '@/lib/matching/realtime/version'
 import {
@@ -60,6 +60,11 @@ export async function POST(req: NextRequest) {
         set: { rank: i + 1, updatedAt: new Date() },
       })
   }
+
+  await db
+    .update(users)
+    .set({ prioritiesSet: true })
+    .where(eq(users.id, userId))
 
   await finalizeMatchingMutationEffects({
     sessionId: activeSession.id,

--- a/app/api/matching/priorities/route.test.ts
+++ b/app/api/matching/priorities/route.test.ts
@@ -7,10 +7,11 @@ import { db } from '@/lib/db'
 import { finalizeMatchingMutationEffects } from '@/lib/matching/mutation-effects'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
-jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn() } }))
+jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn(), update: jest.fn() } }))
 jest.mock('@/lib/db/schema', () => ({
   matchingSessions: {},
   bookPriorities: {},
+  users: { id: 'users.id' },
 }))
 jest.mock('@/lib/matching/realtime/version', () => ({ bumpSessionState: jest.fn() }))
 jest.mock('@/lib/matching/mutation-effects', () => ({
@@ -35,7 +36,13 @@ const userSession = { user: { id: 'user1', isAdmin: false } }
 const adminSession = { user: { id: 'admin1', isAdmin: true } }
 
 describe('PATCH /api/matching/priorities', () => {
-  beforeEach(() => jest.clearAllMocks())
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDb.update = jest.fn().mockReturnValue({
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockResolvedValue([]),
+    })
+  })
 
   it('returns 401 when not authenticated', async () => {
     mockAuth.mockResolvedValue(null)
@@ -84,12 +91,15 @@ describe('PATCH /api/matching/priorities', () => {
       .mockReturnValueOnce(canonicalChain)
     const upsertChain = { values: jest.fn().mockReturnThis(), onConflictDoUpdate: jest.fn().mockResolvedValue([]) }
     mockDb.insert = jest.fn().mockReturnValue(upsertChain)
+    const updateChain = { set: jest.fn().mockReturnThis(), where: jest.fn().mockResolvedValue([]) }
+    mockDb.update = jest.fn().mockReturnValue(updateChain)
 
     const res = await PATCH(makeReq({ bookIds: ['b2', 'b1'] }))
     expect(res.status).toBe(200)
     const json = await res.json()
     expect(json.ranks).toHaveLength(2)
     expect(mockDb.insert).toHaveBeenCalledTimes(2)
+    expect(updateChain.set).toHaveBeenCalledWith({ prioritiesSet: true })
   })
 
   it('пишет событие priorities_updated с упорядоченным списком (source=matching)', async () => {

--- a/app/api/matching/priorities/route.ts
+++ b/app/api/matching/priorities/route.ts
@@ -3,7 +3,7 @@ export const dynamic = 'force-dynamic'
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { matchingSessions, bookPriorities } from '@/lib/db/schema'
+import { matchingSessions, bookPriorities, users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { bumpSessionState } from '@/lib/matching/realtime/version'
 import {
@@ -48,6 +48,11 @@ export async function PATCH(req: NextRequest) {
         set: { rank: i + 1, updatedAt: new Date() },
       })
   }
+
+  await db
+    .update(users)
+    .set({ prioritiesSet: true })
+    .where(eq(users.id, userId))
 
   // Return canonical order so client can reconcile
   const canonical = await db

--- a/lib/admin-users.test.ts
+++ b/lib/admin-users.test.ts
@@ -115,6 +115,73 @@ describe('admin-users aggregations', () => {
     await expect(getAdminUserDetails('missing-user')).resolves.toBeNull()
   })
 
+  it('считает приоритеты расставленными, если строки book_priorities уже есть', async () => {
+    const userCreatedAt = new Date('2026-06-01T10:00:00Z')
+    const signedAt = new Date('2026-06-02T10:00:00Z')
+    const userQuery = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([{
+        id: 'u1',
+        name: 'Евгений',
+        email: null,
+        contactEmail: null,
+        emailVerified: null,
+        createdAt: userCreatedAt,
+        contacts: '@evgeniy',
+        lastActivityAt: null,
+        languages: null,
+        prioritiesSet: false,
+        isAdmin: false,
+      }]),
+    }
+    const signupQuery = {
+      from: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockResolvedValue([
+        { bookId: 'b1', bookName: 'Книга', signedAt, personalStatus: null },
+      ]),
+    }
+    const prioritiesQuery = {
+      from: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockResolvedValue([
+        { bookId: 'b1', bookName: 'Книга', rank: 1, updatedAt: signedAt },
+      ]),
+    }
+    const emptyOrderedQuery = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockResolvedValue([]),
+    }
+    const feedbackQuery = {
+      from: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockResolvedValue([]),
+    }
+    const identityQuery = {
+      from: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([]),
+    }
+    mockSelect
+      .mockReturnValueOnce(userQuery)
+      .mockReturnValueOnce(signupQuery)
+      .mockReturnValueOnce(prioritiesQuery)
+      .mockReturnValueOnce(emptyOrderedQuery)
+      .mockReturnValueOnce(feedbackQuery)
+      .mockReturnValueOnce(identityQuery)
+
+    await expect(getAdminUserDetails('u1')).resolves.toEqual(expect.objectContaining({
+      user: expect.objectContaining({ prioritiesSet: true }),
+      priorities: [{ bookId: 'b1', bookName: 'Книга', rank: 1 }],
+    }))
+  })
+
   it('форматирует фидбеки для админской вкладки', async () => {
     const createdAt = new Date('2026-05-18T10:00:00Z')
     const query = {

--- a/lib/admin-users.ts
+++ b/lib/admin-users.ts
@@ -243,8 +243,10 @@ export async function getAdminUserDetails(userId: string): Promise<AdminUserDeta
     []
   )[0]
 
+  const prioritiesSet = (userRow.prioritiesSet ?? false) || priorityRows.length > 0
+
   return {
-    user: { ...summary, prioritiesSet: userRow.prioritiesSet ?? false },
+    user: { ...summary, prioritiesSet },
     signupBooks: signupRows.map(row => ({ bookId: row.bookId, bookName: row.bookName, signedAt: row.signedAt.toISOString(), personalStatus: (row.personalStatus ?? null) as PersonalBookStatus })),
     priorities: priorityRows.map(row => ({ bookId: row.bookId, bookName: row.bookName, rank: row.rank })),
     submissions: submissionRows.map(row => ({


### PR DESCRIPTION
## Summary
- set users.prioritiesSet when priorities are changed from /matching
- treat existing book_priorities rows as priorities set in admin read paths
- add unit coverage for matching priority writes and admin user details

## Checks
- npm run lint
- npm run typecheck
- npm test