### PR TITLE
fix: добавление книги на доске matching не выбрасывает на гейт

### DIFF
--- a/components/nd/MatchingPersonalList.test.tsx
+++ b/components/nd/MatchingPersonalList.test.tsx
@@ -1,8 +1,18 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import MatchingPersonalList from './MatchingPersonalList'
 import type { CatalogBook } from '@/lib/matching/personal-list'
 
-jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }) }))
+const refresh = jest.fn()
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn(), refresh: () => refresh() }) }))
+
+const addToList = jest.fn().mockResolvedValue(undefined)
+const patchPriorities = jest.fn().mockResolvedValue(undefined)
+jest.mock('@/lib/matching/personal-list-mutations', () => ({
+  addToList: (...args: unknown[]) => addToList(...args),
+  patchPriorities: (...args: unknown[]) => patchPriorities(...args),
+  patchStatus: jest.fn().mockResolvedValue(undefined),
+  removeFromList: jest.fn().mockResolvedValue(undefined),
+}))
 
 const myBook = {
   bookId: 'b1',
@@ -102,6 +112,28 @@ test('unranked active books are shown first with a calculation warning', () => {
   expect(rows[1]).toHaveTextContent('Книга A')
   expect(rows[1]).toHaveTextContent('#1')
   expect(getByText('Книги без приоритета не участвуют в расчете')).toBeInTheDocument()
+})
+
+test('adding a book from the catalog on the board saves it to the server as rank #1 (no ranking-gate bounce)', async () => {
+  refresh.mockClear()
+  addToList.mockClear()
+  patchPriorities.mockClear()
+
+  render(
+    <MatchingPersonalList
+      books={[myBook, catalogBook]}
+      bookParticipants={[]}
+      viewingUserId="u1"
+    />,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'Хочу читать' }))
+
+  await waitFor(() => expect(addToList).toHaveBeenCalledWith('b2', undefined))
+  await waitFor(() => expect(patchPriorities).toHaveBeenCalledWith(['b2', 'b1'], undefined, undefined))
+  // addToList must resolve before patchPriorities fires (FK signup_books → book_priorities).
+  expect(addToList.mock.invocationCallOrder[0]).toBeLessThan(patchPriorities.mock.invocationCallOrder[0])
+  await waitFor(() => expect(refresh).toHaveBeenCalled())
 })
 
 test('excludes the viewer from popup chips by opaque ref', () => {

--- a/components/nd/MatchingPersonalList.tsx
+++ b/components/nd/MatchingPersonalList.tsx
@@ -550,10 +550,19 @@ export default function MatchingPersonalList({
       setBooks(nextBooks)
       setModalBook((prev) => (prev?.bookId === bookId ? { ...prev, isInList: true, rank: 1 } : prev))
       signalBusy()
-      await addToList(bookId, mutationUserId)
-      notifyOrRefresh(nextBooks)
+      onBusyChange?.(true)
+      try {
+        await addToList(bookId, mutationUserId)
+        const activeIds = nextBooks
+          .filter((b) => b.isInList && b.personalStatus === null)
+          .map((b) => b.bookId)
+        await patchPriorities(activeIds, mutationUserId, priorityMutationSource)
+        notifyOrRefresh(nextBooks)
+      } finally {
+        onBusyChange?.(false)
+      }
     },
-    [books, mutationUserId, notifyOrRefresh, signalBusy, pending],
+    [books, mutationUserId, priorityMutationSource, notifyOrRefresh, signalBusy, onBusyChange, pending],
   )
 
   const handleRemoveFromList = useCallback(

--- a/e2e/matching-satisfaction.spec.ts
+++ b/e2e/matching-satisfaction.spec.ts
@@ -389,6 +389,45 @@ test('Ranking Gate: одна книга без явного drag-реордер�
   await expect(persistedRows.nth(0)).toContainText('#1')
 })
 
+test('добавление книги из каталога на доске не выбрасывает на Ranking Gate и сохраняет ранг #1 после reload', async ({
+  page,
+  createMatchingSession,
+  createTestBook,
+}) => {
+  const session = await createMatchingSession({ minGroupSize: 2, maxGroupSize: 2 })
+  const rankedBook = await createTestBook({ title: `E2E Board Ranked ${test.info().testId}`, author: 'Board Author' })
+  const catalogBook = await createTestBook({ title: `E2E Board Catalog ${test.info().testId}`, author: 'Board Author' })
+  await joinWithRankedBook(page, session.id, rankedBook.id, 'Читатель Board')
+
+  await page.goto('/matching')
+  await page.waitForLoadState('networkidle')
+  // Уже на доске: активная проранжированная книга, гейта нет.
+  await expect(page.getByTestId('ranking-gate')).toHaveCount(0)
+  await expect(page.getByTestId('matching-realtime-client')).toBeVisible()
+
+  const priorityResponse = page.waitForResponse((response) => (
+    response.request().method() === 'PATCH' && response.url().includes('/api/matching/priorities')
+  ))
+  const catalogRow = page.getByTestId('matching-catalog-available').getByRole('listitem').filter({ hasText: catalogBook.title })
+  await catalogRow.hover()
+  await catalogRow.getByRole('button', { name: 'Хочу читать' }).click()
+  expect((await priorityResponse).ok()).toBe(true)
+
+  // Остаёмся на доске — гейт не появляется.
+  await expect(page.getByTestId('ranking-gate')).toHaveCount(0)
+  await expect(page.getByTestId('matching-realtime-client')).toBeVisible()
+
+  await page.reload()
+  await expect(page.getByTestId('ranking-gate')).toHaveCount(0)
+  await expect(page.getByTestId('matching-realtime-client')).toBeVisible()
+  const persistedRows = page.getByTestId('pl-books-ul').locator(':scope > li')
+  await expect(persistedRows).toHaveCount(2)
+  await expect(persistedRows.nth(0)).toContainText(catalogBook.title)
+  await expect(persistedRows.nth(0)).toContainText('#1')
+  await expect(persistedRows.nth(1)).toContainText(rankedBook.title)
+  await expect(persistedRows.nth(1)).toContainText('#2')
+})
+
 test('выход из сессии делает hard navigation и остаётся Welcome после reload', async ({
   page,
   createMatchingSession,


### PR DESCRIPTION
При добавлении книги из «Остального каталога» на доске handleAddToList
сохранял только запись в signup_books, но не приоритет — после refresh
у книги rank=null → listCanEnterSession=false → пользователя выбрасывало
на экран «Сначала — расставь приоритеты», теряя контекст.

Теперь новая книга по умолчанию встаёт на первое место и её приоритет
сразу персистится (patchPriorities), поэтому пользователь остаётся на
доске. Busy-обёртка по аналогии с applyNewOrder.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
