### PR TITLE
fix(matching): assign random welcome pseudonym instead of stable per-user

### DIFF
--- a/lib/matching/__tests__/pseudonyms.test.ts
+++ b/lib/matching/__tests__/pseudonyms.test.ts
@@ -1,4 +1,4 @@
-import { ANIMALS, assignPseudonym, assignStablePseudonym, assignRandomPseudonymExcluding, PseudonymExhaustedError } from '../pseudonyms'
+import { ANIMALS, assignPseudonym, assignRandomPseudonymExcluding, PseudonymExhaustedError } from '../pseudonyms'
 
 describe('ANIMALS', () => {
   it('contains at least 200 entries', () => {
@@ -43,38 +43,6 @@ describe('assignPseudonym', () => {
     const all = new Set(ANIMALS)
     expect(() => assignPseudonym(all)).toThrow(PseudonymExhaustedError)
     expect(() => assignPseudonym(all)).toThrow('All pseudonyms have been assigned in this session')
-  })
-})
-
-describe('assignStablePseudonym', () => {
-  it('returns the same pseudonym for the same seed while it remains available', () => {
-    const seed = 'session-1:user-1'
-
-    expect(assignStablePseudonym(new Set(), seed)).toBe(assignStablePseudonym(new Set(), seed))
-  })
-
-  it('uses the next available pseudonym when the seeded candidate is already taken', () => {
-    const seed = 'session-1:user-1'
-    const first = assignStablePseudonym(new Set(), seed)
-    const second = assignStablePseudonym(new Set([first]), seed)
-
-    expect(second).not.toBe(first)
-    expect(ANIMALS).toContain(second)
-  })
-
-  it('does not mutate the taken set', () => {
-    const taken = new Set([assignStablePseudonym(new Set(), 'session-1:user-1')])
-    const before = new Set(taken)
-
-    assignStablePseudonym(taken, 'session-1:user-2')
-
-    expect(taken).toEqual(before)
-  })
-
-  it('throws PseudonymExhaustedError when all pseudonyms are taken', () => {
-    const all = new Set(ANIMALS)
-
-    expect(() => assignStablePseudonym(all, 'session-1:user-1')).toThrow(PseudonymExhaustedError)
   })
 })
 

--- a/lib/matching/pseudonym-reservations.ts
+++ b/lib/matching/pseudonym-reservations.ts
@@ -4,7 +4,7 @@ import {
   matchingPseudonymReservations,
   matchingSessionParticipants,
 } from '@/lib/db/schema'
-import { assignStablePseudonym, assignRandomPseudonymExcluding } from './pseudonyms'
+import { assignPseudonym, assignRandomPseudonymExcluding } from './pseudonyms'
 
 const RESERVATION_TTL_MS = 30 * 60 * 1000
 const MAX_ASSIGN_ATTEMPTS = 5
@@ -48,7 +48,7 @@ export async function getOrCreatePseudonymReservation(
 
   for (let attempt = 0; attempt < MAX_ASSIGN_ATTEMPTS; attempt++) {
     const taken = await getTakenPseudonyms(sessionId, userId, now)
-    const pseudonym = assignStablePseudonym(taken, `${sessionId}:${userId}`)
+    const pseudonym = assignPseudonym(taken)
 
     const [inserted] = await db
       .insert(matchingPseudonymReservations)

--- a/lib/matching/pseudonyms.ts
+++ b/lib/matching/pseudonyms.ts
@@ -76,22 +76,3 @@ export function assignRandomPseudonymExcluding(
   return available[Math.floor(Math.random() * available.length)]
 }
 
-function stableIndex(seed: string): number {
-  let hash = 0
-  for (let i = 0; i < seed.length; i++) {
-    hash = ((hash << 5) - hash + seed.charCodeAt(i)) | 0
-  }
-  return Math.abs(hash) % ANIMALS.length
-}
-
-export function assignStablePseudonym(takenSet: ReadonlySet<string>, seed: string): string {
-  if (takenSet.size >= ANIMALS.length) throw new PseudonymExhaustedError()
-
-  const start = stableIndex(seed)
-  for (let offset = 0; offset < ANIMALS.length; offset++) {
-    const candidate = ANIMALS[(start + offset) % ANIMALS.length]
-    if (!takenSet.has(candidate)) return candidate
-  }
-
-  throw new PseudonymExhaustedError()
-}


### PR DESCRIPTION
The welcome screen offered a deterministic pseudonym derived from a
sessionId:userId hash, so the same user always saw the same name first.
Stability across reloads is already guaranteed by the persisted
reservation row, so the deterministic seed only removed the intended
randomness. Switch first assignment to assignPseudonym and drop the now
dead assignStablePseudonym helper.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
