### PR TITLE
feat(matching): кнопка «← Каталог» в шапке сессии

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -185,6 +185,42 @@ body {
   -moz-appearance: textfield;
 }
 
+/* ── Back-to-catalog link in /matching header ────────────────────────────── */
+
+.nd-back-to-catalog {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 0.1rem 0;
+  transition: color 0.15s ease;
+}
+.nd-back-to-catalog:hover { color: var(--accent); }
+.nd-back-to-catalog:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 1px;
+}
+.nd-back-arrow {
+  font-size: 1.05rem;
+  line-height: 1;
+  transition: transform 0.15s ease;
+}
+.nd-back-to-catalog:hover .nd-back-arrow { transform: translateX(-3px); }
+
+.nd-back-divider {
+  width: 1px;
+  align-self: stretch;
+  flex-shrink: 0;
+  margin: 2px 0;
+  background: var(--border);
+}
+
 /* ── Move item cards ─────────────────────────────────────────────────────── */
 
 .nd-move-item {

--- a/components/nd/MatchingHeader.tsx
+++ b/components/nd/MatchingHeader.tsx
@@ -233,8 +233,14 @@ export default function MatchingHeader({
         }}
       >
         <div className="flex items-center justify-between gap-4">
-        {/* Left: session name + meta */}
-        <div className="flex items-baseline gap-3 min-w-0 flex-wrap">
+        {/* Left: back-to-catalog + session name + meta */}
+        <div className="flex items-center gap-3 min-w-0">
+          <a href="/" className="nd-back-to-catalog" aria-label="На каталог">
+            <span className="nd-back-arrow" aria-hidden="true">←</span>
+            <span>Каталог</span>
+          </a>
+          <span className="nd-back-divider" aria-hidden="true" />
+          <div className="flex items-baseline gap-3 min-w-0 flex-wrap">
           <h1
             className="leading-none m-0 truncate"
             style={{ fontFamily: 'var(--nd-serif)', fontWeight: 700, fontSize: '1.5rem', letterSpacing: '-0.01em', color: 'var(--text)' }}
@@ -388,6 +394,7 @@ export default function MatchingHeader({
                 активна
               </span>
             )}
+          </div>
           </div>
         </div>
 

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -219,6 +219,29 @@ test.describe('Matching layout', () => {
       expect(offset).toBeGreaterThanOrEqual(8)
     }
   })
+
+  test('back-to-catalog link is visible and left of session title', async ({
+    page,
+    createMatchingSession,
+    loginAsUser,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await createMatchingSession({ minGroupSize: 3, maxGroupSize: 3 })
+    await loginAsUser({ name: 'UI Back Link User' })
+
+    await page.goto('/matching')
+    await expect(page.getByRole('link', { name: 'На каталог' })).toBeVisible()
+
+    const backBox = await page.getByRole('link', { name: 'На каталог' }).boundingBox()
+    const titleBox = await page.getByRole('heading', { level: 1 }).boundingBox()
+
+    expect(backBox).not.toBeNull()
+    expect(titleBox).not.toBeNull()
+    // back link starts to the left of the session title
+    expect(backBox!.x).toBeLessThan(titleBox!.x)
+    // back link is within the top area (header)
+    expect(backBox!.y).toBeLessThan(100)
+  })
 })
 
 test.describe('Matching feed height', () => {


### PR DESCRIPTION
## Summary

- Добавляет `<a href="/">← Каталог</a>` в левый угол шапки `/matching`, слева от названия сессии (вариант B — средняя заметность)
- Вертикальный хайрлайн (`nd-back-divider`) отделяет навигацию от заголовка
- CSS-классы `.nd-back-to-catalog`, `.nd-back-arrow`, `.nd-back-divider` в `globals.css` — hover-анимация терракотой + стрелка уезжает влево на 3px за 150ms
- Навигация `flex-shrink:0 white-space:nowrap` — не сжимается, `<h1>` по-прежнему `truncate`

Closes #386

## Test plan

- [ ] Lint + typecheck + secretlint — зелёные (pre-commit hook)
- [ ] E2E: `back-to-catalog link is visible and left of session title` в `e2e/ui-states.spec.ts`
- [ ] Hover: цвет `var(--accent)`, стрелка сдвигается влево — проверить визуально в preview Vercel
- [ ] Tab-навигация: `:focus-visible` контур виден
- [ ] На узком экране (375px iPhone SE) навигация не прячется и не ломает layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)