### PR TITLE
style(summaries): акцентный eyebrow-стиль для заголовков h3

### DIFF
--- a/components/nd/SummaryMarkdown.test.tsx
+++ b/components/nd/SummaryMarkdown.test.tsx
@@ -56,10 +56,13 @@ describe('SummaryMarkdown', () => {
     render(<SummaryMarkdown markdown={'### Подраздел\n\n#### Внутренний тезис'} />)
 
     expect(screen.getByRole('heading', { name: 'Подраздел', level: 3 })).toHaveStyle({
-      fontSize: '1.12rem',
+      fontSize: '0.78rem',
+      textTransform: 'uppercase',
+      color: 'var(--accent)',
     })
     expect(screen.getByRole('heading', { name: 'Внутренний тезис', level: 4 })).toHaveStyle({
       textTransform: 'uppercase',
+      color: 'var(--text-muted)',
     })
   })
 

--- a/components/nd/SummaryMarkdown.tsx
+++ b/components/nd/SummaryMarkdown.tsx
@@ -81,7 +81,7 @@ function MarkdownBlock({ markdown }: Props) {
           ),
           h1: ({ children }) => <h1 style={{ fontFamily: 'var(--nd-serif)', fontSize: '1.8rem', lineHeight: 1.15, margin: '1.5rem 0 0.75rem' }}>{children}</h1>,
           h2: ({ children }) => <h2 style={{ fontFamily: 'var(--nd-serif)', fontSize: '1.35rem', lineHeight: 1.2, margin: '1.35rem 0 0.6rem' }}>{children}</h2>,
-          h3: ({ children }) => <h3 style={{ fontFamily: 'var(--nd-serif)', fontSize: '1.12rem', lineHeight: 1.25, margin: '1.2rem 0 0.5rem' }}>{children}</h3>,
+          h3: ({ children }) => <h3 style={{ fontFamily: 'var(--nd-sans)', fontSize: '0.78rem', fontWeight: 600, lineHeight: 1.4, margin: '2.25rem 0 0.6rem', textTransform: 'uppercase', letterSpacing: '0.13em', color: 'var(--accent)' }}>{children}</h3>,
           h4: ({ children }) => <h4 style={{ fontFamily: 'var(--nd-sans)', fontSize: '0.72rem', lineHeight: 1.4, margin: '1rem 0 0.4rem', textTransform: 'uppercase', letterSpacing: '0.12em', color: 'var(--text-muted)' }}>{children}</h4>,
           p: ({ children }) => <p style={{ margin: '0 0 1rem' }}>{children}</p>,
           blockquote: ({ children }) => (


### PR DESCRIPTION
h3 в саммари рендерился как serif 1.12rem и при скролле сливался с
h2 и основным текстом — граница раздела терялась. Меняю на sans
UPPERCASE с терракотовым акцентом (var(--accent)) и увеличенным
верхним отступом, по канону микрометок дизайн-системы. По цвету
отличается от muted-h4, иерархия h3 > h4 сохранена.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
