### PR TITLE
codex/preserve toolbar scroll

### DIFF
--- a/components/nd/MarkdownToolbar.test.tsx
+++ b/components/nd/MarkdownToolbar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { useRef, useState } from 'react'
 import MarkdownToolbar from './MarkdownToolbar'
 
@@ -23,6 +23,38 @@ describe('MarkdownToolbar', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Жирный' }))
 
     expect(textarea.value).toBe('**важный** текст')
+  })
+
+  it('restores selection and textarea viewport without scrolling on focus', () => {
+    jest.useFakeTimers()
+    let focusSpy: jest.SpyInstance | undefined
+    try {
+      render(<Harness />)
+      const textarea = screen.getByLabelText('markdown') as HTMLTextAreaElement
+      focusSpy = jest.spyOn(textarea, 'focus')
+      textarea.focus()
+      focusSpy.mockClear()
+      textarea.setSelectionRange(0, 6)
+      textarea.scrollTop = 240
+      textarea.scrollLeft = 12
+
+      fireEvent.click(screen.getByRole('button', { name: 'Жирный' }))
+      act(() => { jest.runOnlyPendingTimers() })
+
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+      expect(textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)).toBe('важный')
+      expect(textarea.scrollTop).toBe(240)
+      expect(textarea.scrollLeft).toBe(12)
+    } finally {
+      focusSpy?.mockRestore()
+      jest.useRealTimers()
+    }
+  })
+
+  it('does not let a pointer press steal focus from the textarea', () => {
+    render(<Harness />)
+
+    expect(fireEvent.mouseDown(screen.getByRole('button', { name: 'Жирный' }))).toBe(false)
   })
 
   it('inserts a portable details block template', () => {

--- a/components/nd/MarkdownToolbar.tsx
+++ b/components/nd/MarkdownToolbar.tsx
@@ -10,6 +10,38 @@ interface Props {
   onChange: (value: string) => void
 }
 
+interface TextareaSelection {
+  start: number
+  end: number
+  scrollTop: number
+  scrollLeft: number
+}
+
+function readTextareaSelection(textarea: HTMLTextAreaElement | null, fallback: number): TextareaSelection {
+  return {
+    start: textarea?.selectionStart ?? fallback,
+    end: textarea?.selectionEnd ?? fallback,
+    scrollTop: textarea?.scrollTop ?? 0,
+    scrollLeft: textarea?.scrollLeft ?? 0,
+  }
+}
+
+function restoreTextareaSelection(
+  textareaRef: RefObject<HTMLTextAreaElement>,
+  start: number,
+  end: number,
+  viewport: Pick<TextareaSelection, 'scrollTop' | 'scrollLeft'>,
+) {
+  window.setTimeout(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    textarea.focus({ preventScroll: true })
+    textarea.setSelectionRange(start, end)
+    textarea.scrollTop = viewport.scrollTop
+    textarea.scrollLeft = viewport.scrollLeft
+  }, 0)
+}
+
 export function formatWikipediaEmbed(text: string, target: WikipediaTarget): string {
   const authorText = text || 'Текст вставки'
   const quote = authorText
@@ -60,19 +92,15 @@ function formatOrderedList(text: string): string {
 
 export default function MarkdownToolbar({ textareaRef, value, onChange }: Props) {
   const [dialogOpen, setDialogOpen] = useState(false)
-  const selectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 })
+  const selectionRef = useRef<TextareaSelection>({ start: 0, end: 0, scrollTop: 0, scrollLeft: 0 })
 
   function openWikipediaDialog() {
-    const textarea = textareaRef.current
-    selectionRef.current = {
-      start: textarea?.selectionStart ?? value.length,
-      end: textarea?.selectionEnd ?? value.length,
-    }
+    selectionRef.current = readTextareaSelection(textareaRef.current, value.length)
     setDialogOpen(true)
   }
 
   function insertWikipedia(target: WikipediaTarget) {
-    const { start, end } = selectionRef.current
+    const { start, end, scrollTop, scrollLeft } = selectionRef.current
     const selected = value.slice(start, end)
     const authorText = selected || 'Текст вставки'
     const block = formatWikipediaEmbed(selected, target)
@@ -87,28 +115,20 @@ export default function MarkdownToolbar({ textareaRef, value, onChange }: Props)
 
     const authorStart = before.length + leading.length + 2 // skip the leading "> "
     const authorEnd = authorStart + authorText.length
-    window.setTimeout(() => {
-      const textarea = textareaRef.current
-      textarea?.focus()
-      textarea?.setSelectionRange(authorStart, authorEnd)
-    }, 0)
+    restoreTextareaSelection(textareaRef, authorStart, authorEnd, { scrollTop, scrollLeft })
   }
 
   function applyTool(tool: Tool) {
-    const textarea = textareaRef.current
-    const start = textarea?.selectionStart ?? value.length
-    const end = textarea?.selectionEnd ?? value.length
+    const selection = readTextareaSelection(textareaRef.current, value.length)
+    const { start, end } = selection
     const selected = value.slice(start, end)
     const inner = tool.format ? tool.format(selected || tool.placeholder) : selected || tool.placeholder
     const next = `${value.slice(0, start)}${tool.before}${inner}${tool.after}${value.slice(end)}`
     onChange(next)
 
-    window.setTimeout(() => {
-      textarea?.focus()
-      const cursorStart = start + tool.before.length
-      const cursorEnd = cursorStart + inner.length
-      textarea?.setSelectionRange(cursorStart, cursorEnd)
-    }, 0)
+    const cursorStart = start + tool.before.length
+    const cursorEnd = cursorStart + inner.length
+    restoreTextareaSelection(textareaRef, cursorStart, cursorEnd, selection)
   }
 
   return (
@@ -118,6 +138,7 @@ export default function MarkdownToolbar({ textareaRef, value, onChange }: Props)
           key={tool.label}
           type="button"
           aria-label={tool.label}
+          onMouseDown={event => event.preventDefault()}
           onClick={() => applyTool(tool)}
           style={{
             minWidth: 30,
@@ -138,6 +159,7 @@ export default function MarkdownToolbar({ textareaRef, value, onChange }: Props)
       <button
         type="button"
         aria-label="Вставка из Wikipedia"
+        onMouseDown={event => event.preventDefault()}
         onClick={openWikipediaDialog}
         style={{
           minWidth: 30,

--- a/docs/superpowers/plans/2026-06-28-preserve-markdown-toolbar-scroll.md
+++ b/docs/superpowers/plans/2026-06-28-preserve-markdown-toolbar-scroll.md
@@ -1,0 +1,174 @@
+# Preserve Markdown Toolbar Selection and Scroll Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the summary editor at the same page and textarea position when a Markdown toolbar action formats selected text.
+
+**Architecture:** `MarkdownToolbar` will capture selection and textarea viewport state before changing the controlled value, then restore them after React renders. Pointer-down on toolbar buttons will not steal textarea focus, and focus restoration will use the browser's `preventScroll` option.
+
+**Tech Stack:** React 18, TypeScript, Jest/Testing Library, Playwright, Next.js 14.
+
+---
+
+### Task 1: Lock the regression with component tests
+
+**Files:**
+- Modify: `components/nd/MarkdownToolbar.test.tsx`
+
+- [ ] **Step 1: Add failing focus and viewport restoration tests**
+
+Add tests using fake timers that select `важный`, set non-zero `scrollTop` and `scrollLeft`, click `Жирный`, and assert:
+
+```ts
+expect(textarea.focus).toHaveBeenCalledWith({ preventScroll: true })
+expect(textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)).toBe('важный')
+expect(textarea.scrollTop).toBe(240)
+expect(textarea.scrollLeft).toBe(12)
+```
+
+Add a separate pointer-focus assertion:
+
+```ts
+expect(fireEvent.mouseDown(screen.getByRole('button', { name: 'Жирный' }))).toBe(false)
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+npx jest --runInBand --runTestsByPath components/nd/MarkdownToolbar.test.tsx
+```
+
+Expected: focus restoration fails because `focus()` receives no `preventScroll`, and pointer-down is not cancelled.
+
+### Task 2: Restore selection without moving the viewport
+
+**Files:**
+- Modify: `components/nd/MarkdownToolbar.tsx`
+- Test: `components/nd/MarkdownToolbar.test.tsx`
+
+- [ ] **Step 1: Add one shared restoration helper**
+
+Capture a viewport object before every toolbar value change:
+
+```ts
+interface TextareaViewport {
+  scrollTop: number
+  scrollLeft: number
+}
+```
+
+Restore after the controlled update:
+
+```ts
+function restoreTextarea(
+  textareaRef: RefObject<HTMLTextAreaElement>,
+  start: number,
+  end: number,
+  viewport: TextareaViewport,
+) {
+  window.setTimeout(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    textarea.focus({ preventScroll: true })
+    textarea.setSelectionRange(start, end)
+    textarea.scrollTop = viewport.scrollTop
+    textarea.scrollLeft = viewport.scrollLeft
+  }, 0)
+}
+```
+
+- [ ] **Step 2: Apply the helper to direct formatting and Wikipedia insertion**
+
+Extend the saved Wikipedia selection with viewport offsets, and replace both existing timer blocks with the shared helper. Add this to every toolbar button, including Wikipedia:
+
+```tsx
+onMouseDown={event => event.preventDefault()}
+```
+
+- [ ] **Step 3: Run the component tests and verify GREEN**
+
+Run:
+
+```bash
+npx jest --runInBand --runTestsByPath components/nd/MarkdownToolbar.test.tsx
+```
+
+Expected: all toolbar tests pass.
+
+### Task 3: Cover the real browser scroll behavior
+
+**Files:**
+- Modify: `e2e/ui-states.spec.ts`
+
+- [ ] **Step 1: Add a long-document editor test**
+
+In the existing `Summary editor layout` describe block, create an isolated test book and read-status user, open a draft, and save a body with enough lines to scroll. In the browser:
+
+```ts
+await textarea.evaluate((element: HTMLTextAreaElement) => {
+  const marker = 'выделенный фрагмент'
+  const start = element.value.indexOf(marker)
+  element.focus()
+  element.setSelectionRange(start, start + marker.length)
+  element.scrollTop = 300
+})
+await page.evaluate(() => window.scrollTo(0, 700))
+```
+
+Record `window.scrollY` and `textarea.scrollTop`, click `Жирный`, then assert focus, selected text, and both offsets are unchanged within one pixel.
+
+- [ ] **Step 2: Run the focused browser test**
+
+Run against the isolated E2E Neon branch:
+
+```bash
+npm run test:e2e e2e/ui-states.spec.ts --grep "форматирование не меняет прокрутку"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the complete required UI suite**
+
+Run:
+
+```bash
+npm run test:e2e e2e/ui-states.spec.ts
+```
+
+Expected: all UI-state tests pass.
+
+### Task 4: Verify and deliver through PR
+
+**Files:** all changed files
+
+- [ ] **Step 1: Run full local verification**
+
+```bash
+npm run lint && npm run typecheck && npm test -- --runInBand && npm run build
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Assess release artifacts and commit**
+
+Report before committing:
+
+- `E2E: нужен` because this fixes browser focus and scroll behavior in an existing editor flow.
+- `Wiki: не нужна` because APIs, data, routing, and the workflow are unchanged.
+
+Commit without bypassing hooks:
+
+```bash
+git add components/nd/MarkdownToolbar.tsx components/nd/MarkdownToolbar.test.tsx e2e/ui-states.spec.ts docs/superpowers/plans/2026-06-28-preserve-markdown-toolbar-scroll.md
+git commit -m "fix: preserve summary editor position when formatting"
+```
+
+- [ ] **Step 3: Push, create PR, enable auto-merge, and monitor**
+
+Push `codex/preserve-toolbar-scroll`, create a PR, enable squash auto-merge, inspect `mergeStateStatus`, and keep fixing the same branch until GitHub CI is green and the PR is merged.
+
+- [ ] **Step 4: Verify production deployment**
+
+Wait for the Vercel status on the merge commit to become `success`, then verify the production site responds successfully.

--- a/docs/superpowers/specs/2026-06-28-preserve-markdown-toolbar-scroll-design.md
+++ b/docs/superpowers/specs/2026-06-28-preserve-markdown-toolbar-scroll-design.md
@@ -1,0 +1,36 @@
+# Preserve Markdown Toolbar Selection and Scroll
+
+## Goal
+
+Formatting selected text in the summary Markdown editor must not move the page or the textarea's internal viewport. The formatted fragment remains selected so the author can continue working from the same place.
+
+## Root cause
+
+`MarkdownToolbar` updates the controlled textarea and then calls `textarea.focus()` in a timer. Focusing a large textarea without options lets the browser scroll the page to bring the element into view. The toolbar button also receives pointer focus before its click handler, making selection preservation dependent on browser blur behavior.
+
+## Design
+
+Before changing the Markdown value, the toolbar records:
+
+- `selectionStart` and `selectionEnd`;
+- `scrollTop` and `scrollLeft` of the textarea.
+
+Formatting buttons prevent their pointer-down default so they do not take focus from the textarea. After React applies the controlled value update, one shared restoration helper:
+
+1. calls `textarea.focus({ preventScroll: true })`;
+2. restores the intended selection range around the formatted inner text;
+3. restores the textarea's internal scroll offsets.
+
+The same helper is used after Wikipedia insertion. Keyboard activation remains unchanged because only pointer-down default behavior is suppressed.
+
+The implementation does not force `window.scrollTo`: `preventScroll` avoids the page jump without a visible corrective movement.
+
+## Tests
+
+- Jest reproduces the regression by asserting that formatting restores focus with `preventScroll`, preserves the selected fragment, and returns the textarea to its previous internal scroll offsets.
+- Jest asserts that pointer-down on a formatting button is cancelled, preserving the active textarea selection.
+- Playwright covers the real browser behavior in the existing summary-editor UI suite: select text in a long document, format it, then assert the page position, textarea scroll position, focus, and selected text remain stable.
+
+## Scope
+
+No API, database, routing, or user-workflow changes. Technical feature and owner Wiki documentation do not need updates; the automated regression tests document the corrected behavior.

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -252,6 +252,87 @@ test.describe('Summary editor layout', () => {
     expect(toolbarBox!.width).toBeGreaterThanOrEqual(workspaceBox!.width - 64)
   })
 
+  test('форматирование не меняет прокрутку и сохраняет выделенный текст', async ({
+    page,
+    createTestBook,
+    loginAsUser,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 720 })
+    const book = await createTestBook({
+      title: `UI Summary Formatting ${Date.now()}`,
+      author: 'Layout Author',
+    })
+    const user = await loginAsUser({ name: 'UI Formatting Writer' })
+    const signupRes = await page.request.post('/api/test/signup', {
+      data: {
+        userId: user.userId,
+        name: user.name,
+        email: user.email,
+        contacts: '@ui_formatting_writer',
+        selectedBookIds: [book.id],
+      },
+    })
+    expect(signupRes.ok()).toBe(true)
+    const statusRes = await page.request.patch(`/api/signup-books/${encodeURIComponent(book.id)}/status`, {
+      data: { status: 'read' },
+    })
+    expect(statusRes.ok()).toBe(true)
+    const draftRes = await page.request.post(`/api/summaries/by-book/${encodeURIComponent(book.id)}`)
+    expect(draftRes.ok()).toBe(true)
+    const draft = (await draftRes.json()) as { summary: { id: string } }
+    const marker = 'выделенный фрагмент'
+    const longBody = [
+      ...Array.from({ length: 70 }, (_, index) => `Вводная строка ${index}`),
+      marker,
+      ...Array.from({ length: 70 }, (_, index) => `Заключительная строка ${index}`),
+    ].join('\n')
+    const saveRes = await page.request.patch(`/api/summaries/${draft.summary.id}`, {
+      data: { bodyMarkdown: longBody },
+    })
+    expect(saveRes.ok()).toBe(true)
+
+    await page.goto(`/summaries/${draft.summary.id}/edit`)
+    await page.waitForLoadState('networkidle')
+    const textarea = page.getByLabel('Текст саммари')
+    const boldButton = page.getByRole('button', { name: 'Жирный' })
+    await expect(textarea).toBeVisible()
+    await expect(boldButton).toBeVisible()
+
+    await textarea.evaluate((element, selectedText) => {
+      const input = element as HTMLTextAreaElement
+      const start = input.value.indexOf(selectedText)
+      input.focus()
+      input.setSelectionRange(start, start + selectedText.length)
+      input.scrollTop = Math.min(900, input.scrollHeight - input.clientHeight)
+    }, marker)
+    await page.evaluate(() => window.scrollTo({ top: 640, behavior: 'instant' }))
+
+    const before = await textarea.evaluate(element => {
+      const input = element as HTMLTextAreaElement
+      return { pageY: window.scrollY, scrollTop: input.scrollTop }
+    })
+
+    await boldButton.click()
+    await expect.poll(() => textarea.evaluate(element => {
+      const input = element as HTMLTextAreaElement
+      return input.value.slice(input.selectionStart, input.selectionEnd)
+    })).toBe(marker)
+
+    const after = await textarea.evaluate(element => {
+      const input = element as HTMLTextAreaElement
+      return {
+        pageY: window.scrollY,
+        scrollTop: input.scrollTop,
+        focused: document.activeElement === input,
+        formatted: input.value.includes('**выделенный фрагмент**'),
+      }
+    })
+    expect(after.focused).toBe(true)
+    expect(after.formatted).toBe(true)
+    expect(Math.abs(after.pageY - before.pageY)).toBeLessThanOrEqual(1)
+    expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(1)
+  })
+
   test('details rail spans the open block and only the rail collapses body text', async ({ page, createTestBook, loginAsUser }) => {
     await page.setViewportSize({ width: 1280, height: 900 })
     const book = await createTestBook({


### PR DESCRIPTION
- **docs: design stable markdown toolbar focus**
- **docs: plan stable markdown toolbar focus**
- **fix: preserve summary editor position when formatting**
