### PR TITLE
fix(e2e): drop unreliable ranking-gate visibility checks in satisfaction test

### DIFF
--- a/e2e/matching-satisfaction.spec.ts
+++ b/e2e/matching-satisfaction.spec.ts
@@ -84,7 +84,9 @@ test('satisfaction session gates unranked readers before showing quality-first s
   await enter.click()
   await page.waitForLoadState('networkidle')
 
-  await expect(page.getByTestId('ranking-gate')).not.toBeVisible()
+  // On board phase the gate collapses via grid-template-rows:0fr + opacity:0, but the
+  // ranking-gate element stays mounted (its own bounding box stays non-zero and Playwright
+  // treats opacity:0 as visible), so we assert the board surface instead of the gate's absence.
   await expect(page.getByRole('heading', { name: 'Сценарии' })).toBeVisible()
   const scenariosPanel = page.getByTestId('matching-reader-circles-panel')
   const scenarioCards = scenariosPanel.getByTestId('matching-scenario-card')
@@ -97,7 +99,6 @@ test('satisfaction session gates unranked readers before showing quality-first s
   // persistence: reload keeps us on the board (ranking complete persisted)
   await page.reload()
   await page.waitForLoadState('networkidle')
-  await expect(page.getByTestId('ranking-gate')).not.toBeVisible()
   await expect(page.getByRole('heading', { name: 'Сценарии' })).toBeVisible()
   // board content present (a scenarios surface rendered)
   await expect(


### PR DESCRIPTION
На board-фазе гейт сворачивается через grid-template-rows:0fr + opacity:0, но
элемент ranking-gate остаётся в DOM: его собственный bounding box ненулевой, а
opacity:0 Playwright считает visible → expect(ranking-gate).not.toBeVisible() висит.
Тот же приём уже задокументирован в тесте #3 этого файла. Проверяем появление
board-поверхности (заголовок «Сценарии»), а не отсутствие гейта.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
