### PR TITLE
fix: suppress matching presence audit noise

### DIFF
--- a/docs/features/audit-log.md
+++ b/docs/features/audit-log.md
@@ -35,7 +35,7 @@ export const auditLog = pgTable('audit_log', {
 
 ## Триггерная функция `audit_capture`
 
-Одна plpgsql-функция (`drizzle/0040_audit_triggers.sql`) навешивается триггером AFTER INSERT/UPDATE/DELETE на каждую аудируемую таблицу.
+Одна plpgsql-функция (`audit_capture`) навешивается триггером AFTER INSERT/UPDATE/DELETE на каждую аудируемую таблицу. Базовая версия создана в `0040`, а актуальное определение всегда находится в последней миграции с `CREATE OR REPLACE FUNCTION` (сейчас `0049_restore_matching_presence_audit_filter.sql`).
 
 Что делает функция:
 1. Формирует `v_before = to_jsonb(OLD)`, `v_after = to_jsonb(NEW)` по `TG_OP`.
@@ -44,13 +44,14 @@ export const auditLog = pgTable('audit_log', {
    - `telegram_preauth_tokens` → вырезает `token_hash`.
    - `book_summary_helpful_reactions` → вырезает псевдонимный `visitor_hash` из `before` и `after`.
 3. Для UPDATE вычисляет `changedFields` — ключи, где `v_after -> key IS DISTINCT FROM v_before -> key`.
-4. Собирает `entity_id`: сначала пробует `id`; при композитных PK — конкатенирует `session_id:user_id:book_id` (актуально для `book_priorities`, `signup_books`, `matching_*`).
-5. Читает контекст из transaction-local настроек:
+4. Не пишет чисто технические heartbeat-апдейты: `user.last_activity_at`, `user_identities.last_seen_at` и `matching_session_participants.last_seen_at`. Любое обновление этих строк вместе с бизнес-полем продолжает аудироваться.
+5. Собирает `entity_id`: сначала пробует `id`; при композитных PK — конкатенирует `session_id:user_id:book_id` (актуально для `book_priorities`, `signup_books`, `matching_*`).
+6. Читает контекст из transaction-local настроек:
    - `current_setting('app.audit_actor', true)` → `actor_user_id`
    - `current_setting('app.audit_label', true)` → `actor_label`
    - `current_setting('app.audit_source', true)` → `source`; если пусто — подставляет `'trigger'`
    - `current_setting('app.audit_reason', true)` → `reason`
-6. Вставляет строку в `audit_log`.
+7. Вставляет строку в `audit_log`.
 
 ## Реестр `AUDITED_TABLES`
 
@@ -188,3 +189,4 @@ FK на `actor_user_id` снят намеренно: `ON DELETE set null` пот
 - `components/nd/AdminAuditLog.tsx` — UI вкладки «История изменений»
 - `drizzle/0040_audit_triggers.test.ts` — reconciliation-тест реестра и триггеров
 - `drizzle/0047_summary_helpful_reactions.sql` — trigger для реакций и masking `visitor_hash`
+- `drizzle/0049_restore_matching_presence_audit_filter.sql` — актуальная функция с masking и подавлением matching heartbeat-телеметрии

--- a/docs/superpowers/plans/2026-06-29-matching-simplified.md
+++ b/docs/superpowers/plans/2026-06-29-matching-simplified.md
@@ -739,8 +739,8 @@ Expected: `CLEAN` или `BLOCKED`; при `BEHIND` выполнить `gh pr up
 
 - Modify: `lib/db/schema.ts`
 - Modify: `lib/audit/audited-tables.ts`
-- Create: `drizzle/0049_drop_legacy_matching.sql`
-- Create: `drizzle/0049_drop_legacy_matching.test.ts`
+- Create: `drizzle/0050_drop_legacy_matching.sql`
+- Create: `drizzle/0050_drop_legacy_matching.test.ts`
 - Modify: `drizzle/0040_audit_triggers.test.ts`
 - Modify docs if Phase A smoke revealed operational details
 
@@ -760,7 +760,7 @@ Expected: `CLEAN` или `BLOCKED`; при `BEHIND` выполнить `gh pr up
 - [ ] Выполнить красный test:
 
 ```bash
-npm test -- drizzle/0049_drop_legacy_matching.test.ts drizzle/0040_audit_triggers.test.ts
+npm test -- drizzle/0050_drop_legacy_matching.test.ts drizzle/0040_audit_triggers.test.ts
 ```
 
 Expected: FAIL до migration/schema cleanup.

--- a/docs/superpowers/plans/2026-06-30-matching-presence-audit.md
+++ b/docs/superpowers/plans/2026-06-30-matching-presence-audit.md
@@ -1,0 +1,15 @@
+# Matching Presence Audit Noise Fix
+
+**Goal:** Восстановить подавление чистых `last_seen_at` heartbeat-апдейтов в глобальном audit log.
+
+**Root cause:** `drizzle/0047_summary_helpful_reactions.sql` переопределил `audit_capture()` на базе устаревшей версии и потерял условие для `matching_session_participants`, добавленное в `0042`.
+
+## Steps
+
+1. Красным migration-test зафиксировать три обязательных telemetry-фильтра и все актуальные masking-правила.
+2. Добавить идемпотентную `0049`-миграцию только с `CREATE OR REPLACE FUNCTION audit_capture()`; таблицы и триггеры не менять.
+3. Обновить техническое описание аудита и Wiki базы данных.
+4. Проверить миграцию на E2E Neon-ветке: чистый heartbeat не создаёт audit row, а реальное изменение участника создаёт.
+5. Пройти lint/typecheck/unit/build, PR-flow и после merge применить тот же SQL к production через `scripts/apply-migration.mjs`.
+6. Проверить production-функцию и отсутствие новых heartbeat-строк; старые шумовые строки не удалять.
+

--- a/docs/wiki/Data-and-Database.md
+++ b/docs/wiki/Data-and-Database.md
@@ -210,6 +210,7 @@ erDiagram
 - `0046_book_slugs.sql` — nullable slug книги и уникальный индекс для красивых URL саммари.
 - `0047_summary_helpful_reactions.sql` — реакции, partial unique-индексы, audit trigger и masking `visitor_hash`.
 - `0048_matching_simplified.sql` — public refs, confirmations, locked circles, notices, matching events, ограничения и audit triggers нового flow.
+- `0049_restore_matching_presence_audit_filter.sql` — возвращает подавление чистых `last_seen_at` heartbeat-обновлений в глобальном audit log; старые шумовые записи сохраняются как история.
 - `0034_matching_pseudonym_reservations.sql` — временные резервы псевдонимов для welcome screen.
 - `0035_matching_preference_events.sql` — персистентная аналитика изменений предпочтений в matching.
 - `0036_drop_admin_views.sql` — удаление аудит-лога `admin_views` (бесполезный лог impersonation-просмотров).

--- a/drizzle/0040_audit_triggers.test.ts
+++ b/drizzle/0040_audit_triggers.test.ts
@@ -1,20 +1,23 @@
 /**
  * @jest-environment node
  */
-import { readFileSync } from 'fs'
+import { readdirSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { AUDITED_TABLES } from '../lib/audit/audited-tables'
 
 describe('0040 audit triggers migration', () => {
   const sql = readFileSync(join(process.cwd(), 'drizzle/0040_audit_triggers.sql'), 'utf8')
-  const allSql = [
-    '0040_audit_triggers.sql',
-    '0043_user_merge_events.sql',
-    '0044_book_summaries.sql',
-    '0045_book_summary_revisions.sql',
-    '0047_summary_helpful_reactions.sql',
-    '0048_matching_simplified.sql',
-  ].map(file => readFileSync(join(process.cwd(), 'drizzle', file), 'utf8')).join('\n')
+  const migrationFiles = readdirSync(join(process.cwd(), 'drizzle'))
+    .filter((file) => /^\d{4}_.+\.sql$/.test(file))
+    .sort()
+  const migrationSql = migrationFiles.map((file) => ({
+    file,
+    sql: readFileSync(join(process.cwd(), 'drizzle', file), 'utf8'),
+  }))
+  const allSql = migrationSql.map((migration) => migration.sql).join('\n')
+  const currentAuditFunctionSql = migrationSql
+    .filter((migration) => migration.sql.includes('CREATE OR REPLACE FUNCTION audit_capture()'))
+    .at(-1)?.sql
 
   it('defines the audit_capture function reading app.audit_* settings', () => {
     expect(sql).toContain('CREATE OR REPLACE FUNCTION audit_capture()')
@@ -33,9 +36,16 @@ describe('0040 audit triggers migration', () => {
     expect(sql).not.toContain('ON "audit_log"')
   })
 
-  it('masks secret columns before storing', () => {
-    expect(sql).toContain("v_before := v_before - 'token'")
-    expect(sql).toContain("v_before := v_before - 'token_hash'")
+  it('keeps every current mask in the latest audit_capture definition', () => {
+    expect(currentAuditFunctionSql).toContain("v_before := v_before - 'token'")
+    expect(currentAuditFunctionSql).toContain("v_before := v_before - 'token_hash'")
+    expect(currentAuditFunctionSql).toContain("v_before := v_before - 'visitor_hash'")
+  })
+
+  it('keeps telemetry-only updates out of the latest audit_capture definition', () => {
+    expect(currentAuditFunctionSql).toContain("TG_TABLE_NAME = 'user' AND v_changed <@ '[\"last_activity_at\"]'::jsonb")
+    expect(currentAuditFunctionSql).toContain("TG_TABLE_NAME = 'user_identities' AND v_changed <@ '[\"last_seen_at\"]'::jsonb")
+    expect(currentAuditFunctionSql).toContain("TG_TABLE_NAME = 'matching_session_participants' AND v_changed <@ '[\"last_seen_at\"]'::jsonb")
   })
 
   it('builds a composite entity_id for tables without an id column', () => {

--- a/drizzle/0049_restore_matching_presence_audit_filter.sql
+++ b/drizzle/0049_restore_matching_presence_audit_filter.sql
@@ -1,0 +1,72 @@
+CREATE OR REPLACE FUNCTION audit_capture() RETURNS trigger AS $$
+DECLARE
+  v_before jsonb;
+  v_after jsonb;
+  v_changed jsonb;
+  v_entity_id text;
+BEGIN
+  IF (TG_OP = 'DELETE') THEN
+    v_before := to_jsonb(OLD); v_after := NULL;
+  ELSIF (TG_OP = 'UPDATE') THEN
+    v_before := to_jsonb(OLD); v_after := to_jsonb(NEW);
+  ELSE
+    v_before := NULL; v_after := to_jsonb(NEW);
+  END IF;
+
+  IF TG_TABLE_NAME = 'verificationToken' THEN
+    v_before := v_before - 'token'; v_after := v_after - 'token';
+  ELSIF TG_TABLE_NAME = 'telegram_preauth_tokens' THEN
+    v_before := v_before - 'token_hash'; v_after := v_after - 'token_hash';
+  ELSIF TG_TABLE_NAME = 'book_summary_helpful_reactions' THEN
+    v_before := v_before - 'visitor_hash'; v_after := v_after - 'visitor_hash';
+  END IF;
+
+  IF (TG_OP = 'UPDATE') THEN
+    SELECT jsonb_agg(e.key) INTO v_changed
+    FROM jsonb_each(v_after) AS e
+    WHERE v_after -> e.key IS DISTINCT FROM v_before -> e.key;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND v_changed IS NOT NULL THEN
+    IF TG_TABLE_NAME = 'user' AND v_changed <@ '["last_activity_at"]'::jsonb THEN
+      RETURN NEW;
+    END IF;
+    IF TG_TABLE_NAME = 'user_identities' AND v_changed <@ '["last_seen_at"]'::jsonb THEN
+      RETURN NEW;
+    END IF;
+    IF TG_TABLE_NAME = 'matching_session_participants' AND v_changed <@ '["last_seen_at"]'::jsonb THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  v_entity_id := COALESCE(
+    v_after ->> 'id',
+    v_before ->> 'id',
+    NULLIF(concat_ws(':',
+      COALESCE(v_after ->> 'session_id', v_before ->> 'session_id'),
+      COALESCE(v_after ->> 'user_id',    v_before ->> 'user_id'),
+      COALESCE(v_after ->> 'book_id',    v_before ->> 'book_id')
+    ), ''),
+    v_after ->> 'tag',        v_before ->> 'tag',
+    v_after ->> 'identifier', v_before ->> 'identifier'
+  );
+
+  INSERT INTO audit_log
+    (id, actor_user_id, actor_label, source, action, entity_type, entity_id, before, after, changed_fields, reason)
+  VALUES (
+    gen_random_uuid()::text,
+    NULLIF(current_setting('app.audit_actor', true), ''),
+    NULLIF(current_setting('app.audit_label', true), ''),
+    COALESCE(NULLIF(current_setting('app.audit_source', true), ''), 'trigger'),
+    lower(TG_OP),
+    TG_TABLE_NAME,
+    v_entity_id,
+    v_before,
+    v_after,
+    v_changed,
+    NULLIF(current_setting('app.audit_reason', true), '')
+  );
+
+  IF (TG_OP = 'DELETE') THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/drizzle/0049_restore_matching_presence_audit_filter.test.ts
+++ b/drizzle/0049_restore_matching_presence_audit_filter.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+describe('0049 matching presence audit filter migration', () => {
+  const sql = readFileSync(
+    join(process.cwd(), 'drizzle/0049_restore_matching_presence_audit_filter.sql'),
+    'utf8',
+  )
+
+  it('replaces the shared audit capture function without changing triggers', () => {
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION audit_capture() RETURNS trigger')
+    expect(sql).not.toContain('CREATE TRIGGER')
+    expect(sql).not.toContain('DROP TRIGGER')
+  })
+
+  it('keeps every telemetry-only update out of the audit log', () => {
+    expect(sql).toContain("TG_TABLE_NAME = 'user' AND v_changed <@ '[\"last_activity_at\"]'::jsonb")
+    expect(sql).toContain("TG_TABLE_NAME = 'user_identities' AND v_changed <@ '[\"last_seen_at\"]'::jsonb")
+    expect(sql).toContain("TG_TABLE_NAME = 'matching_session_participants' AND v_changed <@ '[\"last_seen_at\"]'::jsonb")
+  })
+
+  it('preserves every current sensitive-field mask', () => {
+    expect(sql).toContain("v_before := v_before - 'token'; v_after := v_after - 'token';")
+    expect(sql).toContain("v_before := v_before - 'token_hash'; v_after := v_after - 'token_hash';")
+    expect(sql).toContain("v_before := v_before - 'visitor_hash'; v_after := v_after - 'visitor_hash';")
+  })
+})


### PR DESCRIPTION
## Summary
- restore the matching participant heartbeat filter lost by migration 0047
- preserve all current audit masks in a new idempotent 0049 function migration
- make the audit reconciliation test inspect the latest function definition dynamically
- document telemetry suppression and move the planned Phase B cleanup migration to 0050

## Verification
- E2E Neon transaction: audit counts 1 after insert, 1 after heartbeat, 2 after business-field update
- npm run lint
- npm run typecheck
- npm test -- --runInBand (186 suites, 1236 tests)
- npm run build