### PR TITLE
feat: тултип метрик сценария + мелкие правки доски matching

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -843,7 +843,18 @@ body {
   cursor: pointer;
 }
 .nd-book-link { position: relative; display: block; width: 54px; height: 76px; overflow: hidden; border-radius: 4px; box-shadow: var(--shadow-cover); }
-.nd-book-title-button { font-family: var(--nd-serif); font-size: 1rem; font-weight: 700; line-height: 1.15; }
+.nd-book-title-button { font-family: var(--nd-serif); font-size: 1rem; font-weight: 700; line-height: 1.15; transition: color 0.12s ease; }
+/* Clickable-book affordance in scenarios */
+.nd-book-link { transition: box-shadow 0.12s ease; }
+.nd-book-link:hover { box-shadow: var(--shadow-cover), 0 0 0 2px var(--accent); }
+.nd-book-title-button:hover { color: var(--accent); text-decoration: underline; }
+/* Scenario metrics tooltip (hover/focus on «Сценарий N») */
+.nd-scenario-label { position: relative; display: inline-block; cursor: help; }
+.nd-scenario-label-text { font-family: var(--nd-sans); font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-muted); border-bottom: 1px dotted var(--text-muted); padding-bottom: 2px; }
+.nd-scenario-label:hover .nd-scenario-label-text, .nd-scenario-label:focus-visible .nd-scenario-label-text { color: var(--text-secondary); border-bottom-color: var(--text-secondary); }
+.nd-scenario-tip { position: absolute; top: calc(100% + 6px); left: 0; z-index: 6; opacity: 0; pointer-events: none; transition: opacity 0.12s ease; max-width: 280px; white-space: normal; background: var(--text); color: var(--bg-input); font-family: var(--nd-sans); font-size: 0.68rem; line-height: 1.35; letter-spacing: normal; text-transform: none; font-weight: 400; padding: 0.4rem 0.6rem; border-radius: 6px; box-shadow: var(--shadow-pop); }
+.nd-scenario-label:hover .nd-scenario-tip, .nd-scenario-label:focus-visible .nd-scenario-tip { opacity: 1; }
+@media (prefers-reduced-motion: reduce) { .nd-scenario-tip { transition: none; } }
 .nd-text-action { margin-top: 0.35rem; color: var(--accent); text-decoration: underline; }
 .nd-primary-action {
   border: 0;

--- a/components/nd/MatchingSatisfactionFlow.tsx
+++ b/components/nd/MatchingSatisfactionFlow.tsx
@@ -99,7 +99,7 @@ export default function MatchingSatisfactionFlow({
       <Collapsible open={board}>
         <div className="nd-flow-slide-from-top flex flex-col">
           {board && header}
-          {board && <div style={{ height: 'min(68svh, 760px)', minHeight: 420 }}>{workspace}</div>}
+          {board && <div style={{ height: 'min(82svh, 920px)', minHeight: 420 }}>{workspace}</div>}
         </div>
       </Collapsible>
 

--- a/components/nd/MatchingScenarios.test.tsx
+++ b/components/nd/MatchingScenarios.test.tsx
@@ -81,22 +81,25 @@ describe('MatchingScenarios', () => {
     expect(screen.getByText('Первая книга')).toBeInTheDocument()
   })
 
-  it('renders cover, author and ranks without presentation metrics (canon: metrics hidden)', () => {
+  it('surfaces scenario metrics and left-out in a tooltip, and content without inline clutter', () => {
     const scenario = makeScenario('s1', [{ key: 'k1', bookId: 'book-1', memberRefs: ['r1', 'r2'] }])
     scenario.score = { coveredCount: 2, totalCount: 3, avgRank: 1.5, worstRank: 2 }
     scenario.leftOut = [{ ref: 'r3', displayName: 'Вера' }]
     scenario.circles[0].avgRank = 1.5
     scenario.circles[0].members[0] = { ...scenario.circles[0].members[0], displayName: 'Анна', rank: 1, interest: 'очень хочу' }
     render(<MatchingScenarios {...base} scenarios={[scenario]} />)
-    // metrics are intentionally hidden from the layout (white-canon restyle)
-    expect(screen.queryByText(/средний ранг/)).toBeNull()
-    expect(screen.queryByText(/охват/)).toBeNull()
-    expect(screen.queryByText(/За бортом/)).toBeNull()
-    expect(screen.queryByText(/участников/)).toBeNull()
+    // metrics + left-out live in the tooltip on «Сценарий N», not inline
+    const tip = screen.getByRole('tooltip')
+    expect(tip).toHaveTextContent('средний ранг 1.5')
+    expect(tip).toHaveTextContent('охват 2 из 3')
+    expect(tip).toHaveTextContent('за бортом: Вера')
     // content still present
     expect(screen.getByAltText('Обложка: Первая книга')).toBeVisible()
     expect(screen.getByText('Автор один')).toBeVisible()
-    expect(screen.getByText('Анна').closest('.nd-chip-text')).toHaveAttribute('title', expect.stringContaining('ранг 1'))
+    // participant tooltip: place only, no duplicated «ранг» wording
+    const chipTitle = screen.getByText('Анна').closest('.nd-chip-text')?.getAttribute('title') ?? ''
+    expect(chipTitle).toContain('на 1 месте')
+    expect(chipTitle).not.toContain('ранг')
     // no empty ○ glyph for unconfirmed members — only ✓ for confirmed
     expect(screen.queryByLabelText('Анна: не подтвердил')).toBeNull()
     expect(screen.queryByText('○')).toBeNull()

--- a/components/nd/MatchingScenarios.tsx
+++ b/components/nd/MatchingScenarios.tsx
@@ -19,6 +19,19 @@ interface Props {
 }
 
 function popupChips(circle: PublicScenarioCircle): BookParticipant[] { return circle.members.map(member => ({ ref: member.ref, bookId: circle.bookId, displayName: member.displayName, rank: member.rank, personalStatus: null })) }
+function formatRank(value: number | null) { return value === null ? '—' : Number.isInteger(value) ? String(value) : value.toFixed(1) }
+function circleWord(n: number) { const m10 = n % 10; const m100 = n % 100; return m10 === 1 && m100 !== 11 ? 'круг' : m10 >= 2 && m10 <= 4 && (m100 < 12 || m100 > 14) ? 'круга' : 'кругов' }
+// Why this scenario is ranked where it is — metrics + who is left out (data already
+// computed server-side; surfaced in a tooltip on the «Сценарий N» label).
+function scenarioTip(scenario: PublicScenario): string {
+  const parts = [
+    `средний ранг ${formatRank(scenario.score.avgRank)}`,
+    `${scenario.circles.length} ${circleWord(scenario.circles.length)}`,
+    `охват ${scenario.score.coveredCount} из ${scenario.score.totalCount}`,
+  ]
+  if (scenario.leftOut.length > 0) parts.push(`за бортом: ${scenario.leftOut.map(p => p.displayName).join(', ')}`)
+  return parts.join(' · ')
+}
 
 export default function MatchingScenarios({ sessionId, stateVersion, scenarios, viewerConfirmedCircleKey, viewerRole, frozen, booksById = {}, onConfirmationChange }: Props) {
   const { openBook } = useBookDetail()
@@ -50,7 +63,12 @@ export default function MatchingScenarios({ sessionId, stateVersion, scenarios, 
     <ul data-testid="matching-scenarios-list" style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '1rem' }}>
       {scenarios.map((scenario, index) => <li key={scenario.ref} data-testid="matching-scenario-card" style={{ background: 'var(--bg-input)', borderRadius: 'var(--radius-card)', boxShadow: 'var(--shadow-card)', padding: '1rem 1.2rem 1.15rem' }}>
         <header style={{ borderBottom: '1px solid var(--border-subtle)', paddingBottom: '0.7rem', marginBottom: '0.9rem' }}>
-          <h3 style={{ margin: 0, fontFamily: 'var(--nd-sans)', fontSize: '0.62rem', textTransform: 'uppercase', letterSpacing: '0.12em', color: 'var(--text-muted)' }}>Сценарий {index + 1}</h3>
+          <h3 style={{ margin: 0 }}>
+            <span className="nd-scenario-label" tabIndex={0}>
+              <span className="nd-scenario-label-text">Сценарий {index + 1}</span>
+              <span className="nd-scenario-tip" role="tooltip">{scenarioTip(scenario)}</span>
+            </span>
+          </h3>
         </header>
         <div className="nd-scenario-circles">
           {scenario.circles.map(circle => {

--- a/components/nd/ParticipantInterestChip.tsx
+++ b/components/nd/ParticipantInterestChip.tsx
@@ -43,7 +43,7 @@ export default function ParticipantInterestChip({
         opacity: dimmed ? 0.4 : 1,
         transition: 'opacity 0.16s ease, background 0.16s ease',
       }}
-      title={`${displayName}: ранг ${rank ?? '—'} · ${rankTooltip(rank)}`}
+      title={`${displayName}: ${rankTooltip(rank)}`}
     >
       <b
         style={{

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -412,6 +412,14 @@ test.describe('Matching restored board shell', () => {
     // Warm dashboard: soft control radius (var(--radius-control) = 8px), not sharp
     expect(parseFloat(ctaRadius)).toBeGreaterThan(0)
 
+    // Scenario metrics live in a tooltip on «Сценарий N» — hidden until hover/focus
+    const scnLabel = page.locator('.nd-scenario-label').first()
+    const scnTip = scnLabel.locator('.nd-scenario-tip')
+    expect(await scnTip.evaluate((element) => getComputedStyle(element).opacity)).toBe('0')
+    await scnLabel.hover()
+    await expect.poll(() => scnTip.evaluate((element) => getComputedStyle(element).opacity)).toBe('1')
+    await expect(scnTip).toContainText('средний ранг')
+
     // Clicking the CTA confirms immediately (no confirmation dialog)
     await cta.click()
 


### PR DESCRIPTION
По фидбеку (данные уже считаются сервером — только вытащил в UI):
- Вернул тултип на «Сценарий N»: «средний ранг X · N круг(а/ов) · охват K из M»,
  плюс «за бортом: имена» (раньше показывали инлайн). Данные из
  scenario.score / scenario.leftOut — сервер не трогал.
- Ховер-аффорданс на книге в сценарии: обложка → accent-кольцо, название →
  подчёркивание + accent (понятно, что кликабельно).
- Тултип имени участника: убрал дублирующее «ранг N», оставил «книга на N месте».
- Блок сценариев выше (min(68svh,760px) → min(82svh,920px)) — каталог внизу
  показывает только заголовки «Остальной каталог» / «Мои книги».

E2E: добавил в ui-states проверку тултипа сценария (скрыт → hover → виден).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
