### PR TITLE
fix: мобильная шапка matching не влезала в 390px (min-width на заголовке)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1079,7 +1079,7 @@ body {
 
   /* §3 Compact header. */
   .nd-mx-hdr { padding: 0.5rem 0.9rem !important; column-gap: 0.6rem !important; }
-  .nd-mx-hdr-title { font-size: 1rem !important; flex: 1 1 auto !important; overflow: hidden !important; text-overflow: ellipsis !important; white-space: nowrap !important; }
+  .nd-mx-hdr-title { font-size: 1rem !important; flex: 1 1 auto !important; min-width: 0 !important; overflow: hidden !important; text-overflow: ellipsis !important; white-space: nowrap !important; }
   .nd-mx-hdr-groups,
   .nd-mx-hdr-you,
   .nd-mx-hdr-deadline,


### PR DESCRIPTION
.nd-mx-hdr-title имел flex/overflow/ellipsis, но без min-width:0 — в flex-строке
элемент не сжимается ниже min-content, поэтому длинный заголовок сессии не
обрезался ellipsis-ом и распирал ряд за пределы вьюпорта (~26px overflow на 390px).
Добавлен min-width:0, теперь заголовок клипается. Ловит e2e ui-states:153
(header control ends inside viewport).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
