### PR TITLE
feat(audit): actor для matching-мутаций (3/3)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,9 +31,7 @@
         "lib/user-identities.ts",
         "lib/auth-adapter.ts",
         "lib/user-activity.ts",
-        "lib/matching/**",
-        "app/api/matching/**",
-        "app/api/admin/matching/**"
+        "lib/matching/pseudonym-reservations.ts"
       ],
       "rules": { "no-restricted-syntax": "off" }
     }

--- a/app/api/admin/matching/sessions/[id]/participants/[userId]/route.test.ts
+++ b/app/api/admin/matching/sessions/[id]/participants/[userId]/route.test.ts
@@ -12,6 +12,9 @@ jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
 jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), delete: jest.fn() } }))
 jest.mock('@/lib/matching/preference-events', () => ({ recordParticipantLeftEvent: jest.fn() }))
 jest.mock('@/lib/matching/realtime/version', () => ({ bumpSessionState: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockDb = db as jest.Mocked<typeof db>

--- a/app/api/admin/matching/sessions/[id]/participants/[userId]/route.ts
+++ b/app/api/admin/matching/sessions/[id]/participants/[userId]/route.ts
@@ -7,6 +7,7 @@ import { matchingSessions, matchingSessionParticipants } from '@/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { bumpSessionState } from '@/lib/matching/realtime/version'
 import { recordParticipantLeftEvent } from '@/lib/matching/preference-events'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 interface Params { params: { id: string; userId: string } }
 
@@ -40,14 +41,19 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
     source: 'admin',
   }).catch(() => {}) // analytics must never block the removal
 
-  await db
-    .delete(matchingSessionParticipants)
-    .where(
-      and(
-        eq(matchingSessionParticipants.sessionId, sessionId),
-        eq(matchingSessionParticipants.userId, userId),
-      ),
-    )
+  await withAuditContext(
+    { actorUserId: adminId, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: 'admin' },
+    async (tx) => {
+      await tx
+        .delete(matchingSessionParticipants)
+        .where(
+          and(
+            eq(matchingSessionParticipants.sessionId, sessionId),
+            eq(matchingSessionParticipants.userId, userId),
+          ),
+        )
+    },
+  )
 
   await bumpSessionState(sessionId)
 

--- a/app/api/matching/books/route.test.ts
+++ b/app/api/matching/books/route.test.ts
@@ -14,6 +14,9 @@ jest.mock('@/lib/matching/mutation-effects', () => ({
   finalizeMatchingMutationEffects: jest.fn(),
 }))
 jest.mock('@/lib/matching/realtime/version', () => ({ bumpSessionState: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 jest.mock('@/lib/db/schema', () => ({
   matchingSessions: {},
   signupBooks: {},

--- a/app/api/matching/books/route.ts
+++ b/app/api/matching/books/route.ts
@@ -10,6 +10,7 @@ import {
   captureMatchingMutationSnapshot,
   finalizeMatchingMutationEffects,
 } from '@/lib/matching/mutation-effects'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 export async function POST(req: NextRequest) {
   const session = await auth()
@@ -33,46 +34,56 @@ export async function POST(req: NextRequest) {
 
   const before = await captureMatchingMutationSnapshot(activeSession.id)
 
-  await db
-    .insert(signupBooks)
-    .values({ userId, bookId })
-    .onConflictDoNothing()
+  const actorId = session.user.id
+  const actorLabel = session.user.name ?? session.user.contactEmail ?? null
+  const auditSource = asUserId ? 'admin' : 'matching'
 
-  const currentOrder = await db
-    .select({ bookId: bookPriorities.bookId })
-    .from(bookPriorities)
-    .where(eq(bookPriorities.userId, userId))
-    .orderBy(asc(bookPriorities.rank))
+  await withAuditContext(
+    { actorUserId: actorId, actorLabel, source: auditSource },
+    async (tx) => {
+      await tx
+        .insert(signupBooks)
+        .values({ userId, bookId })
+        .onConflictDoNothing()
 
-  const nextOrder = [
-    bookId,
-    ...currentOrder
-      .map((row) => row.bookId)
-      .filter((existingBookId) => existingBookId !== bookId),
-  ]
+      const rows = await tx
+        .select({ bookId: bookPriorities.bookId })
+        .from(bookPriorities)
+        .where(eq(bookPriorities.userId, userId))
+        .orderBy(asc(bookPriorities.rank))
 
-  for (let i = 0; i < nextOrder.length; i++) {
-    await db
-      .insert(bookPriorities)
-      .values({ userId, bookId: nextOrder[i], rank: i + 1 })
-      .onConflictDoUpdate({
-        target: [bookPriorities.userId, bookPriorities.bookId],
-        set: { rank: i + 1, updatedAt: new Date() },
-      })
-  }
+      const nextOrder = [
+        bookId,
+        ...rows
+          .map((row) => row.bookId)
+          .filter((existingBookId) => existingBookId !== bookId),
+      ]
 
-  await db
-    .update(users)
-    .set({ prioritiesSet: true })
-    .where(eq(users.id, userId))
+      for (let i = 0; i < nextOrder.length; i++) {
+        await tx
+          .insert(bookPriorities)
+          .values({ userId, bookId: nextOrder[i], rank: i + 1 })
+          .onConflictDoUpdate({
+            target: [bookPriorities.userId, bookPriorities.bookId],
+            set: { rank: i + 1, updatedAt: new Date() },
+          })
+      }
+
+      await tx
+        .update(users)
+        .set({ prioritiesSet: true })
+        .where(eq(users.id, userId))
+
+    },
+  )
 
   await finalizeMatchingMutationEffects({
     sessionId: activeSession.id,
     targetUserId: userId,
-    actorUserId: session.user.id,
+    actorUserId: actorId,
     bookId,
     kind: 'book_added',
-    source: asUserId ? 'admin' : 'matching',
+    source: auditSource,
     before,
   })
   await bumpSessionState(activeSession.id)

--- a/app/api/matching/priorities/route.test.ts
+++ b/app/api/matching/priorities/route.test.ts
@@ -18,6 +18,9 @@ jest.mock('@/lib/matching/mutation-effects', () => ({
   captureMatchingMutationSnapshot: jest.fn().mockResolvedValue(null),
   finalizeMatchingMutationEffects: jest.fn(),
 }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockDb = db as jest.Mocked<typeof db>
@@ -164,7 +167,7 @@ describe('PATCH /api/matching/priorities', () => {
         targetUserId: 'participant1',
         actorUserId: 'admin1',
         kind: 'priorities_updated',
-        source: 'matching',
+        source: 'admin',
       }),
     )
   })

--- a/app/api/matching/priorities/route.ts
+++ b/app/api/matching/priorities/route.ts
@@ -10,6 +10,7 @@ import {
   captureMatchingMutationSnapshot,
   finalizeMatchingMutationEffects,
 } from '@/lib/matching/mutation-effects'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 const prioritySources = ['matching', 'matching_priority_gate'] as const
 type PrioritySource = typeof prioritySources[number]
@@ -42,25 +43,33 @@ export async function PATCH(req: NextRequest) {
 
   const userId = asUserId ?? session.user.id
   const ordered = bookIds as string[]
+  const actorId = session.user.id
+  const actorLabel = session.user.name ?? session.user.contactEmail ?? null
+  const auditSource = asUserId ? 'admin' : source
 
   // Snapshot the leader scenario before the change so analytics can show impact.
   const before = await captureMatchingMutationSnapshot(activeSession.id)
 
   // Upsert each book with its new rank (1-indexed position)
-  for (let i = 0; i < ordered.length; i++) {
-    await db
-      .insert(bookPriorities)
-      .values({ userId, bookId: ordered[i], rank: i + 1 })
-      .onConflictDoUpdate({
-        target: [bookPriorities.userId, bookPriorities.bookId],
-        set: { rank: i + 1, updatedAt: new Date() },
-      })
-  }
+  await withAuditContext(
+    { actorUserId: actorId, actorLabel, source: auditSource },
+    async (tx) => {
+      for (let i = 0; i < ordered.length; i++) {
+        await tx
+          .insert(bookPriorities)
+          .values({ userId, bookId: ordered[i], rank: i + 1 })
+          .onConflictDoUpdate({
+            target: [bookPriorities.userId, bookPriorities.bookId],
+            set: { rank: i + 1, updatedAt: new Date() },
+          })
+      }
 
-  await db
-    .update(users)
-    .set({ prioritiesSet: true })
-    .where(eq(users.id, userId))
+      await tx
+        .update(users)
+        .set({ prioritiesSet: true })
+        .where(eq(users.id, userId))
+    },
+  )
 
   // Return canonical order so client can reconcile
   const canonical = await db
@@ -74,10 +83,10 @@ export async function PATCH(req: NextRequest) {
   await finalizeMatchingMutationEffects({
     sessionId: activeSession.id,
     targetUserId: userId,
-    actorUserId: session.user.id,
+    actorUserId: actorId,
     bookId: null,
     kind: 'priorities_updated',
-    source,
+    source: auditSource,
     before,
     metadata: { rankedBookIds: ordered },
   })

--- a/app/api/matching/sessions/[id]/freeze/route.test.ts
+++ b/app/api/matching/sessions/[id]/freeze/route.test.ts
@@ -27,6 +27,9 @@ jest.mock('@/lib/matching/scenarios', () => ({
   }),
 }))
 jest.mock('@/lib/matching/realtime/version', () => ({ bumpSessionState: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockDb = db as jest.Mocked<typeof db>

--- a/app/api/matching/sessions/[id]/freeze/route.ts
+++ b/app/api/matching/sessions/[id]/freeze/route.ts
@@ -13,12 +13,14 @@ import {
 import { eq, inArray, and } from 'drizzle-orm'
 import { filterSignupsByMode, generateScenarioSets, type OptimizationMode } from '@/lib/matching/scenarios'
 import { bumpSessionState } from '@/lib/matching/realtime/version'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 type Params = { params: { id: string } }
 
 export async function POST(_req: NextRequest, { params }: Params) {
   const session = await auth()
-  if (!session?.user?.isAdmin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  if (!session?.user?.isAdmin || !session.user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  const actorId = session.user.id
 
   const [matchSession] = await db
     .select()
@@ -89,19 +91,24 @@ export async function POST(_req: NextRequest, { params }: Params) {
     ? leader.circles.reduce((sum, circle) => sum + circle.wantsCount, 0) / Math.max(leader.score.coveredCount, 1)
     : 0
 
-  await db
-    .update(matchingSessions)
-    .set({
-      status: 'frozen',
-      frozenAt,
-      frozenScenarioJson: leader ?? null,
-      metricGroupsCount,
-      metricCoverage,
-      metricTimeToFreezeSeconds,
-      metricTimeSinceLastMutationSeconds: null,
-      metricTop3HitRate,
-    })
-    .where(eq(matchingSessions.id, params.id))
+  await withAuditContext(
+    { actorUserId: actorId, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: 'admin' },
+    async (tx) => {
+      await tx
+        .update(matchingSessions)
+        .set({
+          status: 'frozen',
+          frozenAt,
+          frozenScenarioJson: leader ?? null,
+          metricGroupsCount,
+          metricCoverage,
+          metricTimeToFreezeSeconds,
+          metricTimeSinceLastMutationSeconds: null,
+          metricTop3HitRate,
+        })
+        .where(eq(matchingSessions.id, params.id))
+    },
+  )
 
   await bumpSessionState(params.id)
 

--- a/app/api/matching/sessions/[id]/leave/route.test.ts
+++ b/app/api/matching/sessions/[id]/leave/route.test.ts
@@ -12,6 +12,9 @@ jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
 jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), delete: jest.fn() } }))
 jest.mock('@/lib/matching/preference-events', () => ({ recordParticipantLeftEvent: jest.fn() }))
 jest.mock('@/lib/matching/realtime/version', () => ({ bumpSessionState: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockDb = db as jest.Mocked<typeof db>

--- a/app/api/matching/sessions/[id]/leave/route.ts
+++ b/app/api/matching/sessions/[id]/leave/route.ts
@@ -7,6 +7,7 @@ import { matchingSessions, matchingSessionParticipants } from '@/lib/db/schema'
 import { eq, and } from 'drizzle-orm'
 import { bumpSessionState } from '@/lib/matching/realtime/version'
 import { recordParticipantLeftEvent } from '@/lib/matching/preference-events'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 interface Params { params: { id: string } }
 
@@ -40,14 +41,19 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
     source: 'matching',
   }).catch(() => {}) // analytics must never block the leave action
 
-  await db
-    .delete(matchingSessionParticipants)
-    .where(
-      and(
-        eq(matchingSessionParticipants.sessionId, sessionId),
-        eq(matchingSessionParticipants.userId, userId),
-      ),
-    )
+  await withAuditContext(
+    { actorUserId: userId, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: 'matching' },
+    async (tx) => {
+      await tx
+        .delete(matchingSessionParticipants)
+        .where(
+          and(
+            eq(matchingSessionParticipants.sessionId, sessionId),
+            eq(matchingSessionParticipants.userId, userId),
+          ),
+        )
+    },
+  )
 
   await bumpSessionState(sessionId)
 

--- a/app/api/matching/sessions/[id]/mode/route.test.ts
+++ b/app/api/matching/sessions/[id]/mode/route.test.ts
@@ -15,6 +15,9 @@ jest.mock('@/lib/db/schema', () => ({
   bookPriorities: {},
 }))
 jest.mock('@/lib/matching/realtime/version', () => ({ bumpSessionState: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockDb = db as jest.Mocked<typeof db>

--- a/app/api/matching/sessions/[id]/mode/route.ts
+++ b/app/api/matching/sessions/[id]/mode/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { bookPriorities, matchingSessionParticipants, matchingSessions, signupBooks } from '@/lib/db/schema'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { bumpSessionState } from '@/lib/matching/realtime/version'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 type Params = { params: { id: string } }
 type OptimizationMode = 'coverage' | 'satisfaction'
@@ -47,7 +48,8 @@ function participantsHaveRankedActiveBooks(
 
 export async function PATCH(req: NextRequest, { params }: Params) {
   const session = await auth()
-  if (!session?.user?.isAdmin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  if (!session?.user?.isAdmin || !session.user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  const actorId = session.user.id
 
   const body = await req.json().catch(() => ({}))
   const optimizationMode = parseOptimizationMode(body)
@@ -99,10 +101,15 @@ export async function PATCH(req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: incompletePrioritiesError }, { status: 409 })
   }
 
-  await db
-    .update(matchingSessions)
-    .set({ optimizationMode })
-    .where(eq(matchingSessions.id, params.id))
+  await withAuditContext(
+    { actorUserId: actorId, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: 'admin' },
+    async (tx) => {
+      await tx
+        .update(matchingSessions)
+        .set({ optimizationMode })
+        .where(eq(matchingSessions.id, params.id))
+    },
+  )
 
   await bumpSessionState(params.id)
 

--- a/app/api/matching/sessions/[id]/route.test.ts
+++ b/app/api/matching/sessions/[id]/route.test.ts
@@ -12,6 +12,9 @@ jest.mock('@/lib/db/schema', () => ({
   matchingSessions: {},
 }))
 jest.mock('@/lib/matching/realtime/version', () => ({ bumpSessionState: jest.fn() }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockDb = db as jest.Mocked<typeof db>

--- a/app/api/matching/sessions/[id]/route.ts
+++ b/app/api/matching/sessions/[id]/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { matchingSessions } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { bumpSessionState } from '@/lib/matching/realtime/version'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 type Params = { params: { id: string } }
 const MAX_GROUP_SIZE_LIMIT = 10
@@ -27,7 +28,8 @@ function parseGroupSizeRange(body: unknown): { minGroupSize: number; maxGroupSiz
 
 export async function PATCH(req: NextRequest, { params }: Params) {
   const session = await auth()
-  if (!session?.user?.isAdmin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  if (!session?.user?.isAdmin || !session.user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  const actorId = session.user.id
 
   const body = await req.json().catch(() => ({}))
   const groupSizeRange = parseGroupSizeRange(body)
@@ -42,10 +44,15 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   if (!matchSession) return NextResponse.json({ error: 'Session not found' }, { status: 404 })
   if (matchSession.status === 'frozen') return NextResponse.json({ error: 'Session is frozen' }, { status: 409 })
 
-  await db
-    .update(matchingSessions)
-    .set({ minGroupSize: groupSizeRange.minGroupSize, maxGroupSize: groupSizeRange.maxGroupSize })
-    .where(eq(matchingSessions.id, params.id))
+  await withAuditContext(
+    { actorUserId: actorId, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: 'admin' },
+    async (tx) => {
+      await tx
+        .update(matchingSessions)
+        .set({ minGroupSize: groupSizeRange.minGroupSize, maxGroupSize: groupSizeRange.maxGroupSize })
+        .where(eq(matchingSessions.id, params.id))
+    },
+  )
 
   await bumpSessionState(params.id)
 

--- a/app/api/matching/sessions/route.test.ts
+++ b/app/api/matching/sessions/route.test.ts
@@ -8,6 +8,9 @@ import { db } from '@/lib/db'
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }))
 jest.mock('@/lib/db', () => ({ db: { select: jest.fn(), insert: jest.fn() } }))
 jest.mock('@/lib/db/schema', () => ({ matchingSessions: {} }))
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: (_ctx: unknown, fn: (tx: unknown) => unknown) => fn(jest.requireMock('@/lib/db').db),
+}))
 
 const mockAuth = authModule.auth as jest.Mock
 const mockDb = db as jest.Mocked<typeof db>

--- a/app/api/matching/sessions/route.ts
+++ b/app/api/matching/sessions/route.ts
@@ -5,6 +5,7 @@ import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { matchingSessions } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { withAuditContext } from '@/lib/audit/with-audit-context'
 
 interface CreateSessionBody {
   name: string
@@ -32,9 +33,10 @@ function parseGroupSizeRange(body: CreateSessionBody): { minGroupSize: number; m
 
 export async function POST(req: NextRequest) {
   const session = await auth()
-  if (!session?.user?.isAdmin) {
+  if (!session?.user?.isAdmin || !session.user.id) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
+  const actorId = session.user.id
 
   let body: CreateSessionBody
   try {
@@ -81,25 +83,31 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  const [created] = await db
-    .insert(matchingSessions)
-    .values({
-      name,
-      createdBy: session.user.id,
-      status: 'active',
-      minGroupSize: groupSizeRange.minGroupSize,
-      maxGroupSize: groupSizeRange.maxGroupSize,
-      optimizationMode,
-      deadlineAt,
-    })
-    .returning({
-      id: matchingSessions.id,
-      name: matchingSessions.name,
-      status: matchingSessions.status,
-      minGroupSize: matchingSessions.minGroupSize,
-      maxGroupSize: matchingSessions.maxGroupSize,
-      optimizationMode: matchingSessions.optimizationMode,
-    })
+  const [created] = await withAuditContext(
+    { actorUserId: actorId, actorLabel: session.user.name ?? session.user.contactEmail ?? null, source: 'admin' },
+    async (tx) => {
+      const rows = await tx
+        .insert(matchingSessions)
+        .values({
+          name,
+          createdBy: actorId,
+          status: 'active',
+          minGroupSize: groupSizeRange.minGroupSize,
+          maxGroupSize: groupSizeRange.maxGroupSize,
+          optimizationMode,
+          deadlineAt,
+        })
+        .returning({
+          id: matchingSessions.id,
+          name: matchingSessions.name,
+          status: matchingSessions.status,
+          minGroupSize: matchingSessions.minGroupSize,
+          maxGroupSize: matchingSessions.maxGroupSize,
+          optimizationMode: matchingSessions.optimizationMode,
+        })
+      return rows
+    },
+  )
 
   return NextResponse.json({ success: true, data: created }, { status: 201 })
 }


### PR DESCRIPTION
## Site-wide audit log — actor для matching-мутаций (PR 3/3)

Завершает серию ([#346](https://github.com/bon2362/book-club/pull/346) инфра, [#347](https://github.com/bon2362/book-club/pull/347) actor + enforcement). Раньше matching-мутации попадали в `audit_log` как `source='trigger'` («внесистемное») — намеренно, т.к. у матчинга есть свой actor-журнал `matching_preference_events`. Этот PR убирает это исключение, чтобы и в общем `audit_log` matching-записи несли реального actor — единое окно для расследований.

### Обёрнуты в `withAuditContext`
| Роут | source |
|---|---|
| создание сессии (`POST /matching/sessions`) | admin |
| правка/удаление сессии (`PATCH /matching/sessions/[id]`) | admin |
| смена режима (`/mode`) | admin |
| заморозка (`/freeze`) | admin |
| удаление участника админом (`participants/[userId]`) | admin |
| выход из сессии (`/leave`) | matching |
| добавление/удаление книг (`/matching/books`) | matching / admin |
| ранги (`/matching/priorities`) | matching / admin / matching_priority_gate |

### Сознательно вне охвата
- **`lib/matching/pseudonym-reservations.ts`** — эфемерные TTL-резервации псевдонимов (истекают сами), низкая форензическая ценность; оставлены в ESLint-исключениях рядом с `lib/user-activity.ts`.
- Auth-цепочка — как и раньше.

ESLint-исключения для `app/api/matching/**`, `app/api/admin/matching/**`, `lib/matching/**` сняты — теперь любая новая matching-мутация тоже обязана нести actor (кроме pseudonym-reservations).

### Тесты
- Unit: моки `withAuditContext` добавлены в 8 matching route-тестов; 818 тестов зелёные; lint/typecheck чисто.
- e2e (изолированная Neon-ветка): **4 matching-спеки** (mode-toggle, reader-circles, realtime, satisfaction) + audit-log + reconciliation — **13/13 зелёные**. Matching-флоу не сломан.

### Прод
Схема не меняется — после мержа только деплой кода.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
