### PR TITLE
fix: add spacing between summary paragraphs

### DIFF
--- a/components/nd/SummaryMarkdown.test.tsx
+++ b/components/nd/SummaryMarkdown.test.tsx
@@ -16,6 +16,7 @@ jest.mock('react-markdown', () => ({
         const H2 = components.h2 ?? 'h2'
         const H3 = components.h3 ?? 'h3'
         const H4 = components.h4 ?? 'h4'
+        const P = components.p ?? 'p'
         const Ul = components.ul ?? 'ul'
         const Ol = components.ol ?? 'ol'
         const Li = components.li ?? 'li'
@@ -34,7 +35,7 @@ jest.mock('react-markdown', () => ({
         }
         if (/^\d+\. /.test(line)) return null
         if (line.startsWith('**') && line.endsWith('**')) return <strong key={index}>{line.slice(2, -2)}</strong>
-        return line ? <p key={index}>{line}</p> : null
+        return line ? <P key={index}>{line}</P> : null
       })}
     </div>
   ),
@@ -103,6 +104,17 @@ describe('SummaryMarkdown', () => {
     })
     expect(screen.getByText('Первый вопрос')).toHaveStyle({
       margin: '0.2rem 0',
+    })
+  })
+
+  it('keeps readable spacing between paragraphs', () => {
+    render(<SummaryMarkdown markdown={'Первый абзац.\n\nВторой абзац.'} />)
+
+    expect(screen.getByText('Первый абзац.')).toHaveStyle({
+      margin: '0 0 1rem',
+    })
+    expect(screen.getByText('Второй абзац.')).toHaveStyle({
+      margin: '0 0 1rem',
     })
   })
 })

--- a/components/nd/SummaryMarkdown.tsx
+++ b/components/nd/SummaryMarkdown.tsx
@@ -87,6 +87,7 @@ function MarkdownBlock({ markdown }: Props) {
           h2: ({ children }) => <h2 style={{ fontFamily: 'var(--nd-serif)', fontSize: '1.35rem', lineHeight: 1.2, margin: '1.35rem 0 0.6rem' }}>{children}</h2>,
           h3: ({ children }) => <h3 style={{ fontFamily: 'var(--nd-serif)', fontSize: '1.12rem', lineHeight: 1.25, margin: '1.2rem 0 0.5rem' }}>{children}</h3>,
           h4: ({ children }) => <h4 style={{ fontFamily: 'var(--nd-sans)', fontSize: '0.72rem', lineHeight: 1.4, margin: '1rem 0 0.4rem', textTransform: 'uppercase', letterSpacing: '0.12em', color: 'var(--text-muted)' }}>{children}</h4>,
+          p: ({ children }) => <p style={{ margin: '0 0 1rem' }}>{children}</p>,
           blockquote: ({ children }) => <blockquote style={{ borderLeft: '2px solid var(--border-strong)', margin: '1rem 0', paddingLeft: '1rem', fontStyle: 'italic' }}>{children}</blockquote>,
           ul: ({ children }) => <ul style={{ listStyleType: 'disc', listStylePosition: 'outside', margin: '1rem 0', paddingLeft: '1.35rem' }}>{children}</ul>,
           ol: ({ children }) => <ol style={{ listStyleType: 'decimal', listStylePosition: 'outside', margin: '1rem 0', paddingLeft: '1.45rem' }}>{children}</ol>,

--- a/e2e/book-summaries.spec.ts
+++ b/e2e/book-summaries.spec.ts
@@ -45,6 +45,10 @@ test.describe('Саммари книг', () => {
     await page.getByLabel('Текст саммари').fill([
       '## Главная мысль',
       '',
+      'Первый абзац раскрывает общий тезис.',
+      '',
+      'Второй абзац продолжает мысль с видимым отступом.',
+      '',
       '### Разбор аргумента',
       '',
       '#### Внутренний тезис',
@@ -70,12 +74,19 @@ test.describe('Саммари книг', () => {
 
     await page.getByRole('button', { name: 'Предпросмотр' }).click()
     await expect(page.getByRole('heading', { name: 'Почему институты важны' })).toBeVisible()
+    await expect(page.getByText('Первый абзац раскрывает общий тезис.')).toBeVisible()
+    await expect(page.getByText('Второй абзац продолжает мысль с видимым отступом.')).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Разбор аргумента', level: 3 })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Внутренний тезис', level: 4 })).toBeVisible()
     await expect(page.getByText('Длинный контекст')).toBeVisible()
     await expect(page.getByText('Институты задают стимулы')).toBeVisible()
     await expect(page.getByRole('listitem').filter({ hasText: 'Противоречит ли социализм демократии?' })).toBeVisible()
     await expect(page.getByRole('listitem').filter({ hasText: 'Сначала разобрать исторический контекст' })).toBeVisible()
+    const previewFirstParagraphBox = await page.getByText('Первый абзац раскрывает общий тезис.').boundingBox()
+    const previewSecondParagraphBox = await page.getByText('Второй абзац продолжает мысль с видимым отступом.').boundingBox()
+    expect(previewFirstParagraphBox).not.toBeNull()
+    expect(previewSecondParagraphBox).not.toBeNull()
+    expect(previewSecondParagraphBox!.y - (previewFirstParagraphBox!.y + previewFirstParagraphBox!.height)).toBeGreaterThan(8)
     await page.getByRole('button', { name: 'Предпросмотр' }).click()
 
     await page.getByRole('button', { name: 'Отправить на проверку' }).click()
@@ -98,12 +109,19 @@ test.describe('Саммари книг', () => {
     await expect(page.getByRole('heading', { name: book.title })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Почему институты решают' })).toBeVisible()
     await expect(page.getByText('Reader One')).toBeVisible()
+    await expect(page.getByText('Первый абзац раскрывает общий тезис.')).toBeVisible()
+    await expect(page.getByText('Второй абзац продолжает мысль с видимым отступом.')).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Разбор аргумента', level: 3 })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Внутренний тезис', level: 4 })).toBeVisible()
     await expect(page.getByText('Длинный контекст')).toBeVisible()
     await expect(page.getByText('Институты задают стимулы')).toBeVisible()
     await expect(page.getByRole('listitem').filter({ hasText: 'Противоречит ли социализм демократии?' })).toBeVisible()
     await expect(page.getByRole('listitem').filter({ hasText: 'Сначала разобрать исторический контекст' })).toBeVisible()
+    const publicFirstParagraphBox = await page.getByText('Первый абзац раскрывает общий тезис.').boundingBox()
+    const publicSecondParagraphBox = await page.getByText('Второй абзац продолжает мысль с видимым отступом.').boundingBox()
+    expect(publicFirstParagraphBox).not.toBeNull()
+    expect(publicSecondParagraphBox).not.toBeNull()
+    expect(publicSecondParagraphBox!.y - (publicFirstParagraphBox!.y + publicFirstParagraphBox!.height)).toBeGreaterThan(8)
 
     await loginAsUser({ email: user.email, name: user.name })
     await page.goto(`/summaries/${draft.summary.id}/edit`)


### PR DESCRIPTION
## Что изменилось
- Добавил явный нижний отступ для параграфов в SummaryMarkdown.
- Покрыл поведение unit-тестом.
- Расширил e2e-сценарий саммари проверкой расстояния между абзацами в preview и на публичной странице.

## Проверки
- npm run lint
- npm run typecheck
- npm test -- SummaryMarkdown.test.tsx --runInBand
- npm test -- --runInBand
- SKIP_ENV_VALIDATION=true DATABASE_URL='postgresql://dummy:dummy@dummy/dummy' npm run build

## E2E / Wiki
- E2E: нужен — CSS/рендер-поведение публичного и preview Markdown; e2e/book-summaries.spec.ts обновлен. Локально Playwright не запускал без .env.test.local.
- Wiki: не нужна — пользовательский workflow и модель фичи не меняются.