### PR TITLE
fix(e2e): добить красный matching E2E (проверено локально на e2e-ветке)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1079,6 +1079,9 @@ body {
 
   /* §3 Compact header. */
   .nd-mx-hdr { padding: 0.5rem 0.9rem !important; column-gap: 0.6rem !important; }
+  /* Left group must be able to shrink below its content so the title actually
+     ellipsis-clips (a nowrap title otherwise keeps the group at full text width). */
+  .nd-mx-hdr-l { flex: 1 1 auto !important; min-width: 0 !important; }
   .nd-mx-hdr-title { font-size: 1rem !important; flex: 1 1 auto !important; min-width: 0 !important; overflow: hidden !important; text-overflow: ellipsis !important; white-space: nowrap !important; }
   /* Hide the participant avatar stack on mobile — only the count remains (tap opens
      the popover). Frees ~100px so the compact header fits a 390px viewport. */
@@ -1119,15 +1122,23 @@ body {
     max-height: 60vh !important;
   }
 
-  /* §4 Gate: sticky footer with safe-area padding. */
+  /* §4 Gate: pin the «Войти» CTA to the viewport bottom. position:sticky doesn't
+     work here — the footer sits in its own collapsible whose grid cell is exactly
+     footer-height, so sticky has no range to pin. position:fixed pins to the
+     viewport reliably (no transform ancestors in the gate chain). Content gets a
+     matching bottom pad so the last book isn't hidden behind it. */
   .nd-mx-gate-foot {
-    position: sticky !important;
+    position: fixed !important;
+    left: 0 !important;
+    right: 0 !important;
     bottom: 0 !important;
+    z-index: 20 !important;
     background: var(--bg) !important;
     border-top: 1px solid var(--hair) !important;
     padding-bottom: calc(1rem + env(safe-area-inset-bottom)) !important;
   }
   .nd-mx-gate-foot button { width: 100% !important; }
+  .nd-mx-gate-root { padding-bottom: 5.5rem !important; }
 
   /* §4 Gate: the sticky footer lives inside a .nd-flow-collapsible whose inner
      clips overflow (for the grid-rows grow/collapse animation). Any ancestor

--- a/components/nd/MatchingHeader.tsx
+++ b/components/nd/MatchingHeader.tsx
@@ -121,7 +121,7 @@ export default function MatchingHeader(props: MatchingHeaderProps) {
     {props.isImpersonating && <div data-testid="admin-impersonation-banner" style={{ padding: '0.45rem 1.3rem', borderBottom: '1px solid var(--border)', color: 'var(--status-warn)' }}>👁 Просмотр за {props.viewer.displayName}<a href="/admin?tab=matching" style={{ float: 'right', color: 'inherit' }}>← вернуться в админку</a></div>}
     <header data-testid="matching-header" className="nd-mx-hdr" style={{ padding: '0.7rem 1.3rem', borderBottom: '1px solid var(--border-strong)', background: 'var(--bg)' }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.85rem', flexWrap: 'wrap' }}>
+        <div className="nd-mx-hdr-l" style={{ display: 'flex', alignItems: 'center', gap: '0.85rem', flexWrap: 'wrap' }}>
           <a href="/" aria-label="На каталог" className="nd-back-to-catalog" style={{ fontFamily: 'var(--nd-sans)', fontSize: '0.8rem', color: 'var(--text-secondary)' }}>←<span className="nd-mx-hdr-back-text"> Каталог</span></a><span className="nd-mx-hdr-div" style={{ width: 1, height: 22, background: 'var(--border)' }} />
           <h1 className="nd-mx-hdr-title" style={{ margin: 0, fontFamily: 'var(--nd-serif)', fontSize: '1.2rem', fontWeight: 700, letterSpacing: '-0.01em', lineHeight: 1.1, color: 'var(--text)' }}>{props.sessionName}</h1>
           {editingSize ? <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>

--- a/e2e/admin-tools.spec.ts
+++ b/e2e/admin-tools.spec.ts
@@ -1,12 +1,7 @@
 import { test, expect } from './fixtures'
 
-test('admin gallery page renders species photos', async ({ page, loginAsAdmin }) => {
-  await loginAsAdmin()
-  await page.goto('/admin/gallery')
-  await page.waitForLoadState('networkidle')
-  await expect(page.getByRole('heading', { name: 'Галерея фото видов' })).toBeVisible()
-  expect(await page.locator('main img').count()).toBeGreaterThan(0)
-})
+// The species-photo pseudonym gallery (/admin/gallery) was removed together with
+// pseudonyms in the matching simplification (#431). Only the sitemap page remains.
 
 test('admin sitemap page lists site routes', async ({ page, loginAsAdmin }) => {
   await loginAsAdmin()
@@ -16,10 +11,8 @@ test('admin sitemap page lists site routes', async ({ page, loginAsAdmin }) => {
   await expect(page.getByRole('link', { name: '/matching', exact: true })).toBeVisible()
 })
 
-test('admin gallery and sitemap redirect non-admins', async ({ page, loginAsUser }) => {
+test('admin sitemap redirects non-admins', async ({ page, loginAsUser }) => {
   await loginAsUser({ name: 'E2E Non-Admin' })
-  await page.goto('/admin/gallery')
-  await expect(page).toHaveURL(/\/$/)
   await page.goto('/admin/sitemap')
   await expect(page).toHaveURL(/\/$/)
 })

--- a/e2e/matching-satisfaction.spec.ts
+++ b/e2e/matching-satisfaction.spec.ts
@@ -252,10 +252,11 @@ test('Welcome раскрывает реальные имена и сохраня
 
   await page.getByTestId('welcome-name-input').fill('Новое имя')
   await page.getByTestId('welcome-join-button').click()
-  await expect(page.getByTestId('matching-realtime-client')).toBeVisible({ timeout: 15_000 })
-  await expect(page.getByTestId('ranking-gate')).toHaveCount(0)
-  await expect(page.getByTestId('matching-header')).toBeVisible()
-  await expect(page.getByTestId('matching-scenarios-workspace')).toBeVisible()
+  // Session has no ranked books yet, so joining lands on the ranking gate (per the
+  // gate readiness rule, #439). What this test verifies is that we leave the welcome
+  // and the edited name persists — not the board vs gate distinction.
+  await expect(page.getByTestId('ranking-gate')).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByTestId('welcome-name-input')).toHaveCount(0)
   await expect(page.getByTestId('matching-catalog-panel')).toBeVisible()
 
   await page.reload()


### PR DESCRIPTION
Все 4 падавших теста воспроизведены и починены локальным прогоном e2e:

- ui-states:153 — мобильная шапка вылезала за 390px не из-за заголовка, а из-за
  левой группы: у неё не было min-width:0, поэтому nowrap-заголовок держал
  группу на полной ширине текста и не клипался. Добавлен .nd-mx-hdr-l
  { flex:1 1 auto; min-width:0 }.
- ui-states:1089 — sticky-кнопка «Войти» на мобильном гейте не приклеивалась:
  футер лежит в отдельном collapsible, чей grid-cell равен высоте футера, так
  что position:sticky некуда цепляться. Переведён на position:fixed к низу
  вьюпорта + padding-bottom у контента гейта.
- matching-satisfaction:238 — сессия без книг → по логике #439 после джойна
  показывается ranking gate (не board). Тест приведён к фактическому
  поведению: проверяем уход с welcome + сохранение имени (board vs gate — не
  суть теста).
- admin-tools — /admin/gallery («Галерея фото видов») удалён вместе с
  псевдонимами в #431; мёртвые тесты галереи убраны, sitemap-тесты оставлены.

E2E: проверено локально (npm run test:e2e) против изолированной Neon e2e-ветки.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
