### PR TITLE
feat(editor): выделять URL после оборачивания выделенного текста в ссылку

### DIFF
--- a/components/nd/MarkdownToolbar.test.tsx
+++ b/components/nd/MarkdownToolbar.test.tsx
@@ -99,6 +99,42 @@ describe('MarkdownToolbar', () => {
     expect(textarea.value).toBe('1. первый\n2. второй')
   })
 
+  it('selects the URL placeholder after linking selected text', () => {
+    jest.useFakeTimers()
+    try {
+      render(<Harness />)
+      const textarea = screen.getByLabelText('markdown') as HTMLTextAreaElement
+      textarea.focus()
+      textarea.setSelectionRange(0, 6)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Ссылка' }))
+      act(() => { jest.runOnlyPendingTimers() })
+
+      expect(textarea.value).toBe('[важный](https://) текст')
+      expect(textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)).toBe('https://')
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('selects the link-text placeholder when nothing was selected', () => {
+    jest.useFakeTimers()
+    try {
+      render(<Harness />)
+      const textarea = screen.getByLabelText('markdown') as HTMLTextAreaElement
+      textarea.focus()
+      textarea.setSelectionRange(0, 0)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Ссылка' }))
+      act(() => { jest.runOnlyPendingTimers() })
+
+      expect(textarea.value).toBe('[текст ссылки](https://)важный текст')
+      expect(textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)).toBe('текст ссылки')
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   function openDialog(textarea: HTMLTextAreaElement, start: number, end: number) {
     textarea.focus()
     textarea.setSelectionRange(start, end)

--- a/components/nd/MarkdownToolbar.tsx
+++ b/components/nd/MarkdownToolbar.tsx
@@ -58,6 +58,10 @@ interface Tool {
   after: string
   placeholder: string
   format?: (text: string) => string
+  // Когда текст уже был выделен, после вставки выделить эту подстроку из `after`
+  // (например URL у ссылки), чтобы её можно было сразу перепечатать. Без выделения
+  // работает обычная логика — выделяется вставленный плейсхолдер.
+  selectInAfterWhenSelected?: string
 }
 
 const tools: Tool[] = [
@@ -68,7 +72,7 @@ const tools: Tool[] = [
   { label: 'Маркированный список', text: '•', before: '', after: '', placeholder: 'Пункт списка', format: formatUnorderedList },
   { label: 'Нумерованный список', text: '1.', before: '', after: '', placeholder: 'Пункт списка', format: formatOrderedList },
   { label: 'Сворачиваемый раздел', text: '▾', before: '\n<details>\n<summary>Заголовок раздела</summary>\n\n', after: '\n</details>', placeholder: 'Текст раздела' },
-  { label: 'Ссылка', text: 'Link', before: '[', after: '](https://)', placeholder: 'текст ссылки' },
+  { label: 'Ссылка', text: 'Link', before: '[', after: '](https://)', placeholder: 'текст ссылки', selectInAfterWhenSelected: 'https://' },
 ]
 
 function formatUnorderedList(text: string): string {
@@ -126,9 +130,18 @@ export default function MarkdownToolbar({ textareaRef, value, onChange }: Props)
     const next = `${value.slice(0, start)}${tool.before}${inner}${tool.after}${value.slice(end)}`
     onChange(next)
 
-    const cursorStart = start + tool.before.length
-    const cursorEnd = cursorStart + inner.length
-    restoreTextareaSelection(textareaRef, cursorStart, cursorEnd, selection)
+    const hadSelection = start !== end
+    const afterTarget = tool.selectInAfterWhenSelected
+    if (hadSelection && afterTarget) {
+      const offset = tool.after.indexOf(afterTarget)
+      const cursorStart = start + tool.before.length + inner.length + offset
+      const cursorEnd = cursorStart + afterTarget.length
+      restoreTextareaSelection(textareaRef, cursorStart, cursorEnd, selection)
+    } else {
+      const cursorStart = start + tool.before.length
+      const cursorEnd = cursorStart + inner.length
+      restoreTextareaSelection(textareaRef, cursorStart, cursorEnd, selection)
+    }
   }
 
   return (


### PR DESCRIPTION
При клике по кнопке «Ссылка» с уже выделенным текстом курсор оставался
на тексте ссылки — приходилось вручную искать https://. Теперь, если
текст был выделен, после вставки выделяется https:// в части `](...)`,
чтобы сразу вписать адрес. Без выделения поведение прежнее: выделяется
плейсхолдер «текст ссылки».

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
