### PR TITLE
perf(home): UI-префы в cookie вместо localStorage — фикс CLS 0.32

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import { cookies } from 'next/headers'
 import { auth } from '@/lib/auth'
 import { fetchBooksWithCovers } from '@/lib/books'
 import { getAllSignups } from '@/lib/signup-books'
@@ -55,12 +56,19 @@ export default async function Home() {
 
   const tagDescMap = Object.fromEntries(tagDescs.map(d => [d.tag, d.description]))
 
+  // Читаем UI-настройки из cookie на сервере, чтобы первый кадр уже был
+  // в нужном состоянии и не дёргался после гидратации (CLS).
+  const cookieStore = await cookies()
+  const initialAboutVisible = cookieStore.get('about_dismissed')?.value !== 'true'
+  const initialViewMode = cookieStore.get('book_view_mode')?.value === 'list' ? 'list' : 'grid'
+  const initialShowRead = cookieStore.get('show_read')?.value === 'true'
+
   return (
     <>
       {!session && <GoogleOneTap />}
       {session?.user?.id && <SiteVisitTracker />}
       <Suspense fallback={null}><AuthErrorBanner /></Suspense>
-      <BooksPage books={booksWithStatus} currentUser={currentUser} tagDescriptions={tagDescMap} introHeader={{ title: introHeader.title, body: introHeader.body }} introSections={introSections} />
+      <BooksPage books={booksWithStatus} currentUser={currentUser} tagDescriptions={tagDescMap} introHeader={{ title: introHeader.title, body: introHeader.body }} introSections={introSections} initialAboutVisible={initialAboutVisible} initialViewMode={initialViewMode} initialShowRead={initialShowRead} />
     </>
   )
 }

--- a/components/nd/BooksPage.auth-memory.test.tsx
+++ b/components/nd/BooksPage.auth-memory.test.tsx
@@ -112,6 +112,9 @@ describe('BooksPage auth memory', () => {
         tagDescriptions={{}}
         introHeader={{ title: 'Intro', body: 'Body' }}
         introSections={[]}
+        initialAboutVisible={true}
+        initialViewMode="grid"
+        initialShowRead={false}
       />
     )
 

--- a/components/nd/BooksPage.tsx
+++ b/components/nd/BooksPage.tsx
@@ -30,6 +30,15 @@ interface Props {
   tagDescriptions: Record<string, string>
   introHeader: AboutBlockHeader
   introSections: AboutBlockSection[]
+  initialAboutVisible: boolean
+  initialViewMode: 'grid' | 'list'
+  initialShowRead: boolean
+}
+
+// Пишем UI-настройку в cookie (не localStorage), чтобы сервер видел её до
+// отрисовки и первый кадр сразу был правильным — иначе вёрстка дёргается (CLS).
+function setPrefCookie(name: string, value: string) {
+  document.cookie = `${name}=${value}; path=/; max-age=31536000; samesite=lax`
 }
 
 async function saveSelection(name: string, contacts: string, bookIds: string[]) {
@@ -50,25 +59,18 @@ async function saveProfile(name: string, contacts: string) {
   if (!res.ok) throw new Error(`Profile save failed: ${res.status}`)
 }
 
-export default function BooksPage({ books, currentUser, tagDescriptions, introHeader, introSections }: Props) {
+export default function BooksPage({ books, currentUser, tagDescriptions, introHeader, introSections, initialAboutVisible, initialViewMode, initialShowRead }: Props) {
   const { data: session } = useSession()
   const { isHidden } = useScrollHide()
   const isLoggedIn = !!session?.user?.id
   const isAdmin = !!session?.user?.isAdmin
   const contactEmail = getUserContactEmail(session?.user)
 
-  const [aboutVisible, setAboutVisible] = useState(true)
+  const [aboutVisible, setAboutVisible] = useState(initialAboutVisible)
   const aboutRef = useRef<AboutBlockHandle>(null)
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>(initialViewMode)
   const [showScrollTop, setShowScrollTop] = useState(false)
   const lastScrollY = useRef(0)
-
-  useEffect(() => {
-    if (localStorage.getItem('aboutDismissed') === 'true') setAboutVisible(false)
-    const saved = localStorage.getItem('book_view_mode')
-    if (saved === 'grid' || saved === 'list') setViewMode(saved)
-    if (localStorage.getItem('show_read') === 'true') setShowRead(true)
-  }, [])
 
   useEffect(() => {
     function handleScroll() {
@@ -83,7 +85,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
   }, [])
 
   function handleCloseAbout() {
-    localStorage.setItem('aboutDismissed', 'true')
+    setPrefCookie('about_dismissed', 'true')
     setAboutVisible(false)
   }
 
@@ -93,7 +95,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
       aboutRef.current?.scrollIntoView()
       return
     }
-    localStorage.removeItem('aboutDismissed')
+    setPrefCookie('about_dismissed', 'false')
     // flushSync ensures React commits the render before we call imperative methods
     flushSync(() => { setAboutVisible(true) })
     aboutRef.current?.openAccordion()
@@ -102,13 +104,13 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
 
   function handleSetViewMode(mode: 'grid' | 'list') {
     setViewMode(mode)
-    localStorage.setItem('book_view_mode', mode)
+    setPrefCookie('book_view_mode', mode)
   }
 
   const [query, setQuery] = useState('')
   const [filterTag, setFilterTag] = useState('')
   const [filterAuthor, setFilterAuthor] = useState('')
-  const [showRead, setShowRead] = useState(false)
+  const [showRead, setShowRead] = useState(initialShowRead)
   const [showMyBooks, setShowMyBooks] = useState(false)
   const [showNew, setShowNew] = useState(false)
   const [selectedBooks, setSelectedBooks] = useState<string[]>(
@@ -448,7 +450,7 @@ export default function BooksPage({ books, currentUser, tagDescriptions, introHe
                 )}
                 {hasReadBooks && (
                   <button
-                    onClick={() => setShowRead(v => { const next = !v; localStorage.setItem('show_read', String(next)); return next })}
+                    onClick={() => setShowRead(v => { const next = !v; setPrefCookie('show_read', String(next)); return next })}
                     style={chipStyle(showRead)}
                   >
                     {showRead ? '✓ Прочитанные' : 'Прочитанные'}

--- a/e2e/view-mode.spec.ts
+++ b/e2e/view-mode.spec.ts
@@ -1,15 +1,16 @@
 import { test, expect } from './fixtures'
 import { epic, feature } from 'allure-js-commons'
 
-// localStorage key: 'book_view_mode', values: 'grid' | 'list'
+// cookie key: 'book_view_mode', values: 'grid' | 'list'
+// Хранится в cookie (а не localStorage), чтобы сервер рендерил нужный вид
+// сразу и вёрстка не дёргалась после гидратации (CLS).
 // Кнопка переключения: title меняется в зависимости от текущего вида
 
 test.describe('переключение вида отображения', () => {
   test.beforeEach(async ({ page }) => {
     await epic('UI')
     await feature('Режим просмотра')
-    await page.goto('/')
-    await page.evaluate(() => localStorage.removeItem('book_view_mode'))
+    await page.context().clearCookies()
     await page.goto('/')
     await page.waitForSelector('article')
   })
@@ -31,12 +32,13 @@ test.describe('переключение вида отображения', () => 
     await expect(page.locator('table')).toHaveCount(0)
   })
 
-  // Персистентность: выбранный вид пишется в localStorage и восстанавливается
-  // после reload. Покрывает прежние 2 теста (localStorage + восстановление).
+  // Персистентность: выбранный вид пишется в cookie и восстанавливается
+  // после reload. Покрывает прежние 2 теста (cookie + восстановление).
   test('выбранный вид сохраняется после перезагрузки страницы', async ({ page }) => {
     await page.locator('button[title="Переключить в таблицу"]').click()
     await expect(page.locator('table')).toBeVisible()
-    expect(await page.evaluate(() => localStorage.getItem('book_view_mode'))).toBe('list')
+    const cookies = await page.context().cookies()
+    expect(cookies.find(c => c.name === 'book_view_mode')?.value).toBe('list')
 
     await page.reload()
     await page.waitForSelector('table')


### PR DESCRIPTION
Вид сетка/список, свёрнутость блока «О клубе» и фильтр «прочитанные»
читались из localStorage в useEffect после гидратации. У вернувшихся
пользователей первый кадр рисовался с дефолтами, затем состояние
корректировалось — список книг прыгал вверх на высоту About-блока.
Это давало CLS 0.32 (Poor) на главной.

Теперь префы хранятся в functional cookie: сервер (page force-dynamic)
читает их до отрисовки и передаёт начальные значения в BooksPage, так
что первый кадр сразу корректный — сдвига нет.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
