### PR TITLE
fix: вернуть «книгу нынешнего круга» в why-text карточки «Мои ходы»

### DIFF
--- a/components/nd/MatchingMyMoves.tsx
+++ b/components/nd/MatchingMyMoves.tsx
@@ -302,7 +302,7 @@ function MoveWhyText({
               <span key={b.userId}>
                 {i > 0 && ' '}
                 <b>{b.pseudonym}</b>
-                {' ставит '}{thisBook}{` на ${rAfter}-е место, а книгу оптимального — на ${rBefore}-е.`}
+                {' ставит '}{thisBook}{` на ${rAfter}-е место, а книгу нынешнего круга — на ${rBefore}-е.`}
               </span>
             )
           })}


### PR DESCRIPTION
В PR #327 случайно изменилась фраза в why-text: «книгу нынешнего круга» превратилась в «книгу оптимального».

Этот PR возвращает оригинальную формулировку. Чип «оптимальный» на карточке сценария остаётся без изменений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)