### PR TITLE
fix(e2e): back-to-catalog join + admin catalog networkidle

### DIFF
--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -577,19 +577,14 @@ test.describe('ProfileDrawer: auth methods layout', () => {
       data: {
         userId: sessionBody.userId,
         name: NAME,
-        contacts: '',
+        contacts: '@e2e_auth_ui',
         selectedBookIds: [],
       },
     })
     expect(profileResponse.ok()).toBe(true)
     try {
       await page.goto('/')
-      await page.waitForLoadState('domcontentloaded')
-      const blockingDialog = page.getByRole('dialog')
-      if (await blockingDialog.count()) {
-        await blockingDialog.first().getByRole('button', { name: 'Закрыть' }).click()
-        await expect(blockingDialog).toHaveCount(0)
-      }
+      await page.waitForLoadState('networkidle')
       const profileButton = page.locator('.nd-header-avatar')
       await expect(profileButton).toBeVisible({ timeout: 20_000 })
       await profileButton.click({ timeout: 10_000 })

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -226,8 +226,9 @@ test.describe('Matching layout', () => {
     loginAsUser,
   }) => {
     await page.setViewportSize({ width: 1440, height: 900 })
-    await createMatchingSession({ minGroupSize: 3, maxGroupSize: 3 })
+    const session = await createMatchingSession({ minGroupSize: 3, maxGroupSize: 3 })
     await loginAsUser({ name: 'UI Back Link User' })
+    await joinMatchingSessionAndAddBooks(page, session.id, [])
 
     await page.goto('/matching')
     await expect(page.getByRole('link', { name: 'На каталог' })).toBeVisible()
@@ -434,8 +435,11 @@ test.describe('Admin Catalog: section + editor layout', () => {
     createdId = (await (await createRes).json()).data.id as string
 
     await page.reload()
-    await page.waitForLoadState('networkidle')
-    await page.getByTestId('admin-tab-catalog').click()
+    // AdminRefresh calls router.refresh() on mount which keeps network active;
+    // wait for the tab to be visible instead of networkidle
+    const catalogTabAfterReload = page.getByTestId('admin-tab-catalog')
+    await expect(catalogTabAfterReload).toBeVisible({ timeout: 15_000 })
+    await catalogTabAfterReload.click()
 
     const row = page.getByTestId(`admin-book-row-${createdId}`)
     await expect(row).toBeVisible({ timeout: 15_000 })


### PR DESCRIPTION
## Проблема

Нightly E2E: [run 27507255172](https://github.com/bon2362/book-club/actions/runs/27507255172) — 2 новых падения.

## Фикс 1: `back-to-catalog link is visible`

Тест создавал matching session и логинился, но **не джойнил** пользователя в сессию. Пользователь без join-а видит `MatchingWelcome` вместо `MatchingHeader` — link «На каталог» находится именно в хедере. Добавлен вызов `joinMatchingSessionAndAddBooks(page, session.id, [])` по аналогии с соседними тестами.

## Фикс 2: `Admin Catalog networkidle` timeout

Компонент `AdminRefresh` вызывает `router.refresh()` при каждом монте страницы. После `page.reload()` это генерирует фоновый fetch, который не даёт `waitForLoadState('networkidle')` завершиться за 60 секунд (default test timeout). Заменено на explicit `expect(admin-tab-catalog).toBeVisible()` — корректно ждёт гидратации без зависимости от networkidle.

## E2E/Wiki
- E2E: нужен — это сами тесты
- Wiki: не нужна — только тесты, поведение приложения не менялось