### PR TITLE
fix: sticky-кнопка «Войти» на мобильном гейте matching

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1126,6 +1126,18 @@ body {
   }
   .nd-mx-gate-foot button { width: 100% !important; }
 
+  /* §4 Gate: the sticky footer lives inside a .nd-flow-collapsible whose inner
+     clips overflow (for the grid-rows grow/collapse animation). Any ancestor
+     with overflow != visible breaks `position: sticky`, so without this the CTA
+     never pins to the viewport bottom — it ends up buried below the two panels
+     at the very end of the scrolled page (the reported bug). Un-clip only the
+     footer's own collapsible so the sticky CTA works; other collapsibles (board
+     chrome, gate intro) keep their clipping. */
+  .nd-mx-foot-collapsible,
+  .nd-mx-foot-collapsible > .nd-flow-collapsible-inner {
+    overflow: visible !important;
+  }
+
   /* §5 Book popup: bottom-sheet overlay + dialog. */
   .nd-mx-sheet-overlay { padding: 0 !important; align-items: flex-end !important; }
   .nd-mx-sheet {

--- a/components/nd/MatchingSatisfactionFlow.tsx
+++ b/components/nd/MatchingSatisfactionFlow.tsx
@@ -10,9 +10,9 @@ import { listHasActiveBook } from '@/lib/matching/ranking-readiness'
  *  grows from zero height together with its content (pushing the catalog down),
  *  rather than expanding a fixed 100svh viewport — gentle, coupled motion.
  *  Timing + reduced-motion live in globals.css (.nd-flow-collapsible). */
-function Collapsible({ open, children }: { open: boolean; children: React.ReactNode }) {
+function Collapsible({ open, className, children }: { open: boolean; className?: string; children: React.ReactNode }) {
   return (
-    <div className={'nd-flow-collapsible' + (open ? ' is-open' : '')}>
+    <div className={'nd-flow-collapsible' + (open ? ' is-open' : '') + (className ? ' ' + className : '')}>
       <div className="nd-flow-collapsible-inner">{children}</div>
     </div>
   )
@@ -177,7 +177,7 @@ export default function MatchingSatisfactionFlow({
 
       {/* Gate footer (collapses on enter) */}
       {!board && (
-        <Collapsible open>
+        <Collapsible open className="nd-mx-foot-collapsible">
           <div
           className="nd-flow-fade-collapse p-4 nd-mx-gate-foot"
           style={{

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -1085,6 +1085,62 @@ test.describe('Satisfaction ranking gate layout', () => {
     expect(box).not.toBeNull()
     expect(box!.y + box!.height).toBeLessThanOrEqual(viewport.height + 1)
   })
+
+  test('на мобильном (375×812) кнопка «Войти в сессию» видна и находится в пределах вьюпорта', async ({
+    page,
+    createMatchingSession,
+    createTestBook,
+    loginAsUser,
+  }) => {
+    const session = await createMatchingSession({
+      minGroupSize: 3,
+      maxGroupSize: 3,
+    })
+    const bookA = await createTestBook({ title: `UI Gate Mobile Book A ${Date.now()}`, author: 'Gate Author' })
+    const bookB = await createTestBook({ title: `UI Gate Mobile Book B ${Date.now()}`, author: 'Gate Author' })
+
+    // Two participants with complete rankings so the gate is reachable
+    await loginAsUser({ name: 'UI Gate Mobile Peer One' })
+    await joinMatchingSessionAndAddBooks(page, session.id, [bookA.id, bookB.id])
+    await loginAsUser({ name: 'UI Gate Mobile Peer Two' })
+    await joinMatchingSessionAndAddBooks(page, session.id, [bookA.id, bookB.id])
+
+    // Third participant joins but has NOT submitted a ranking — should see the gate
+    await loginAsUser({ name: 'UI Gate Mobile Viewer' })
+    const joinRes = await page.request.post(`/api/matching/sessions/${session.id}/join`, {
+      data: { name: 'UI Gate Mobile Viewer' },
+    })
+    expect(joinRes.ok()).toBe(true)
+    const addRes = await page.request.post('/api/matching/books', { data: { bookId: bookA.id } })
+    expect(addRes.ok()).toBe(true)
+
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.setViewportSize({ width: 375, height: 812 })
+    await page.goto('/matching')
+    await page.waitForLoadState('networkidle')
+
+    const gate = page.getByTestId('ranking-gate')
+    await expect(gate).toBeVisible()
+
+    const enter = page.getByTestId('ranking-gate-enter')
+    const viewport = page.viewportSize()!
+
+    // На мобиле гейт скроллится как обычная страница, а CTA — sticky-бар. Кнопка
+    // обязана быть в пределах вьюпорта БЕЗ доскролла до самого низа (иначе она
+    // тонет под панелями — это и был баг: sticky ломался overflow:hidden предком).
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await expect(enter).toBeVisible()
+    let box = await enter.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.y).toBeGreaterThanOrEqual(0)
+    expect(box!.y + box!.height).toBeLessThanOrEqual(viewport.height + 1)
+
+    // И остаётся приклеенной после прокрутки страницы вниз.
+    await page.mouse.wheel(0, 400)
+    box = await enter.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.y + box!.height).toBeLessThanOrEqual(viewport.height + 1)
+  })
 })
 
 test.describe('BookCardMobile: responsive layout', () => {


### PR DESCRIPTION
CTA-футер (.nd-mx-gate-foot, position:sticky) лежит внутри
.nd-flow-collapsible, чей .nd-flow-collapsible-inner имеет overflow:hidden
(для grow/collapse-анимации). Предок с overflow!=visible ломает sticky —
кнопка не приклеивалась к низу вьюпорта, а тонула в самом конце длинной
страницы под двумя 60vh-панелями. На телефоне её было не видно.

Разжимаем overflow только у collapsible футера (nd-mx-foot-collapsible)
в мобильном медиазапросе — sticky снова работает, остальные collapsible
(board chrome, интро гейта) не тронуты. Collapsible получил опциональный
className.

E2E ui-states: тест переписан — кнопка обязана быть в пределах вьюпорта
без доскролла до низа и оставаться приклеенной после прокрутки (раньше
scrollIntoViewIfNeeded маскировал баг).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
