### PR TITLE
fix(matching): #341 — имена админу в попапе книги из «Сценариев» и «Моих ходов»

### DIFF
--- a/components/nd/MatchingMyMoves.tsx
+++ b/components/nd/MatchingMyMoves.tsx
@@ -95,6 +95,7 @@ export default function MatchingMyMoves({
           chips={modalState.chips}
           viewingUserId={viewingUserId}
           onClose={() => setModalState(null)}
+          adminNamesByPseudonym={adminNamesByPseudonym}
         />
       )}
       {moves.length === 0 ? (

--- a/components/nd/MatchingScenarios.tsx
+++ b/components/nd/MatchingScenarios.tsx
@@ -75,6 +75,7 @@ export default function MatchingScenarios({
           chips={bookParticipants.filter((p) => p.bookId === modalBook.bookId)}
           viewingUserId={viewingUserId}
           onClose={closeModal}
+          adminNamesByPseudonym={adminNamesByPseudonym}
         />
       )}
       {/* Тёплый фон контейнера — белые карточки сценариев читаются на нём */}


### PR DESCRIPTION
MatchingScenarios и MatchingMyMoves рендерят собственные MatchingBookDetailModal, но не форвардили adminNamesByPseudonym (хотя сами его получают). Добавлен проброс — теперь чипы в попапе книги показывают «Псевдоним (Имя)» админу из всех точек открытия, а не только из «Моих книг»/«Остального каталога».

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
