### PR TITLE
fix(auth): диагностика провала Telegram-входа + видимый баннер ошибки

### DIFF
--- a/app/api/auth/telegram/callback/route.ts
+++ b/app/api/auth/telegram/callback/route.ts
@@ -1,12 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createTelegramPreauthToken, verifyTelegramHash } from '@/lib/telegram-auth'
+import { createTelegramPreauthToken, verifyTelegramHashWithReason } from '@/lib/telegram-auth'
 import { resolveOrCreateUserFromIdentity } from '@/lib/user-identities'
 
 export async function GET(req: NextRequest) {
   const { searchParams, origin } = new URL(req.url)
   const params = Object.fromEntries(searchParams)
 
-  if (!verifyTelegramHash(params)) {
+  const verdict = verifyTelegramHashWithReason(params)
+  if (!verdict.ok) {
+    console.error('[telegram-callback] verification failed', {
+      reason: verdict.reason,
+      skewSeconds: verdict.skewSeconds,
+      hasHash: Boolean(params.hash),
+      tgId: params.id ?? null,
+      authDate: params.auth_date ?? null,
+    })
     return NextResponse.redirect(new URL('/?auth=failed', origin))
   }
 
@@ -22,6 +30,7 @@ export async function GET(req: NextRequest) {
 
   const ts = String(Math.floor(Date.now() / 1000))
   const { token } = await createTelegramPreauthToken(user.id)
+  console.log('[telegram-callback] ok', { userId: user.id, tgId: id })
 
   const url = new URL('/auth/telegram', origin)
   url.searchParams.set('token', token)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { auth } from '@/lib/auth'
 import { fetchBooksWithCovers } from '@/lib/books'
 import { getAllSignups } from '@/lib/signup-books'
@@ -7,6 +8,7 @@ import { eq } from 'drizzle-orm'
 import BooksPage from '@/components/nd/BooksPage'
 import GoogleOneTap from '@/components/nd/GoogleOneTap'
 import SiteVisitTracker from '@/components/nd/SiteVisitTracker'
+import AuthErrorBanner from '@/components/nd/AuthErrorBanner'
 import { DEFAULT_HEADER, DEFAULT_SECTIONS, getIntroData } from '@/lib/intro'
 
 export const dynamic = 'force-dynamic'
@@ -57,6 +59,7 @@ export default async function Home() {
     <>
       {!session && <GoogleOneTap />}
       {session?.user?.id && <SiteVisitTracker />}
+      <Suspense fallback={null}><AuthErrorBanner /></Suspense>
       <BooksPage books={booksWithStatus} currentUser={currentUser} tagDescriptions={tagDescMap} introHeader={{ title: introHeader.title, body: introHeader.body }} introSections={introSections} />
     </>
   )

--- a/components/nd/AuthErrorBanner.tsx
+++ b/components/nd/AuthErrorBanner.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { useState } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+
+export default function AuthErrorBanner() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const [dismissed, setDismissed] = useState(false)
+  if (dismissed || searchParams.get('auth') !== 'failed') return null
+  function dismiss() { setDismissed(true); router.replace('/') }
+  return (
+    <div role="alert" style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem',
+      background: 'var(--bg-input)', borderLeft: '3px solid var(--accent)',
+      borderBottom: '1px solid var(--border-strong)', padding: '0.75rem 1.25rem',
+    }}>
+      <span style={{ fontFamily: 'var(--nd-sans), system-ui, sans-serif', fontSize: '0.85rem', color: 'var(--text)' }}>
+        Не получилось войти через Telegram. Попробуйте ещё раз.
+      </span>
+      <button onClick={dismiss} aria-label="Закрыть" style={{
+        background: 'none', border: 'none', cursor: 'pointer', fontSize: '1rem',
+        color: 'var(--text-muted)', lineHeight: 1, padding: '0.2rem',
+        fontFamily: 'var(--nd-sans), system-ui, sans-serif',
+      }}>✕</button>
+    </div>
+  )
+}

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -439,6 +439,22 @@ test.describe('Satisfaction ranking gate layout', () => {
   })
 })
 
+test.describe('AuthErrorBanner: conditional render', () => {
+  test('баннер виден на /?auth=failed и скрыт на /', async ({ page }) => {
+    // Переход на /?auth=failed — баннер должен отображаться
+    await page.goto('/?auth=failed')
+    await page.waitForLoadState('networkidle')
+    const banner = page.getByRole('alert')
+    await expect(banner).toBeVisible()
+    await expect(banner).toContainText('Не получилось войти через Telegram')
+
+    // Переход на / без параметра — баннера нет
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('alert')).toHaveCount(0)
+  })
+})
+
 test.describe('ProfileDrawer: status accordion menu', () => {
   const EMAIL = 'e2e-mybooks-ui@test.invalid'
   const NAME = 'E2E MyBooks UI'

--- a/lib/telegram-auth.test.ts
+++ b/lib/telegram-auth.test.ts
@@ -5,6 +5,12 @@
  * Проверяет каждую причину отказа и успешный путь.
  */
 import { createHash, createHmac } from 'crypto'
+
+// telegram-auth.ts тянет lib/db → @/env (ESM @t3-oss/env-nextjs, который Jest не
+// трансформирует). verifyTelegramHashWithReason сам БД не использует — мокаем db,
+// чтобы цепочка импортов не грузила env (как в callback/route.test.ts).
+jest.mock('@/lib/db', () => ({ db: {} }))
+
 import { verifyTelegramHashWithReason, TELEGRAM_AUTH_MAX_AGE_SECONDS } from './telegram-auth'
 
 const BOT_TOKEN = 'test-bot-token-for-reason-tests'

--- a/lib/telegram-auth.test.ts
+++ b/lib/telegram-auth.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for verifyTelegramHashWithReason (lib/telegram-auth.ts).
+ * Проверяет каждую причину отказа и успешный путь.
+ */
+import { createHash, createHmac } from 'crypto'
+import { verifyTelegramHashWithReason, TELEGRAM_AUTH_MAX_AGE_SECONDS } from './telegram-auth'
+
+const BOT_TOKEN = 'test-bot-token-for-reason-tests'
+
+function computeHash(data: Record<string, string>, token: string): string {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { hash: _omit, ...rest } = data
+  const dataCheckString = Object.keys(rest).sort().map(k => `${k}=${rest[k]}`).join('\n')
+  const secret = createHash('sha256').update(token).digest()
+  return createHmac('sha256', secret).update(dataCheckString).digest('hex')
+}
+
+const NOW = Math.floor(Date.now() / 1000)
+
+const baseData = {
+  id: '111222333',
+  first_name: 'Test',
+  auth_date: String(NOW),
+}
+
+beforeEach(() => {
+  process.env.TELEGRAM_BOT_TOKEN = BOT_TOKEN
+})
+
+afterEach(() => {
+  delete process.env.TELEGRAM_BOT_TOKEN
+})
+
+describe('verifyTelegramHashWithReason', () => {
+  it('ok: true для корректного payload', () => {
+    const hash = computeHash(baseData, BOT_TOKEN)
+    const result = verifyTelegramHashWithReason({ ...baseData, hash }, NOW)
+    expect(result.ok).toBe(true)
+    expect(result.reason).toBeUndefined()
+    expect(result.skewSeconds).toBeDefined()
+    expect(result.skewSeconds).toBeGreaterThanOrEqual(0)
+  })
+
+  it('no_bot_token: нет TELEGRAM_BOT_TOKEN в env', () => {
+    delete process.env.TELEGRAM_BOT_TOKEN
+    const hash = computeHash(baseData, BOT_TOKEN)
+    const result = verifyTelegramHashWithReason({ ...baseData, hash }, NOW)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('no_bot_token')
+  })
+
+  it('no_hash: отсутствует поле hash', () => {
+    const result = verifyTelegramHashWithReason({ ...baseData }, NOW)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('no_hash')
+  })
+
+  it('bad_auth_date: auth_date не является числом', () => {
+    const data = { ...baseData, auth_date: 'not-a-number', hash: 'aabbcc' }
+    const result = verifyTelegramHashWithReason(data, NOW)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('bad_auth_date')
+  })
+
+  it('stale: auth_date слишком старый (skewSeconds > MAX_AGE)', () => {
+    const staleDate = NOW - TELEGRAM_AUTH_MAX_AGE_SECONDS - 10
+    const staleData = { ...baseData, auth_date: String(staleDate) }
+    const hash = computeHash(staleData, BOT_TOKEN)
+    const result = verifyTelegramHashWithReason({ ...staleData, hash }, NOW)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('stale')
+    expect(result.skewSeconds).toBeGreaterThan(TELEGRAM_AUTH_MAX_AGE_SECONDS)
+  })
+
+  it('future: auth_date в будущем (> now + 60)', () => {
+    const futureDate = NOW + 120
+    const futureData = { ...baseData, auth_date: String(futureDate) }
+    const hash = computeHash(futureData, BOT_TOKEN)
+    const result = verifyTelegramHashWithReason({ ...futureData, hash }, NOW)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('future')
+  })
+
+  it('hmac_mismatch: неверный hash при правильных остальных полях', () => {
+    const hash = 'a'.repeat(64) // валидный hex, но неверное значение
+    const result = verifyTelegramHashWithReason({ ...baseData, hash }, NOW)
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('hmac_mismatch')
+    expect(result.skewSeconds).toBeDefined()
+  })
+})

--- a/lib/telegram-auth.ts
+++ b/lib/telegram-auth.ts
@@ -14,19 +14,36 @@ function safeEqualHex(left: string, right: string) {
   }
 }
 
-export function verifyTelegramHash(data: Record<string, string>, now = Math.floor(Date.now() / 1000)): boolean {
-  if (!process.env.TELEGRAM_BOT_TOKEN) return false
+export type TelegramVerifyFailReason =
+  | 'no_bot_token' | 'no_hash' | 'bad_auth_date' | 'stale' | 'future' | 'hmac_mismatch'
+
+export interface TelegramVerifyResult {
+  ok: boolean
+  reason?: TelegramVerifyFailReason
+  skewSeconds?: number   // now - authDate, когда auth_date распарсился
+}
+
+export function verifyTelegramHashWithReason(
+  data: Record<string, string>,
+  now = Math.floor(Date.now() / 1000),
+): TelegramVerifyResult {
+  if (!process.env.TELEGRAM_BOT_TOKEN) return { ok: false, reason: 'no_bot_token' }
   const { hash, ...rest } = data
-  if (!hash) return false
-
+  if (!hash) return { ok: false, reason: 'no_hash' }
   const authDate = Number.parseInt(rest.auth_date ?? '', 10)
-  if (!Number.isFinite(authDate)) return false
-  if (now - authDate > TELEGRAM_AUTH_MAX_AGE_SECONDS || authDate > now + 60) return false
-
+  if (!Number.isFinite(authDate)) return { ok: false, reason: 'bad_auth_date' }
+  const skewSeconds = now - authDate
+  if (skewSeconds > TELEGRAM_AUTH_MAX_AGE_SECONDS) return { ok: false, reason: 'stale', skewSeconds }
+  if (authDate > now + 60) return { ok: false, reason: 'future', skewSeconds }
   const dataCheckString = Object.keys(rest).sort().map(k => `${k}=${rest[k]}`).join('\n')
   const secret = createHash('sha256').update(process.env.TELEGRAM_BOT_TOKEN).digest()
   const expected = createHmac('sha256', secret).update(dataCheckString).digest('hex')
-  return safeEqualHex(hash, expected)
+  if (!safeEqualHex(hash, expected)) return { ok: false, reason: 'hmac_mismatch', skewSeconds }
+  return { ok: true, skewSeconds }
+}
+
+export function verifyTelegramHash(data: Record<string, string>, now = Math.floor(Date.now() / 1000)): boolean {
+  return verifyTelegramHashWithReason(data, now).ok
 }
 
 export function hashTelegramPreauthToken(token: string) {


### PR DESCRIPTION
Периодически вход через Telegram не срабатывает (со второй попытки заходит).
Провальные попытки падают в callback на verifyTelegramHash ДО первой записи
в БД, и этот сегмент не логировался — причину было не установить.

- verifyTelegramHashWithReason(): возвращает причину отказа (no_hash / stale /
  future / hmac_mismatch / …) и skewSeconds; verifyTelegramHash — обёртка над ней
- callback логирует причину провала и факт успеха ([telegram-callback]),
  не раскрывая hash и токен бота
- AuthErrorBanner: при ?auth=failed показывает видимое сообщение «попробуйте
  ещё раз» вместо молчаливой главной
- юнит-тесты на все причины отказа + e2e на условный рендер баннера

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
