### PR TITLE
fix(catalog): убрать дубли DOM-селекторов мобильной раскладки в e2e

### DIFF
--- a/components/nd/BookCardMobile.tsx
+++ b/components/nd/BookCardMobile.tsx
@@ -62,7 +62,11 @@ export default function BookCardMobile({ book, isSelected, onToggle, personalSta
   const isRead = book.status === 'read'
 
   return (
-    <article
+    // Корневой <div> (а не <article>), чтобы глобальный e2e-селектор
+    // `locator('article')` продолжал означать только десктоп-карточку
+    // (BookCard) — обе раскладки одновременно присутствуют в DOM и
+    // переключаются media-query, поэтому общий тег создал бы дубли.
+    <div
       data-testid="book-card-mobile"
       style={{
         padding: '14px 13px',
@@ -461,6 +465,6 @@ export default function BookCardMobile({ book, isSelected, onToggle, personalSta
           </a>
         )}
       </div>
-    </article>
+    </div>
   )
 }

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -92,7 +92,9 @@ test.describe('Home submit book CTA layout', () => {
     await page.goto('/')
     await page.waitForLoadState('networkidle')
 
-    const box = await page.getByTestId('submit-book-card').boundingBox()
+    // На мобильном видим именно мобильный каталог (десктоп-дерево скрыто
+    // media-query, но присутствует в DOM) — скоупим на видимый контейнер.
+    const box = await page.getByTestId('catalog-mobile').getByTestId('submit-book-card').boundingBox()
     expect(box).not.toBeNull()
     expect(box!.height).toBeLessThanOrEqual(96)
   })
@@ -128,10 +130,10 @@ test.describe('Home submit book CTA layout', () => {
     await page.getByPlaceholder('Поиск по названию или автору…').fill(book.title)
     await expect(page.getByRole('heading', { name: book.title })).toBeVisible()
 
-    const submittedBadge = page.locator('[aria-label="Эта книга предложена участни:цей клуба"]')
+    const submittedBadge = page.getByTestId('catalog-mobile').locator('[aria-label="Эта книга предложена участни:цей клуба"]')
     await submittedBadge.click()
 
-    const tooltip = page.getByTestId('submitted-book-tooltip')
+    const tooltip = page.getByTestId('catalog-mobile').getByTestId('submitted-book-tooltip')
     await expect(tooltip).toBeVisible()
     await submittedBadge.click()
     await expect(tooltip).toBeVisible()


### PR DESCRIPTION
Обе раскладки каталога рендерятся одновременно и переключаются
media-query (display:none). Скрытое дерево всё равно матчится
CSS-локаторами Playwright, что ломало существующие тесты:
- BookCardMobile использовал <article> → дублировал глобальный
  селектор locator('article') (view-mode, search, signup, submit-book).
  Заменён на <div> — `article` снова = только десктоп-карточка.
- ui-states «submit compact / submitted badge» теперь скоупятся на
  видимый контейнер catalog-mobile (тесты на mobile-вьюпорте).

E2E: нужен — правка самих e2e (дубли селекторов из dual-render).
Wiki: не нужна — внутренняя правка тестов/тега, без изменения фич.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
