### PR TITLE
feat(matching): taller catalog panels + slower morph

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -480,15 +480,25 @@ body {
 /* ── Matching satisfaction flow: gate → board entrance morph ── */
 .nd-flow-slide-from-top {
   opacity: 0;
-  transform: translateY(-22px);
-  transition: opacity 1.4s ease, transform 1.6s cubic-bezier(0.22, 1, 0.36, 1);
+  transform: translateY(-26px);
+  transition: opacity 2.8s ease, transform 3.2s cubic-bezier(0.22, 1, 0.36, 1);
 }
 .nd-flow.is-board .nd-flow-slide-from-top { opacity: 1; transform: none; }
 
-.nd-flow-fade-collapse { transition: opacity 0.9s ease; }
+.nd-flow-fade-collapse { transition: opacity 1.8s ease; }
 .nd-flow.is-board .nd-flow-fade-collapse { opacity: 0; pointer-events: none; }
+
+/* Soft staggered reveal of the «Сценарии» / «Мои ходы» content once the board
+   chrome has slid in. */
+.nd-flow-stagger {
+  opacity: 0;
+  transform: translateY(14px);
+  transition: opacity 2.6s ease, transform 2.8s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.nd-flow-stagger.is-loaded { opacity: 1; transform: none; }
 
 @media (prefers-reduced-motion: reduce) {
   .nd-flow-slide-from-top,
-  .nd-flow-fade-collapse { transition: none !important; }
+  .nd-flow-fade-collapse,
+  .nd-flow-stagger { transition: none !important; }
 }

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -579,7 +579,7 @@ export default function MatchingPersonalList({
       {/* ── Остальной каталог ── */}
       <section
         data-testid="matching-catalog-available"
-        style={{ ...panelStyle, maxHeight: '60vh', overflow: 'hidden', ...(fill ? { minHeight: 0 } : {}) }}
+        style={{ ...panelStyle, overflow: 'hidden', ...(fill ? { minHeight: 0 } : { maxHeight: '80vh' }) }}
         className="flex flex-col"
       >
         <div style={panelHeadStyle}>
@@ -614,7 +614,7 @@ export default function MatchingPersonalList({
       {/* ── Мои книги ── */}
       <section
         data-testid="matching-catalog-mine"
-        style={{ ...panelStyle, maxHeight: '60vh', overflow: 'hidden', ...(fill ? { minHeight: 0 } : {}) }}
+        style={{ ...panelStyle, overflow: 'hidden', ...(fill ? { minHeight: 0 } : { maxHeight: '80vh' }) }}
         className="flex flex-col"
       >
         <div style={panelHeadStyle}>

--- a/components/nd/MatchingSatisfactionFlow.tsx
+++ b/components/nd/MatchingSatisfactionFlow.tsx
@@ -33,7 +33,7 @@ function Collapsible({ open, children }: { open: boolean; children: React.ReactN
 
   useEffect(() => {
     if (open) {
-      const t = setTimeout(() => setSettled(true), 1300)
+      const t = setTimeout(() => setSettled(true), 2600)
       return () => clearTimeout(t)
     }
     setSettled(false)
@@ -51,7 +51,7 @@ function Collapsible({ open, children }: { open: boolean; children: React.ReactN
     nat == null ? (open ? 'none' : 0) : !open ? 0 : settled ? 'none' : nat
 
   return (
-    <div style={{ maxHeight, overflow: 'hidden', transition: 'max-height 1.2s cubic-bezier(0.22, 1, 0.36, 1)' }}>
+    <div style={{ maxHeight, overflow: 'hidden', transition: 'max-height 2.4s cubic-bezier(0.22, 1, 0.36, 1)' }}>
       <div ref={innerRef}>{children}</div>
     </div>
   )
@@ -101,11 +101,20 @@ export default function MatchingSatisfactionFlow({
   const initialCanEnter = useMemo(() => listHasCompleteActiveRanking(books), [books])
   const [canEnter, setCanEnter] = useState(initialCanEnter)
   const [entering, setEntering] = useState(false)
+  const [loaded, setLoaded] = useState(false)
   const isBoard = board || entering
 
   useEffect(() => {
     if (isBoard) window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [isBoard])
+
+  // When morphing in from the gate, reveal the scenarios/moves after the board
+  // chrome has slid in. Direct board loads skip this (no entering → no stagger).
+  useEffect(() => {
+    if (!entering) return
+    const t = setTimeout(() => setLoaded(true), 1800)
+    return () => clearTimeout(t)
+  }, [entering])
 
   const enter = useCallback(() => {
     if (!canEnter || board || entering) return
@@ -126,7 +135,14 @@ export default function MatchingSatisfactionFlow({
       <Collapsible open={isBoard}>
         <div className="nd-flow-slide-from-top flex flex-col" style={{ height: '100svh' }}>
           {header}
-          <div className="flex-1 min-h-0 p-4">{workspace}</div>
+          <div className="flex-1 min-h-0 p-4">
+            <div
+              className={entering ? `nd-flow-stagger${loaded ? ' is-loaded' : ''}` : undefined}
+              style={{ height: '100%' }}
+            >
+              {workspace}
+            </div>
+          </div>
         </div>
       </Collapsible>
 


### PR DESCRIPTION
## Summary
Follow-up tuning on the satisfaction gate↔board morph.

- **Taller panels:** «Остальной каталог» / «Мои книги» were hard-capped at `maxHeight: 60vh`, leaving empty space below the lists (esp. on the gate). Now the gate stretches the panels to fill the available viewport height (via the grid), and the board caps at `80vh`. Both keep internal scroll and fit the screen.
- **Slower morph:** Collapsible 1.2s→2.4s, slide-from-top ~1.5s→~3s, gate fade 0.9s→1.8s.
- **Slow staggered reveal** of «Сценарии»/«Мои ходы» (+ content) after the board chrome slides in — only when morphing from the gate, not on direct board loads. reduced-motion jumps to final state.

## ⚠️ Needs a visual check (auto-merge NOT enabled)
Preview link in checks. Verify: gate panels now fill the height (no empty gap); board catalog panels taller; morph noticeably slower; scenarios/moves fade in after the header/board slides in.

## Test Plan
- [x] typecheck / lint clean
- [x] `npm test` — 793/793
- [ ] Manual: Vercel preview

**E2E:** не требуется (вёрстка/тайминги). **Wiki:** не требуется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)