### PR TITLE
fix(e2e): scope satisfaction gate catalog lookups to matching-catalog-panel

### DIFF
--- a/e2e/matching-satisfaction.spec.ts
+++ b/e2e/matching-satisfaction.spec.ts
@@ -67,15 +67,17 @@ test('satisfaction session gates unranked readers before showing quality-first s
   await expect(page.getByRole('heading', { name: 'Сначала расставьте приоритеты' })).toBeVisible()
   await expect(page.getByTestId('matching-reader-circles-panel')).not.toBeVisible()
 
-  const gate = page.getByTestId('ranking-gate')
-  const perfectBookRow = gate.locator('li').filter({ hasText: perfectBook.title }).first()
+  // The catalog/personal-list lives in a sibling `matching-catalog-panel`, not inside
+  // `ranking-gate` (the gate div holds only the intro copy since the full-width morph, #294).
+  const catalog = page.getByTestId('matching-catalog-panel')
+  const perfectBookRow = catalog.locator('li').filter({ hasText: perfectBook.title }).first()
   await perfectBookRow.hover()
   await perfectBookRow.getByRole('button', { name: 'Хочу читать' }).click()
-  await expect(gate.getByTestId('matching-catalog-mine').getByText(perfectBook.title)).toBeVisible()
-  const fallbackBookRow = gate.locator('li').filter({ hasText: fallbackBook.title }).first()
+  await expect(catalog.getByTestId('matching-catalog-mine').getByText(perfectBook.title)).toBeVisible()
+  const fallbackBookRow = catalog.locator('li').filter({ hasText: fallbackBook.title }).first()
   await fallbackBookRow.hover()
   await fallbackBookRow.getByRole('button', { name: 'Хочу читать' }).click()
-  await expect(gate.getByTestId('matching-catalog-mine').getByText(fallbackBook.title)).toBeVisible()
+  await expect(catalog.getByTestId('matching-catalog-mine').getByText(fallbackBook.title)).toBeVisible()
 
   const enter = page.getByTestId('ranking-gate-enter')
   await expect(enter).toBeEnabled()


### PR DESCRIPTION
После #294 (full-width gate↔board morph) каталог/персональный список вынесен
из div'а ranking-gate в соседний matching-catalog-panel. Тест продолжал искать
li книг и matching-catalog-mine внутри ranking-gate → hover висел до таймаута.
Чиним ночной E2E (matching-satisfaction.spec.ts:33), переводя лукапы на актуальный testid.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
