### PR TITLE
feat(matching): one-screen cap + internal scroll (coupled morph)

### DIFF
--- a/components/nd/MatchingSatisfactionFlow.tsx
+++ b/components/nd/MatchingSatisfactionFlow.tsx
@@ -86,11 +86,14 @@ export default function MatchingSatisfactionFlow({
         ...(board ? { minHeight: '100svh' } : { height: '100svh', overflow: 'hidden' }),
       }}
     >
-      {/* Board chrome: header + scenarios/moves grow in (content height) */}
+      {/* Board chrome: header + scenarios/moves. Capped at one screen with the
+          workspace scrolling internally, so the grid-rows grow stops at ~100svh
+          (the catalog slides one screen down, coupled) instead of ballooning to
+          the full height of many scenarios. */}
       <Collapsible open={board}>
-        <div className="nd-flow-slide-from-top">
+        <div className="nd-flow-slide-from-top flex flex-col" style={{ height: '100svh' }}>
           {header}
-          <div className="p-4">{workspace}</div>
+          <div className="flex-1 min-h-0 p-4">{workspace}</div>
         </div>
       </Collapsible>
 


### PR DESCRIPTION
## Summary
Сохраняет сцепленный морф, но **кэпит секции «Сценарии»/«Мои ходы» в один экран** с внутренним скроллом — чтобы при 10-11 сценариях каталог не улетал на несколько экранов вниз.

- Board chrome снова `height: 100svh` (шапка + воркспейс с внутренним скроллом).
- `grid-rows 0fr→1fr` теперь растит до **одного экрана** (1fr = 100svh), сцеплено толкая каталог на один экран вниз, и останавливается.
- Контент-механика прежняя: рост проигрывается при приходе `phase="board"` (не по клику), поэтому без дёрганья/пустого роста.

## Проверь на preview (auto-merge выключен)
Вход с гейта при многих сценариях: секция должна вырасти **до одного экрана и остановиться**, каталог уехать ровно на один экран вниз (сцеплено), сценарии — скроллиться **внутри** секции.

## Test Plan
- [x] typecheck / lint / 797
- [ ] Manual: preview (особенно с 10+ сценариями)

**E2E/Wiki:** не требуется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)