### PR TITLE
fix(e2e): устранить флуктуацию теста auth methods

### DIFF
--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -577,19 +577,14 @@ test.describe('ProfileDrawer: auth methods layout', () => {
       data: {
         userId: sessionBody.userId,
         name: NAME,
-        contacts: '',
+        contacts: '@e2e_auth_ui',
         selectedBookIds: [],
       },
     })
     expect(profileResponse.ok()).toBe(true)
     try {
       await page.goto('/')
-      await page.waitForLoadState('domcontentloaded')
-      const blockingDialog = page.getByRole('dialog')
-      if (await blockingDialog.count()) {
-        await blockingDialog.first().getByRole('button', { name: 'Закрыть' }).click()
-        await expect(blockingDialog).toHaveCount(0)
-      }
+      await page.waitForLoadState('networkidle')
       const profileButton = page.locator('.nd-header-avatar')
       await expect(profileButton).toBeVisible({ timeout: 20_000 })
       await profileButton.click({ timeout: 10_000 })


### PR DESCRIPTION
## Проблема

Нightly E2E упал: [run 27487789799](https://github.com/bon2362/book-club/actions/runs/27487789799)

Тест `ProfileDrawer: auth methods layout` падал с:
```
TimeoutError: locator.click: Timeout 10000ms exceeded.
<div role="dialog" aria-modal="true"> intercepts pointer events
```

## Причина

Тест создавал пользователя с `contacts: ''`. ContactsForm появляется **асинхронно** после `domcontentloaded`, уже после того как одноразовая проверка `blockingDialog.count()` возвращала 0. К моменту клика по аватарке диалог уже висел поверх неё.

## Фикс

1. `contacts: '@e2e_auth_ui'` — убирает причину показа ContactsForm (тест проверяет auth methods, не contacts)
2. `waitForLoadState('networkidle')` вместо `'domcontentloaded'` — даёт время всем async-эффектам осесть (паттерн из соседнего успешного теста `status accordion`)

## Checklist
- E2E: нужен — это и есть e2e фикс
- Wiki: не нужна — только тест, поведение не менялось