### PR TITLE
feat(audit): actor-атрибуция мутаций + ESLint enforcement (2/2)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,39 @@
     "next/core-web-vitals",
     "next/typescript"
   ],
-  "root": true
+  "root": true,
+  "rules": {
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.object.name='db'][callee.property.name='transaction']",
+        "message": "Голый db.transaction запрещён — используй withAuditContext (lib/audit), чтобы аудит знал actor. См. docs/features/audit-log.md"
+      },
+      {
+        "selector": "CallExpression[callee.object.name='db'][callee.property.name=/^(insert|update|delete)$/]",
+        "message": "Прямые мутации через db.insert/update/delete запрещены — оборачивай в withAuditContext (lib/audit). См. docs/features/audit-log.md"
+      }
+    ]
+  },
+  "overrides": [
+    {
+      "files": [
+        "lib/audit/**",
+        "lib/db/**",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "scripts/**",
+        "app/api/test/**",
+        "lib/auth.ts",
+        "lib/telegram-auth.ts",
+        "lib/user-identities.ts",
+        "lib/auth-adapter.ts",
+        "lib/user-activity.ts",
+        "lib/matching/**",
+        "app/api/matching/**",
+        "app/api/admin/matching/**"
+      ],
+      "rules": { "no-restricted-syntax": "off" }
+    }
+  ]
 }

--- a/app/api/admin/books/reorder/route.test.ts
+++ b/app/api/admin/books/reorder/route.test.ts
@@ -5,6 +5,9 @@ import { NextRequest } from 'next/server'
 import * as authModule from '@/lib/auth'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 interface UpdateCall { id: string; sortOrder: number }
 const updateCalls: UpdateCall[] = []

--- a/app/api/admin/books/reorder/route.ts
+++ b/app/api/admin/books/reorder/route.ts
@@ -2,9 +2,9 @@ export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
-import { db } from '@/lib/db'
 import { books } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 /**
  * PUT /api/admin/books/reorder
@@ -41,12 +41,17 @@ export async function PUT(req: NextRequest) {
 
   try {
     const now = new Date()
-    for (let i = 0; i < ids.length; i++) {
-      await db
-        .update(books)
-        .set({ sortOrder: i + 1, updatedAt: now })
-        .where(eq(books.id, ids[i] as string))
-    }
+    await withAuditContext(
+      { actorUserId: session.user.id, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: 'admin' },
+      async (tx) => {
+        for (let i = 0; i < ids.length; i++) {
+          await tx
+            .update(books)
+            .set({ sortOrder: i + 1, updatedAt: now })
+            .where(eq(books.id, ids[i] as string))
+        }
+      },
+    )
     return NextResponse.json({ success: true })
   } catch (err) {
     console.error('[reorder] failed:', err)

--- a/app/api/admin/books/route.test.ts
+++ b/app/api/admin/books/route.test.ts
@@ -43,6 +43,10 @@ jest.mock('@/lib/books', () => {
   }
 })
 
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: jest.fn((_ctx: unknown, fn: (tx: unknown) => Promise<unknown>) => fn({})),
+}))
+
 import { GET, POST } from './route'
 
 const mockAuth = authModule.auth as jest.Mock
@@ -126,7 +130,7 @@ describe('POST /api/admin/books', () => {
     pushSelectResult([{ id: 'new1', title: 'New', visibility: 'hidden' }])
     const res = await POST(makePost({ title: 'New', author: 'A' }))
     expect(res.status).toBe(200)
-    expect(createBookMock).toHaveBeenCalledWith({ title: 'New', author: 'A' })
+    expect(createBookMock).toHaveBeenCalledWith({ title: 'New', author: 'A' }, {})
     const json = await res.json()
     expect(json.data.id).toBe('new1')
   })

--- a/app/api/admin/books/route.ts
+++ b/app/api/admin/books/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { books, signupBooks, bookSubmissions, users } from '@/lib/db/schema'
 import { asc, desc, eq, isNotNull, sql } from 'drizzle-orm'
 import { createBook, BookValidationError } from '@/lib/books'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function GET() {
   const session = await auth()
@@ -79,7 +80,14 @@ export async function POST(req: NextRequest) {
 
   try {
     const body = await req.json()
-    const created = await createBook(body)
+    const created = await withAuditContext(
+      {
+        actorUserId: session.user.id,
+        actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+        source: 'admin',
+      },
+      async (tx) => createBook(body, tx),
+    )
     // After creation, also fetch raw row so we return DB-shape (admin UI consumes admin shape).
     const [row] = await db.select().from(books).where(eq(books.id, created.id)).limit(1)
     return NextResponse.json({ success: true, data: row })

--- a/app/api/admin/delete-user/route.test.ts
+++ b/app/api/admin/delete-user/route.test.ts
@@ -15,6 +15,10 @@ jest.mock('@/lib/db', () => ({
     }),
   },
 }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) =>
+    fn((jest.requireMock('@/lib/db') as { db: unknown }).db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockSelect = dbModule.db.select as jest.Mock

--- a/app/api/admin/delete-user/route.ts
+++ b/app/api/admin/delete-user/route.ts
@@ -5,6 +5,7 @@ import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { notificationQueue, users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 function isValidUserId(value: string) {
   return typeof value === 'string' && value.trim().length > 0 && value.length <= 255
@@ -27,13 +28,21 @@ export async function DELETE(req: NextRequest) {
     .where(eq(users.id, userId))
     .limit(1)
 
-  if (targetUser?.contactEmail) {
-    await db
-      .delete(notificationQueue)
-      .where(eq(notificationQueue.userEmail, targetUser.contactEmail))
-  }
-
-  await db.delete(users).where(eq(users.id, userId))
+  await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => {
+      if (targetUser?.contactEmail) {
+        await tx
+          .delete(notificationQueue)
+          .where(eq(notificationQueue.userEmail, targetUser.contactEmail))
+      }
+      await tx.delete(users).where(eq(users.id, userId))
+    },
+  )
 
   return NextResponse.json({ ok: true })
 }

--- a/app/api/admin/intro/[id]/route.test.ts
+++ b/app/api/admin/intro/[id]/route.test.ts
@@ -10,6 +10,9 @@ const deleteMock = jest.fn()
 jest.mock('@/lib/intro', () => ({
   deleteSection: (id: string) => deleteMock(id),
 }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn({}),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 

--- a/app/api/admin/intro/[id]/route.ts
+++ b/app/api/admin/intro/[id]/route.ts
@@ -4,13 +4,21 @@ import { NextResponse } from 'next/server'
 import { revalidateTag } from 'next/cache'
 import { auth } from '@/lib/auth'
 import { deleteSection } from '@/lib/intro'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
   const session = await auth()
   if (!session?.user?.isAdmin) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
-  const result = await deleteSection(params.id)
+  const result = await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => deleteSection(params.id, tx),
+  )
   if (!result.ok) {
     if (result.reason === 'not_found') return NextResponse.json({ error: 'Not found' }, { status: 404 })
     if (result.reason === 'header_protected') return NextResponse.json({ error: 'Cannot delete header' }, { status: 400 })

--- a/app/api/admin/intro/route.test.ts
+++ b/app/api/admin/intro/route.test.ts
@@ -12,6 +12,9 @@ jest.mock('@/lib/intro', () => ({
   updateSections: jest.fn().mockResolvedValue(undefined),
   createSection: jest.fn().mockResolvedValue({ id: 'new', title: '', body: '', sortOrder: 0, isPublished: false }),
 }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn({}),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 

--- a/app/api/admin/intro/route.ts
+++ b/app/api/admin/intro/route.ts
@@ -9,39 +9,54 @@ import {
   updateSections,
   type SectionPatch,
 } from '@/lib/intro'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 async function requireAdmin() {
   const session = await auth()
   if (!session?.user?.isAdmin) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    return { forbidden: NextResponse.json({ error: 'Forbidden' }, { status: 403 }), session: null }
   }
-  return null
+  return { forbidden: null, session }
 }
 
 export async function GET() {
-  const forbidden = await requireAdmin()
+  const { forbidden } = await requireAdmin()
   if (forbidden) return forbidden
   const data = await getIntroData({ onlyPublished: false })
   return NextResponse.json(data)
 }
 
 export async function PUT(req: NextRequest) {
-  const forbidden = await requireAdmin()
+  const { forbidden, session } = await requireAdmin()
   if (forbidden) return forbidden
 
   const body = await req.json() as { patches?: SectionPatch[] }
   if (!Array.isArray(body.patches)) {
     return NextResponse.json({ error: 'patches[] required' }, { status: 400 })
   }
-  await updateSections(body.patches)
+  await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => updateSections(body.patches!, tx),
+  )
   revalidateTag('intro')
   return NextResponse.json({ ok: true })
 }
 
 export async function POST() {
-  const forbidden = await requireAdmin()
+  const { forbidden, session } = await requireAdmin()
   if (forbidden) return forbidden
-  const section = await createSection()
+  const section = await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => createSection(tx),
+  )
   revalidateTag('intro')
   return NextResponse.json({ section })
 }

--- a/app/api/admin/matching/sessions/[id]/participants/route.ts
+++ b/app/api/admin/matching/sessions/[id]/participants/route.ts
@@ -7,6 +7,7 @@ import { matchingSessions, matchingSessionParticipants, users } from '@/lib/db/s
 import { eq, and } from 'drizzle-orm'
 import { assignPseudonym } from '@/lib/matching/pseudonyms'
 import { bumpSessionState } from '@/lib/matching/realtime/version'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 interface Params { params: { id: string } }
 
@@ -79,7 +80,14 @@ export async function POST(req: NextRequest, { params }: Params) {
   const takenSet = new Set(taken.map(r => r.pseudonym))
   const pseudonym = assignPseudonym(takenSet)
 
-  await db.insert(matchingSessionParticipants).values({ sessionId, userId, pseudonym })
+  await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => tx.insert(matchingSessionParticipants).values({ sessionId, userId, pseudonym }),
+  )
 
   await bumpSessionState(sessionId)
 

--- a/app/api/admin/remove-book/route.test.ts
+++ b/app/api/admin/remove-book/route.test.ts
@@ -29,6 +29,10 @@ jest.mock('@/lib/matching/mutation-effects', () => ({
   captureMatchingMutationSnapshot: jest.fn(),
   finalizeMatchingMutationEffects: jest.fn(),
 }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) =>
+    fn((jest.requireMock('@/lib/db') as { db: unknown }).db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockRemoveBook = signups.removeBookFromSignup as jest.Mock

--- a/app/api/admin/remove-book/route.ts
+++ b/app/api/admin/remove-book/route.ts
@@ -3,7 +3,6 @@ export const dynamic = 'force-dynamic'
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { removeBookFromSignup } from '@/lib/signup-books'
-import { db } from '@/lib/db'
 import { bookPriorities } from '@/lib/db/schema'
 import { eq, and, gt, sql } from 'drizzle-orm'
 import {
@@ -14,6 +13,7 @@ import {
   captureMatchingMutationSnapshot,
   finalizeMatchingMutationEffects,
 } from '@/lib/matching/mutation-effects'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function DELETE(req: NextRequest) {
   const session = await auth()
@@ -29,7 +29,13 @@ export async function DELETE(req: NextRequest) {
   const activeSessionId = await getActiveMatchingSessionIdForParticipant(userId)
   const before = activeSessionId ? await captureMatchingMutationSnapshot(activeSessionId) : null
 
-  await db.transaction(async (tx) => {
+  await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => {
     await removeBookFromSignup(userId, bookId, tx)
 
     const [priorityRow] = await tx
@@ -47,7 +53,8 @@ export async function DELETE(req: NextRequest) {
       .update(bookPriorities)
       .set({ rank: sql`${bookPriorities.rank} - 1` })
       .where(and(eq(bookPriorities.userId, userId), gt(bookPriorities.rank, priorityRow.rank)))
-  })
+    },
+  )
 
   if (activeSessionId) {
     await finalizeMatchingMutationEffects({

--- a/app/api/admin/signup-books/route.test.ts
+++ b/app/api/admin/signup-books/route.test.ts
@@ -26,6 +26,10 @@ jest.mock('@/lib/matching/mutation-effects', () => ({
   captureMatchingMutationSnapshot: jest.fn(),
   finalizeMatchingMutationEffects: jest.fn(),
 }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) =>
+    fn((jest.requireMock('@/lib/db') as { db: unknown }).db),
+}))
 
 import { auth } from '@/lib/auth'
 const mockAuth = auth as jest.Mock

--- a/app/api/admin/signup-books/route.ts
+++ b/app/api/admin/signup-books/route.ts
@@ -2,7 +2,6 @@ export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
-import { db } from '@/lib/db'
 import { bookPriorities, signupBooks } from '@/lib/db/schema'
 import { removeBookFromSignup } from '@/lib/signup-books'
 import { and, eq, gt, sql } from 'drizzle-orm'
@@ -14,6 +13,7 @@ import {
   captureMatchingMutationSnapshot,
   finalizeMatchingMutationEffects,
 } from '@/lib/matching/mutation-effects'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 const VALID_STATUSES = new Set(['reading', 'read'])
 
@@ -41,7 +41,13 @@ export async function PATCH(req: NextRequest) {
   const before = activeSessionId ? await captureMatchingMutationSnapshot(activeSessionId) : null
 
   let signupExists = false
-  await db.transaction(async (tx) => {
+  await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => {
     // 1. Verify the user is signed up for this book (inside transaction to avoid race condition)
     const [signup] = await tx
       .select({ bookId: signupBooks.bookId })
@@ -79,7 +85,8 @@ export async function PATCH(req: NextRequest) {
       }
     }
     // If status === null: leave book_priorities untouched
-  })
+    },
+  )
 
   if (!signupExists) {
     return NextResponse.json({ error: 'Not signed up for this book' }, { status: 404 })
@@ -116,7 +123,13 @@ export async function DELETE(req: NextRequest) {
   const activeSessionId = await getActiveMatchingSessionIdForParticipant(userId)
   const before = activeSessionId ? await captureMatchingMutationSnapshot(activeSessionId) : null
 
-  await db.transaction(async (tx) => {
+  await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => {
     const [existing] = await tx
       .select({ rank: bookPriorities.rank })
       .from(bookPriorities)
@@ -135,7 +148,8 @@ export async function DELETE(req: NextRequest) {
         .set({ rank: sql`${bookPriorities.rank} - 1` })
         .where(and(eq(bookPriorities.userId, userId), gt(bookPriorities.rank, existing.rank)))
     }
-  })
+    },
+  )
 
   if (activeSessionId) {
     await finalizeMatchingMutationEffects({

--- a/app/api/admin/submissions/[id]/route.test.ts
+++ b/app/api/admin/submissions/[id]/route.test.ts
@@ -61,6 +61,10 @@ jest.mock('@/lib/db', () => ({
     })),
   },
 }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) =>
+    fn((jest.requireMock('@/lib/db') as { db: unknown }).db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 
@@ -139,7 +143,8 @@ describe('PATCH /api/admin/submissions/[id] — happy path', () => {
     mockPublishSubmissionAsBook.mockClear()
     await PATCH(makeRequest('sub-1', { status: 'approved' }), { params: { id: 'sub-1' } })
     expect(mockPublishSubmissionAsBook).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'sub-1', userId: 'user-1', title: 'Сапиенс' })
+      expect.objectContaining({ id: 'sub-1', userId: 'user-1', title: 'Сапиенс' }),
+      expect.anything(),
     )
   })
 

--- a/app/api/admin/submissions/[id]/route.ts
+++ b/app/api/admin/submissions/[id]/route.ts
@@ -9,6 +9,7 @@ import { Resend } from 'resend'
 import { approvedEmail, rejectedEmail } from '@/lib/email-templates/submission-status'
 import { getUserContactEmail } from '@/lib/user-email'
 import { publishSubmissionAsBook } from '@/lib/book-publish'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function DELETE(
   _req: NextRequest,
@@ -20,10 +21,15 @@ export async function DELETE(
   }
 
   const { id } = params
-  const deleted = await db
-    .delete(bookSubmissions)
-    .where(eq(bookSubmissions.id, id))
-    .returning()
+  const deleted = await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) =>
+      tx.delete(bookSubmissions).where(eq(bookSubmissions.id, id)).returning(),
+  )
 
   if (deleted.length === 0) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -70,37 +76,51 @@ export async function PATCH(
   if (coverUrl !== undefined) updates.coverUrl = coverUrl
   if (rejectionReason !== undefined) updates.rejectionReason = rejectionReason
 
-  const updated = await db
-    .update(bookSubmissions)
-    .set(updates)
-    .where(eq(bookSubmissions.id, id))
-    .returning()
+  const updated = await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => {
+      const rows = await tx
+        .update(bookSubmissions)
+        .set(updates)
+        .where(eq(bookSubmissions.id, id))
+        .returning()
+
+      if (rows.length === 0) return rows
+
+      const submission = rows[0]
+      if (submission.status === 'approved') {
+        // Promote (or sync) the approved submission to a row in `books` and
+        // record the submitter's signup via book_id.
+        await publishSubmissionAsBook(
+          {
+            id: submission.id,
+            userId: submission.userId,
+            title: submission.title,
+            author: submission.author,
+            topic: submission.topic,
+            pages: submission.pages,
+            publishedDate: submission.publishedDate,
+            textUrl: submission.textUrl,
+            description: submission.description,
+            coverUrl: submission.coverUrl,
+            whyRead: submission.whyRead,
+          },
+          tx,
+        )
+      }
+      return rows
+    },
+  )
 
   if (updated.length === 0) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
   const submission = updated[0]
-
-  const isApproved = submission.status === 'approved'
-
-  if (isApproved) {
-    // Promote (or sync) the approved submission to a row in `books` and
-    // record the submitter's signup via book_id.
-    await publishSubmissionAsBook({
-      id: submission.id,
-      userId: submission.userId,
-      title: submission.title,
-      author: submission.author,
-      topic: submission.topic,
-      pages: submission.pages,
-      publishedDate: submission.publishedDate,
-      textUrl: submission.textUrl,
-      description: submission.description,
-      coverUrl: submission.coverUrl,
-      whyRead: submission.whyRead,
-    })
-  }
 
   // After Stage 3 finalize: signup_books and book_priorities are joined to
   // `books` by book_id, so a rename of an approved submission's published

--- a/app/api/admin/tag-description/route.test.ts
+++ b/app/api/admin/tag-description/route.test.ts
@@ -18,6 +18,10 @@ jest.mock('@/lib/db', () => ({
     }),
   },
 }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) =>
+    fn((jest.requireMock('@/lib/db') as { db: unknown }).db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 

--- a/app/api/admin/tag-description/route.ts
+++ b/app/api/admin/tag-description/route.ts
@@ -2,9 +2,9 @@ export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
-import { db } from '@/lib/db'
 import { tagDescriptions } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function POST(req: NextRequest) {
   const session = await auth()
@@ -17,14 +17,23 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Missing tag' }, { status: 400 })
   }
 
-  if (!description.trim()) {
-    await db.delete(tagDescriptions).where(eq(tagDescriptions.tag, tag))
-  } else {
-    await db.insert(tagDescriptions).values({ tag, description: description.trim() }).onConflictDoUpdate({
-      target: tagDescriptions.tag,
-      set: { description: description.trim() },
-    })
-  }
+  await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'admin',
+    },
+    async (tx) => {
+      if (!description.trim()) {
+        await tx.delete(tagDescriptions).where(eq(tagDescriptions.tag, tag))
+      } else {
+        await tx.insert(tagDescriptions).values({ tag, description: description.trim() }).onConflictDoUpdate({
+          target: tagDescriptions.tag,
+          set: { description: description.trim() },
+        })
+      }
+    },
+  )
 
   return NextResponse.json({ ok: true })
 }

--- a/app/api/cron/digest/route.test.ts
+++ b/app/api/cron/digest/route.test.ts
@@ -27,6 +27,11 @@ jest.mock('@/lib/db', () => ({
   })(),
 }))
 jest.mock('@/lib/db/schema', () => ({ notificationQueue: {} }))
+// Роут оборачивает мутации в withAuditContext; в тесте подменяем его прямым
+// вызовом fn(mockDb), чтобы tx === замоканный db (его update-цепочка ниже).
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 const mockDbUpdate = db.update as jest.Mock
 const mockDbTransaction = db.transaction as jest.Mock

--- a/app/api/cron/digest/route.ts
+++ b/app/api/cron/digest/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server'
-import { db } from '@/lib/db'
 import { notificationQueue } from '@/lib/db/schema'
 import { and, isNull, isNotNull, lt, inArray } from 'drizzle-orm'
 import { Resend } from 'resend'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
+
+// Cron-мутации очереди уведомлений: actor отсутствует, source='cron'.
+const CRON_AUDIT = { actorUserId: null, source: 'cron' } as const
 
 export async function GET(req: Request) {
   // 1. Authorization
@@ -23,7 +26,7 @@ export async function GET(req: Request) {
 
   // 3. Release stale locks and atomically claim pending rows.
   const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000)
-  const captured = await db.transaction(async (tx) => {
+  const captured = await withAuditContext(CRON_AUDIT, async (tx) => {
     await tx
       .update(notificationQueue)
       .set({ processingAt: null })
@@ -57,10 +60,12 @@ export async function GET(req: Request) {
   const isForcedFlush = oldestCreatedAt < now - 2 * 60 * 60 * 1000
 
   if (isCooling && !isForcedFlush) {
-    await db
-      .update(notificationQueue)
-      .set({ processingAt: null })
-      .where(inArray(notificationQueue.id, capturedIds))
+    await withAuditContext(CRON_AUDIT, async (tx) => {
+      await tx
+        .update(notificationQueue)
+        .set({ processingAt: null })
+        .where(inArray(notificationQueue.id, capturedIds))
+    })
     return NextResponse.json({ skipped: 'cooling' })
   }
 
@@ -91,15 +96,17 @@ export async function GET(req: Request) {
   } catch (err) {
     // 9. On failure: release lock so next cron cycle retries
     console.error('Digest email failed:', err)
-    await db
-      .update(notificationQueue)
-      .set({ processingAt: null })
-      .where(inArray(notificationQueue.id, capturedIds))
+    await withAuditContext(CRON_AUDIT, async (tx) => {
+      await tx
+        .update(notificationQueue)
+        .set({ processingAt: null })
+        .where(inArray(notificationQueue.id, capturedIds))
+    })
     return NextResponse.json({ error: 'Email send failed' }, { status: 500 })
   }
 
   // 10. Mark as sent
-  await db.transaction(async (tx) => {
+  await withAuditContext(CRON_AUDIT, async (tx) => {
     await tx
       .update(notificationQueue)
       .set({ sentAt: new Date(), processingAt: null })

--- a/app/api/feedback/route.test.ts
+++ b/app/api/feedback/route.test.ts
@@ -17,6 +17,9 @@ jest.mock('resend', () => ({
   })),
 }))
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/db', () => ({
   db: {
     insert: jest.fn(),

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Resend } from 'resend'
 import { auth } from '@/lib/auth'
-import { db } from '@/lib/db'
 import { feedback } from '@/lib/db/schema'
 import { bestEffortRecordUserActivity } from '@/lib/user-activity'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function POST(req: NextRequest) {
   const body = await req.json()
@@ -31,12 +31,20 @@ export async function POST(req: NextRequest) {
       subject,
       text,
     })
-    const saved = await db.insert(feedback).values({
-      userId: session?.user?.id ?? null,
-      name: name?.trim() || null,
-      email: email?.trim() || null,
-      message: message.trim(),
-    }).returning({ id: feedback.id, createdAt: feedback.createdAt })
+    const saved = await withAuditContext(
+      {
+        actorUserId: session?.user?.id ?? null,
+        actorLabel: session?.user?.name ?? session?.user?.contactEmail ?? null,
+        source: 'feedback',
+      },
+      async (tx) =>
+        tx.insert(feedback).values({
+          userId: session?.user?.id ?? null,
+          name: name?.trim() || null,
+          email: email?.trim() || null,
+          message: message.trim(),
+        }).returning({ id: feedback.id, createdAt: feedback.createdAt }),
+    )
     if (session?.user?.id && saved[0]) {
       await bestEffortRecordUserActivity(session.user.id, 'feedback_created', {
         occurredAt: saved[0].createdAt,

--- a/app/api/matching/books/[bookId]/route.test.ts
+++ b/app/api/matching/books/[bookId]/route.test.ts
@@ -7,6 +7,9 @@ import { db } from '@/lib/db'
 import * as mutationEffects from '@/lib/matching/mutation-effects'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), delete: jest.fn(), update: jest.fn() } }))
 jest.mock('@/lib/matching/mutation-effects', () => ({
   captureMatchingMutationSnapshot: jest.fn(),

--- a/app/api/matching/books/[bookId]/route.ts
+++ b/app/api/matching/books/[bookId]/route.ts
@@ -10,6 +10,7 @@ import {
   captureMatchingMutationSnapshot,
   finalizeMatchingMutationEffects,
 } from '@/lib/matching/mutation-effects'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 type Params = { params: { bookId: string } }
 
@@ -32,26 +33,35 @@ export async function DELETE(req: NextRequest, { params }: Params) {
   const { bookId } = params
   const before = await captureMatchingMutationSnapshot(activeSession.id)
 
-  await db.delete(signupBooks).where(
-    and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId))
-  )
-  await db.delete(bookPriorities).where(
-    and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, bookId))
-  )
+  await withAuditContext(
+    {
+      actorUserId: session.user.id,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'matching',
+    },
+    async (tx) => {
+      await tx.delete(signupBooks).where(
+        and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId))
+      )
+      await tx.delete(bookPriorities).where(
+        and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, bookId))
+      )
 
-  // Normalize ranks for remaining books
-  const remaining = await db
-    .select({ bookId: bookPriorities.bookId })
-    .from(bookPriorities)
-    .where(eq(bookPriorities.userId, userId))
-    .orderBy(asc(bookPriorities.rank))
+      // Normalize ranks for remaining books
+      const remaining = await tx
+        .select({ bookId: bookPriorities.bookId })
+        .from(bookPriorities)
+        .where(eq(bookPriorities.userId, userId))
+        .orderBy(asc(bookPriorities.rank))
 
-  for (let i = 0; i < remaining.length; i++) {
-    await db
-      .update(bookPriorities)
-      .set({ rank: i + 1 })
-      .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, remaining[i].bookId)))
-  }
+      for (let i = 0; i < remaining.length; i++) {
+        await tx
+          .update(bookPriorities)
+          .set({ rank: i + 1 })
+          .where(and(eq(bookPriorities.userId, userId), eq(bookPriorities.bookId, remaining[i].bookId)))
+      }
+    },
+  )
 
   await finalizeMatchingMutationEffects({
     sessionId: activeSession.id,

--- a/app/api/matching/sessions/[id]/join/route.test.ts
+++ b/app/api/matching/sessions/[id]/join/route.test.ts
@@ -8,6 +8,9 @@ import * as pseudonymsModule from '@/lib/matching/pseudonyms'
 import { consumePseudonymReservation } from '@/lib/matching/pseudonym-reservations'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn() } }))
 jest.mock('@/lib/db/schema', () => ({
   matchingSessions: {},

--- a/app/api/matching/sessions/[id]/join/route.ts
+++ b/app/api/matching/sessions/[id]/join/route.ts
@@ -8,6 +8,7 @@ import { eq, and } from 'drizzle-orm'
 import { assignPseudonym } from '@/lib/matching/pseudonyms'
 import { bumpSessionState } from '@/lib/matching/realtime/version'
 import { consumePseudonymReservation } from '@/lib/matching/pseudonym-reservations'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 interface Params { params: { id: string } }
 
@@ -61,11 +62,19 @@ export async function POST(_req: NextRequest, { params }: Params) {
     ? reserved
     : assignPseudonym(takenSet)
 
-  await db.insert(matchingSessionParticipants).values({
-    sessionId,
-    userId,
-    pseudonym,
-  })
+  await withAuditContext(
+    {
+      actorUserId: userId,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'matching',
+    },
+    async (tx) =>
+      tx.insert(matchingSessionParticipants).values({
+        sessionId,
+        userId,
+        pseudonym,
+      }),
+  )
 
   await bumpSessionState(sessionId)
 

--- a/app/api/priorities/route.test.ts
+++ b/app/api/priorities/route.test.ts
@@ -14,6 +14,9 @@ import { finalizeMatchingMutationEffects } from '@/lib/matching/mutation-effects
 
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }))
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/db', () => ({
   db: {
     select: jest.fn(),

--- a/app/api/priorities/route.ts
+++ b/app/api/priorities/route.ts
@@ -15,6 +15,7 @@ import {
   captureMatchingMutationSnapshot,
   finalizeMatchingMutationEffects,
 } from '@/lib/matching/mutation-effects'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function GET() {
   const session = await auth()
@@ -67,7 +68,9 @@ export async function PUT(req: NextRequest) {
   const activeSessionId = await getActiveMatchingSessionIdForParticipant(userId)
   const before = activeSessionId ? await captureMatchingMutationSnapshot(activeSessionId) : null
 
-  await db.transaction(async (tx) => {
+  await withAuditContext(
+    { actorUserId: userId, actorLabel: session!.user.name ?? session!.user.contactEmail ?? null, source: 'priorities' },
+    async (tx) => {
     await tx
       .delete(bookPriorities)
       .where(eq(bookPriorities.userId, userId))
@@ -87,7 +90,8 @@ export async function PUT(req: NextRequest) {
       .update(users)
       .set({ prioritiesSet: true })
       .where(eq(users.id, userId))
-  })
+    },
+  )
 
   await bestEffortRecordUserActivity(userId, 'priorities_updated', {
     occurredAt: now,

--- a/app/api/profile/route.test.ts
+++ b/app/api/profile/route.test.ts
@@ -7,6 +7,9 @@ import * as authModule from '@/lib/auth'
 import * as activityModule from '@/lib/user-activity'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/user-activity', () => ({
   buildUserActivityDedupeKey: jest.fn(() => 'profile-dedupe-key'),
   bestEffortRecordUserActivity: jest.fn(),

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { bestEffortRecordUserActivity, buildUserActivityDedupeKey, type UserActivityMetadata } from '@/lib/user-activity'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function GET() {
   const session = await auth()
@@ -68,15 +69,22 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: 'No profile fields to update' }, { status: 400 })
   }
 
-  const updated = await db
-    .update(users)
-    .set(updates)
-    .where(eq(users.id, session.user.id))
-    .returning({
-      name: users.name,
-      contacts: users.contacts,
-      languages: users.languages,
-    })
+  const userId = session.user.id
+  const updated = await withAuditContext(
+    { actorUserId: userId, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: 'profile' },
+    async (tx) => {
+      const rows = await tx
+        .update(users)
+        .set(updates)
+        .where(eq(users.id, userId))
+        .returning({
+          name: users.name,
+          contacts: users.contacts,
+          languages: users.languages,
+        })
+      return rows
+    },
+  )
 
   if (updated.length === 0) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })

--- a/app/api/signup-books/[bookId]/status/route.test.ts
+++ b/app/api/signup-books/[bookId]/status/route.test.ts
@@ -10,6 +10,9 @@ import {
 } from '@/lib/matching/realtime/state-change'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), update: jest.fn() } }))
 jest.mock('@/lib/db/schema', () => ({
   signupBooks: {},

--- a/app/api/signup-books/[bookId]/status/route.ts
+++ b/app/api/signup-books/[bookId]/status/route.ts
@@ -13,6 +13,7 @@ import {
   captureMatchingMutationSnapshot,
   finalizeMatchingMutationEffects,
 } from '@/lib/matching/mutation-effects'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 const VALID_STATUSES = new Set(['reading', 'read'])
 
@@ -52,10 +53,16 @@ export async function PATCH(
     return NextResponse.json({ error: 'Not signed up for this book' }, { status: 404 })
   }
 
-  await db
-    .update(signupBooks)
-    .set({ personalStatus: status ?? null, personalStatusUpdatedAt: new Date() })
-    .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
+  const actorId = session.user.id
+  await withAuditContext(
+    { actorUserId: actorId, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: asUserId ? 'admin' : 'catalog' },
+    async (tx) => {
+      await tx
+        .update(signupBooks)
+        .set({ personalStatus: status ?? null, personalStatusUpdatedAt: new Date() })
+        .where(and(eq(signupBooks.userId, userId), eq(signupBooks.bookId, bookId)))
+    },
+  )
 
   if (activeSessionId) {
     await finalizeMatchingMutationEffects({

--- a/app/api/signup/route.test.ts
+++ b/app/api/signup/route.test.ts
@@ -14,6 +14,9 @@ import {
 import { finalizeMatchingMutationEffects } from '@/lib/matching/mutation-effects'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/signup-books', () => ({ upsertSignupByBookIds: jest.fn() }))
 jest.mock('@/lib/db', () => ({
   db: {
@@ -127,7 +130,7 @@ describe('POST /api/signup', () => {
 
     expect(res.status).toBe(200)
     expect(data.ok).toBe(true)
-    expect(signups.upsertSignupByBookIds).toHaveBeenCalledWith('user-1', ['book-a'])
+    expect(signups.upsertSignupByBookIds).toHaveBeenCalledWith('user-1', ['book-a'], expect.anything())
     expect(mockRecordUserActivity).toHaveBeenCalledWith('user-1', 'profile_submitted', expect.objectContaining({
       source: 'api',
       metadata: expect.objectContaining({ selectedBooksCount: 1, addedBooksCount: 1 }),
@@ -175,7 +178,7 @@ describe('POST /api/signup', () => {
 
     await POST(makeRequest({ name: '  Test User  ', contacts: '  @test  ', selectedBookIds: [] }))
 
-    expect(signups.upsertSignupByBookIds).toHaveBeenCalledWith('user-1', [])
+    expect(signups.upsertSignupByBookIds).toHaveBeenCalledWith('user-1', [], expect.anything())
     expect(mockRecordUserActivity).toHaveBeenCalledWith('user-1', 'profile_submitted', expect.any(Object))
   })
 

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 import { upsertSignupByBookIds } from '@/lib/signup-books'
-import { db } from '@/lib/db'
 import { bookPriorities, notificationQueue, users } from '@/lib/db/schema'
 import { and, eq, notInArray } from 'drizzle-orm'
 import { bestEffortRecordUserActivity, buildUserActivityDedupeKey } from '@/lib/user-activity'
@@ -14,6 +13,7 @@ import {
   captureMatchingMutationSnapshot,
   finalizeMatchingMutationEffects,
 } from '@/lib/matching/mutation-effects'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function POST(req: NextRequest) {
   const session = await auth()
@@ -32,35 +32,43 @@ export async function POST(req: NextRequest) {
   const activeSessionId = await getActiveMatchingSessionIdForParticipant(pgUserId)
   const before = activeSessionId ? await captureMatchingMutationSnapshot(activeSessionId) : null
 
-  let result
-  try {
-    result = await upsertSignupByBookIds(pgUserId, selectedBookIds as string[])
-  } catch {
-    return NextResponse.json({ error: 'Some books were not found' }, { status: 400 })
+  const auditCtx = {
+    actorUserId: pgUserId,
+    actorLabel: session!.user.name ?? session!.user.contactEmail ?? null,
+    source: 'signup',
   }
 
-  await db.update(users).set({
-    name: name.trim(),
-    contacts: contacts.trim(),
-    ...(result.addedBookIds.length === 0 ? { prioritiesSet: false } : {}),
-  }).where(eq(users.id, pgUserId))
+  let result
+  try {
+    result = await withAuditContext(auditCtx, async (tx) => {
+      const upsert = await upsertSignupByBookIds(pgUserId, selectedBookIds as string[], tx)
 
-  // Clean up book_priorities for books no longer in selectedBookIds.
-  if (result.addedBookIds.length > 0) {
-    await db
-      .delete(bookPriorities)
-      .where(
-        and(
-          eq(bookPriorities.userId, pgUserId),
-          notInArray(bookPriorities.bookId, result.addedBookIds)
-        )
-      )
-      .catch(() => {}) // non-critical
-  } else {
-    await db
-      .delete(bookPriorities)
-      .where(eq(bookPriorities.userId, pgUserId))
-      .catch(() => {})
+      await tx.update(users).set({
+        name: name.trim(),
+        contacts: contacts.trim(),
+        ...(upsert.addedBookIds.length === 0 ? { prioritiesSet: false } : {}),
+      }).where(eq(users.id, pgUserId))
+
+      // Clean up book_priorities for books no longer in selectedBookIds.
+      if (upsert.addedBookIds.length > 0) {
+        await tx
+          .delete(bookPriorities)
+          .where(
+            and(
+              eq(bookPriorities.userId, pgUserId),
+              notInArray(bookPriorities.bookId, upsert.addedBookIds)
+            )
+          )
+      } else {
+        await tx
+          .delete(bookPriorities)
+          .where(eq(bookPriorities.userId, pgUserId))
+      }
+
+      return upsert
+    })
+  } catch {
+    return NextResponse.json({ error: 'Some books were not found' }, { status: 400 })
   }
 
   const profileDedupeKey = buildUserActivityDedupeKey([
@@ -95,13 +103,15 @@ export async function POST(req: NextRequest) {
 
   // Enqueue notification for digest (skip in test mode — tests use the real DB)
   if (result.addedBooks.length > 0 && process.env.NEXTAUTH_TEST_MODE !== 'true') {
-    db.insert(notificationQueue).values({
-      userName: name.trim(),
-      userEmail: getUserContactEmail(session.user) ?? '',
-      contacts: contacts.trim(),
-      addedBooks: JSON.stringify(result.addedBooks),
-      isNew: result.isNew,
-    }).catch(() => {
+    withAuditContext(auditCtx, async (tx) =>
+      tx.insert(notificationQueue).values({
+        userName: name.trim(),
+        userEmail: getUserContactEmail(session.user) ?? '',
+        contacts: contacts.trim(),
+        addedBooks: JSON.stringify(result.addedBooks),
+        isNew: result.isNew,
+      }),
+    ).catch(() => {
       console.error('Failed to enqueue signup notification')
     })
   }

--- a/app/api/submissions/[id]/route.test.ts
+++ b/app/api/submissions/[id]/route.test.ts
@@ -6,6 +6,9 @@ import { DELETE } from './route'
 import * as authModule from '@/lib/auth'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 const mockDelete = jest.fn()
 

--- a/app/api/submissions/[id]/route.ts
+++ b/app/api/submissions/[id]/route.ts
@@ -2,9 +2,9 @@ export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
-import { db } from '@/lib/db'
 import { bookSubmissions } from '@/lib/db/schema'
 import { and, eq } from 'drizzle-orm'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function DELETE(
   _req: NextRequest,
@@ -15,10 +15,17 @@ export async function DELETE(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const deleted = await db
-    .delete(bookSubmissions)
-    .where(and(eq(bookSubmissions.id, params.id), eq(bookSubmissions.userId, session.user.id)))
-    .returning()
+  const userId = session.user.id
+  const deleted = await withAuditContext(
+    { actorUserId: userId, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: 'submission' },
+    async (tx) => {
+      const rows = await tx
+        .delete(bookSubmissions)
+        .where(and(eq(bookSubmissions.id, params.id), eq(bookSubmissions.userId, userId)))
+        .returning()
+      return rows
+    },
+  )
 
   if (deleted.length === 0) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/app/api/submissions/route.test.ts
+++ b/app/api/submissions/route.test.ts
@@ -7,6 +7,9 @@ import * as authModule from '@/lib/auth'
 import * as activityModule from '@/lib/user-activity'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/db', () => ({
   db: {
     insert: jest.fn().mockReturnValue({

--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { bookSubmissions } from '@/lib/db/schema'
 import { eq, desc } from 'drizzle-orm'
 import { bestEffortRecordUserActivity } from '@/lib/user-activity'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function GET() {
   const session = await auth()
@@ -28,6 +29,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  // Захватываем в const до замыкания: внутри async (tx) => {} TS теряет
+  // сужение property-доступа session.user.id и снова считает его string|undefined.
+  const userId = session.user.id
+
   const body = await req.json()
   const { title, author, whyRead, topic, pages, publishedDate, textUrl, description, coverUrl } = body
 
@@ -41,18 +46,28 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'whyRead is required' }, { status: 400 })
   }
 
-  const result = await db.insert(bookSubmissions).values({
-    userId: session.user.id,
-    title,
-    author,
-    whyRead,
-    topic: topic ?? null,
-    pages: pages ?? null,
-    publishedDate: publishedDate ?? null,
-    textUrl: textUrl ?? null,
-    description: description ?? null,
-    coverUrl: coverUrl ?? null,
-  }).returning()
+  const result = await withAuditContext(
+    {
+      actorUserId: userId,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'submission',
+    },
+    async (tx) => {
+      const rows = await tx.insert(bookSubmissions).values({
+        userId,
+        title,
+        author,
+        whyRead,
+        topic: topic ?? null,
+        pages: pages ?? null,
+        publishedDate: publishedDate ?? null,
+        textUrl: textUrl ?? null,
+        description: description ?? null,
+        coverUrl: coverUrl ?? null,
+      }).returning()
+      return rows
+    },
+  )
 
   await bestEffortRecordUserActivity(session.user.id, 'submission_created', {
     occurredAt: result[0].createdAt,

--- a/app/api/user/route.test.ts
+++ b/app/api/user/route.test.ts
@@ -5,6 +5,9 @@ import { DELETE } from './route'
 import * as authModule from '@/lib/auth'
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/db', () => ({
   db: {
     select: jest.fn(),

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { notificationQueue, users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { deletePostHogPerson } from '@/lib/posthog-server'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function DELETE() {
   const session = await auth()
@@ -20,13 +21,21 @@ export async function DELETE() {
     .where(eq(users.id, userId))
     .limit(1)
 
-  if (targetUser?.contactEmail) {
-    await db
-      .delete(notificationQueue)
-      .where(eq(notificationQueue.userEmail, targetUser.contactEmail))
-  }
-
-  await db.delete(users).where(eq(users.id, userId))
+  await withAuditContext(
+    {
+      actorUserId: userId,
+      actorLabel: session.user.name ?? session.user.contactEmail ?? null,
+      source: 'profile',
+    },
+    async (tx) => {
+      if (targetUser?.contactEmail) {
+        await tx
+          .delete(notificationQueue)
+          .where(eq(notificationQueue.userEmail, targetUser.contactEmail))
+      }
+      await tx.delete(users).where(eq(users.id, userId))
+    },
+  )
   await deletePostHogPerson(userId)
 
   return NextResponse.json({ ok: true })

--- a/e2e/audit-reconciliation.spec.ts
+++ b/e2e/audit-reconciliation.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from './fixtures'
+import { epic, feature } from 'allure-js-commons'
+
+const ADMIN_EMAIL = 'e2e-auditrecon-admin@test.invalid'
+const ADMIN_NAME = 'E2E Audit Recon Admin'
+
+// Reconciliation: проверяем, что мутация через обёрнутый роут получает реального
+// actor (source != 'trigger'). Если бы роут забыли обернуть в withAuditContext,
+// триггер выставил бы source='trigger' — и этот тест бы упал, сигнализируя дрейф.
+test.describe('Reconciliation аудита', () => {
+  test.setTimeout(120_000)
+
+  test.beforeEach(async () => {
+    await epic('Администрирование')
+    await feature('Журнал аудита')
+  })
+
+  test.afterEach(async ({ page }) => {
+    await page.request.delete('/api/test/session', { data: { email: ADMIN_EMAIL } })
+  })
+
+  test('обёрнутая мутация пишет реального actor, а не source=trigger', async ({
+    page,
+    createTestBook,
+    dbExec,
+  }) => {
+    await page.request.post('/api/test/session', {
+      data: { email: ADMIN_EMAIL, name: ADMIN_NAME, isAdmin: true },
+    })
+
+    const book = await createTestBook({ visibility: 'draft' })
+    // audit_log append-only и не чистится фикстурой книги — убираем записи зонда сами
+    dbExec.registerCleanup(`DELETE FROM "audit_log" WHERE entity_id = $1`, [book.id])
+
+    const patchRes = await page.request.patch(
+      `/api/admin/books/${encodeURIComponent(book.id)}`,
+      { data: { visibility: 'published' } },
+    )
+    expect(patchRes.ok(), `PATCH должен вернуть 2xx, получили ${patchRes.status()}`).toBe(true)
+
+    const rows = await dbExec(
+      `SELECT source, actor_user_id FROM "audit_log"
+       WHERE entity_id = $1 AND action = 'update'
+       ORDER BY occurred_at DESC LIMIT 1`,
+      [book.id],
+    )
+
+    expect(rows.length).toBe(1)
+    expect(rows[0].source).toBe('admin')
+    expect(rows[0].source).not.toBe('trigger')
+    expect(rows[0].actor_user_id).toBeTruthy()
+  })
+})

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -96,7 +96,7 @@ interface DbExecHelper {
    * Cleanup callbacks registered via `registerCleanup` run in LIFO order
    * in teardown — even when the test body fails.
    */
-  (sql: string, params?: unknown[]): Promise<void>
+  (sql: string, params?: unknown[]): Promise<Record<string, unknown>[]>
   registerCleanup: (cleanupSql: string, params?: unknown[]) => void
 }
 
@@ -181,7 +181,8 @@ export const test = base.extend<E2EHelpers>({
     const cleanups: Array<{ sql: string; params?: unknown[] }> = []
 
     const exec = async (sql: string, params?: unknown[]) => {
-      await pool.query(sql, params as unknown[] | undefined)
+      const res = await pool.query(sql, params as unknown[] | undefined)
+      return res.rows as Record<string, unknown>[]
     }
     exec.registerCleanup = (sql: string, params?: unknown[]) => {
       cleanups.push({ sql, params })

--- a/lib/audit/audited-tables.ts
+++ b/lib/audit/audited-tables.ts
@@ -22,3 +22,8 @@ export const AUDITED_TABLES = [
 ] as const
 
 export type AuditedTable = (typeof AUDITED_TABLES)[number]
+
+// Таблицы, для которых source='trigger' — НЕ сигнал «забыли обернуть»:
+// их пишет NextAuth DrizzleAdapter / auth-цепочка мимо нашего кода (lib/auth.ts,
+// lib/telegram-auth.ts, lib/user-identities.ts). Reconciliation-проверка их игнорирует.
+export const AUTH_OOB_TABLES = ['verificationToken', 'user', 'user_identities'] as const

--- a/lib/book-publish.ts
+++ b/lib/book-publish.ts
@@ -3,6 +3,8 @@ import { books, bookSubmissions } from '@/lib/db/schema'
 import { eq, sql } from 'drizzle-orm'
 import crypto from 'node:crypto'
 
+type DbClient = typeof db
+
 interface SubmissionForPublish {
   id: string
   userId: string
@@ -24,9 +26,12 @@ interface SubmissionForPublish {
  *
  * Also writes the submission author into signup_books via book_id.
  */
-export async function publishSubmissionAsBook(submission: SubmissionForPublish): Promise<string> {
+export async function publishSubmissionAsBook(
+  submission: SubmissionForPublish,
+  dbClient: DbClient = db,
+): Promise<string> {
   // Already linked?
-  const [existing] = await db
+  const [existing] = await dbClient
     .select({ bookId: bookSubmissions.bookId })
     .from(bookSubmissions)
     .where(eq(bookSubmissions.id, submission.id))
@@ -36,7 +41,7 @@ export async function publishSubmissionAsBook(submission: SubmissionForPublish):
   if (existing?.bookId) {
     bookId = existing.bookId
     // Sync title/author/etc. so the catalog reflects post-approval edits.
-    await db
+    await dbClient
       .update(books)
       .set({
         title: submission.title,
@@ -54,7 +59,7 @@ export async function publishSubmissionAsBook(submission: SubmissionForPublish):
   } else {
     bookId = crypto.randomUUID()
     const now = new Date()
-    await db.insert(books).values({
+    await dbClient.insert(books).values({
       id: bookId,
       title: submission.title,
       author: submission.author,
@@ -78,14 +83,14 @@ export async function publishSubmissionAsBook(submission: SubmissionForPublish):
     })
   }
 
-  await db
+  await dbClient
     .update(bookSubmissions)
     .set({ bookId })
     .where(eq(bookSubmissions.id, submission.id))
 
   // Sign up the submitter when the author account still exists.
   // Admin approval should not fail if a test or deleted account removed it first.
-  await db.execute(sql`
+  await dbClient.execute(sql`
     INSERT INTO signup_books (user_id, book_id)
     SELECT ${submission.userId}, ${bookId}
     WHERE EXISTS (SELECT 1 FROM "user" WHERE id = ${submission.userId})

--- a/lib/books.ts
+++ b/lib/books.ts
@@ -123,8 +123,8 @@ export async function fetchBooksForAdmin(): Promise<BookWithCover[]> {
   return loadBooks({ includeHidden: true })
 }
 
-export async function fetchBookById(id: string): Promise<BookWithCover | null> {
-  const [row] = await db.select().from(books).where(eq(books.id, id)).limit(1)
+export async function fetchBookById(id: string, dbClient: typeof db = db): Promise<BookWithCover | null> {
+  const [row] = await dbClient.select().from(books).where(eq(books.id, id)).limit(1)
   return row ? rowToBook(row) : null
 }
 
@@ -169,7 +169,7 @@ export interface CreateBookInput {
   sortOrder?: number
 }
 
-export async function createBook(input: CreateBookInput): Promise<BookWithCover> {
+export async function createBook(input: CreateBookInput, dbClient: typeof db = db): Promise<BookWithCover> {
   const title = (input.title ?? '').trim()
   if (!title) throw new BookValidationError('title is required')
 
@@ -188,7 +188,7 @@ export async function createBook(input: CreateBookInput): Promise<BookWithCover>
 
   const id = crypto.randomUUID()
   const now = new Date()
-  await db.insert(books).values({
+  await dbClient.insert(books).values({
     id,
     title,
     author,
@@ -212,7 +212,7 @@ export async function createBook(input: CreateBookInput): Promise<BookWithCover>
     hiddenAt: visibility === 'hidden' ? now : null,
   })
 
-  const created = await fetchBookById(id)
+  const created = await fetchBookById(id, dbClient)
   if (!created) throw new Error('Failed to load created book')
   return created
 }

--- a/lib/intro.ts
+++ b/lib/intro.ts
@@ -87,11 +87,11 @@ export interface SectionPatch {
   isPublished?: boolean
 }
 
-export async function updateSections(patches: SectionPatch[]) {
+export async function updateSections(patches: SectionPatch[], dbClient: typeof db = db) {
   await ensureIntroTable()
   if (patches.length === 0) return
   const ids = patches.map(p => p.id)
-  const rows = await db
+  const rows = await dbClient
     .select({ id: introSections.id, kind: introSections.kind })
     .from(introSections)
   const kindById = new Map(rows.filter(r => ids.includes(r.id)).map(r => [r.id, r.kind]))
@@ -107,18 +107,18 @@ export async function updateSections(patches: SectionPatch[]) {
       if (p.sortOrder !== undefined) set.sortOrder = p.sortOrder
       if (p.isPublished !== undefined) set.isPublished = p.isPublished
     }
-    await db.update(introSections).set(set).where(eq(introSections.id, p.id))
+    await dbClient.update(introSections).set(set).where(eq(introSections.id, p.id))
   }
 }
 
-export async function createSection(): Promise<IntroSection> {
+export async function createSection(dbClient: typeof db = db): Promise<IntroSection> {
   await ensureIntroTable()
-  const existing = await db
+  const existing = await dbClient
     .select({ sortOrder: introSections.sortOrder })
     .from(introSections)
     .where(eq(introSections.kind, 'section'))
   const maxOrder = existing.reduce((m, r) => Math.max(m, r.sortOrder), -1)
-  const [row] = await db
+  const [row] = await dbClient
     .insert(introSections)
     .values({
       kind: 'section',
@@ -137,15 +137,15 @@ export async function createSection(): Promise<IntroSection> {
   }
 }
 
-export async function deleteSection(id: string): Promise<{ ok: boolean; reason?: string }> {
+export async function deleteSection(id: string, dbClient: typeof db = db): Promise<{ ok: boolean; reason?: string }> {
   await ensureIntroTable()
-  const [row] = await db
+  const [row] = await dbClient
     .select({ kind: introSections.kind })
     .from(introSections)
     .where(eq(introSections.id, id))
     .limit(1)
   if (!row) return { ok: false, reason: 'not_found' }
   if (row.kind !== 'section') return { ok: false, reason: 'header_protected' }
-  await db.delete(introSections).where(eq(introSections.id, id))
+  await dbClient.delete(introSections).where(eq(introSections.id, id))
   return { ok: true }
 }

--- a/lib/signup-books.ts
+++ b/lib/signup-books.ts
@@ -114,7 +114,11 @@ async function resolveBooksByIds(bookIds: string[]): Promise<SignupBookInput[]> 
   return resolved
 }
 
-async function upsertResolvedSignup(userId: string, selectedBooks: SignupBookInput[]): Promise<UpsertResult> {
+async function upsertResolvedSignup(
+  userId: string,
+  selectedBooks: SignupBookInput[],
+  dbClient: typeof db = db,
+): Promise<UpsertResult> {
   const unique = new Map<string, SignupBookInput>()
   for (const book of selectedBooks) unique.set(book.id, book)
   const normalized = Array.from(unique.values())
@@ -123,7 +127,7 @@ async function upsertResolvedSignup(userId: string, selectedBooks: SignupBookInp
   let newlyAddedBookIds: string[] = []
   let removedBookIds: string[] = []
 
-  await db.transaction(async (tx) => {
+  const runInTx = async (tx: typeof db) => {
     // Fetch current signups to determine what changed
     const existing = await tx
       .select({ bookId: signupBooks.bookId })
@@ -150,7 +154,19 @@ async function upsertResolvedSignup(userId: string, selectedBooks: SignupBookInp
         .values(toAdd.map(bookId => ({ userId, bookId })))
         .onConflictDoNothing()
     }
-  })
+  }
+
+  // When a transactional dbClient is supplied (e.g. from withAuditContext on
+  // the caller), run inside it so the audit context is attached. Otherwise open
+  // our own transaction to keep the delete/insert atomic.
+  if (dbClient === db) {
+    // Атомарность delete+insert, когда вызывают без транзакционного клиента
+    // (сейчас — только exempt тест-эндпоинт; рабочие роуты передают tx из withAuditContext).
+    // eslint-disable-next-line no-restricted-syntax -- см. комментарий выше
+    await db.transaction(async (tx) => runInTx(tx as unknown as typeof db))
+  } else {
+    await runInTx(dbClient)
+  }
 
   return {
     isNew: false,
@@ -161,8 +177,12 @@ async function upsertResolvedSignup(userId: string, selectedBooks: SignupBookInp
   }
 }
 
-export async function upsertSignupByBookIds(userId: string, bookIds: string[]): Promise<UpsertResult> {
-  return upsertResolvedSignup(userId, await resolveBooksByIds(bookIds))
+export async function upsertSignupByBookIds(
+  userId: string,
+  bookIds: string[],
+  dbClient: typeof db = db,
+): Promise<UpsertResult> {
+  return upsertResolvedSignup(userId, await resolveBooksByIds(bookIds), dbClient)
 }
 
 export async function removeBookFromSignup(


### PR DESCRIPTION
## Site-wide audit log — actor-атрибуция + enforcement (PR 2/2)

Вторая часть [#346](https://github.com/bon2362/book-club/pull/346). Триггеры уже ловят все мутации; этот PR проставляет реального **actor** (кто/откуда) вместо `source='trigger'` и ставит защиту от будущего дрейфа.

### Что сделано
- **Обёрнуты в `withAuditContext`** мутирующие роуты: admin (books CRUD/reorder, submissions approve, tag-description, delete-user, signup-books, intro), пользовательские (signup, priorities, submissions create/delete, feedback, profile, signup-books status, удаление профиля), cron-digest (`source='cron'`). Хелперы (`lib/books`, `lib/intro`, `lib/book-publish`, `lib/signup-books`) получили опциональный `dbClient`, мутации идут через `tx` вызывающего.
- **ESLint-правило** `no-restricted-syntax` против сырых `db.transaction/insert/update/delete` вне `lib/audit`/`lib/db`/тестов/скриптов — забыть обернуть новый роут теперь = красный CI.
- **AUTH_OOB_TABLES** — auth-таблицы (`verificationToken`, `user`, `user_identities`) легитимно остаются `source='trigger'` (их пишет NextAuth-адаптер мимо кода).

### Сознательно вне охвата (исключены из правила)
- **Matching** (`app/api/matching/**`, `app/api/admin/matching/**`, `lib/matching/**`) — у матчинга уже есть свой actor-aware журнал `matching_preference_events` (через `recordMatchingPreferenceEvent`); в `audit_log` его мутации всё равно попадают через триггеры. Обёртка всех session-lifecycle роутов = риск без выгоды.
- **`lib/auth-adapter.ts`, auth-цепочка** — пишет фреймворк, не наш код.
- **`lib/user-activity.ts`** — сам по себе лог активности, fire-and-forget, вызывается повсеместно.

Если захочется обернуть и matching-роуты — отдельный PR #3 (механизм готов, дело в объёме).

### Тесты
- Unit: обновлены моки задетых роутов (мок `withAuditContext`), все зелёные; typecheck/lint чисто.
- e2e: `audit-log` (персистентность + out-of-band), новый `audit-reconciliation` (обёрнутая мутация → `source='admin'`, не `trigger`), `telegram-auth` (логин не сломан) — 5/5 локально на изолированной Neon-ветке.

### Прод
Схема НЕ меняется (миграции 0039/0040 уже на проде) — после мержа только деплой кода.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
