### PR TITLE
feat(matching): peeking catalog (90svh board chrome)

### DIFF
--- a/components/nd/MatchingSatisfactionFlow.tsx
+++ b/components/nd/MatchingSatisfactionFlow.tsx
@@ -86,12 +86,12 @@ export default function MatchingSatisfactionFlow({
         ...(board ? { minHeight: '100svh' } : { height: '100svh', overflow: 'hidden' }),
       }}
     >
-      {/* Board chrome: header + scenarios/moves. Capped at one screen with the
-          workspace scrolling internally, so the grid-rows grow stops at ~100svh
-          (the catalog slides one screen down, coupled) instead of ballooning to
-          the full height of many scenarios. */}
+      {/* Board chrome: header + scenarios/moves. Capped just under one screen
+          (90svh) with the workspace scrolling internally, so the grid-rows grow
+          stops with the catalog peeking at the bottom — a hint that it scrolls —
+          instead of ballooning to the full height of many scenarios. */}
       <Collapsible open={board}>
-        <div className="nd-flow-slide-from-top flex flex-col" style={{ height: '100svh' }}>
+        <div className="nd-flow-slide-from-top flex flex-col" style={{ height: '90svh' }}>
           {header}
           <div className="flex-1 min-h-0 p-4">{workspace}</div>
         </div>


### PR DESCRIPTION
Cap the board chrome at 90svh so the catalog peeks at the bottom after the morph (hint that it scrolls). Verify the peek amount on preview; easy to tune (e.g. 88/92svh).

**E2E/Wiki:** не требуется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)