### PR TITLE
fix(e2e): починить два красных matching-теста (гонка версий + забытый login)

### DIFF
--- a/e2e/matching-satisfaction.spec.ts
+++ b/e2e/matching-satisfaction.spec.ts
@@ -394,10 +394,12 @@ test('добавление книги из каталога на доске не
   page,
   createMatchingSession,
   createTestBook,
+  loginAsUser,
 }) => {
   const session = await createMatchingSession({ minGroupSize: 2, maxGroupSize: 2 })
   const rankedBook = await createTestBook({ title: `E2E Board Ranked ${test.info().testId}`, author: 'Board Author' })
   const catalogBook = await createTestBook({ title: `E2E Board Catalog ${test.info().testId}`, author: 'Board Author' })
+  await loginAsUser({ name: 'Читатель Board' })
   await joinWithRankedBook(page, session.id, rankedBook.id, 'Читатель Board')
 
   await page.goto('/matching')

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -337,21 +337,26 @@ test.describe('Matching restored board shell', () => {
       const activeDesktopWorkspace = await page.getByTestId('matching-scenarios-workspace').boundingBox()
       expect(activeDesktopWorkspace).not.toBeNull()
 
-      const firstState = await (await page.request.get(`/api/matching/state?session=${session.id}`)).json() as {
-        session: { stateVersion: number }
-        scenarios: Array<{ circles: Array<{ circleKey: string; viewerIsMember: boolean }> }>
+      // Каждый актёр закрепляет свой круг. expectedStateVersion, взятый до PUT,
+      // может устареть, пока предыдущий актёр коммитит подтверждение (гонка версий),
+      // из-за чего в CI (быстрый prod-сервер) PUT иногда возвращает 409. Поэтому
+      // перечитываем свежий stateVersion прямо перед каждой попыткой и ретраим на конфликте.
+      const confirmOwnCircle = async (requestCtx: typeof page.request) => {
+        await expect.poll(async () => {
+          const state = await (await requestCtx.get(`/api/matching/state?session=${session.id}`)).json() as {
+            session: { stateVersion: number }
+            scenarios: Array<{ circles: Array<{ circleKey: string; viewerIsMember: boolean }> }>
+          }
+          const circle = state.scenarios.flatMap(scenario => scenario.circles).find(candidate => candidate.viewerIsMember)
+          if (!circle) return false
+          return (await requestCtx.put(`/api/matching/sessions/${session.id}/confirmation`, { data: { circleKey: circle.circleKey, expectedStateVersion: state.session.stateVersion } })).ok()
+        }, { message: 'actor confirms its own circle (retries on stale stateVersion)' }).toBe(true)
       }
-      const firstCircle = firstState.scenarios.flatMap(scenario => scenario.circles).find(candidate => candidate.viewerIsMember)!
-      expect((await page.request.put(`/api/matching/sessions/${session.id}/confirmation`, { data: { circleKey: firstCircle.circleKey, expectedStateVersion: firstState.session.stateVersion } })).ok()).toBe(true)
-      const peerState = await (await peer.request.get(`/api/matching/state?session=${session.id}`)).json() as typeof firstState
-      const peerCircle = peerState.scenarios.flatMap(scenario => scenario.circles).find(candidate => candidate.viewerIsMember)!
-      expect((await peer.request.put(`/api/matching/sessions/${session.id}/confirmation`, { data: { circleKey: peerCircle.circleKey, expectedStateVersion: peerState.session.stateVersion } })).ok()).toBe(true)
 
+      await confirmOwnCircle(page.request)
+      await confirmOwnCircle(peer.request)
       for (const actor of registryPages) {
-        const state = await (await actor.request.get(`/api/matching/state?session=${session.id}`)).json() as typeof firstState
-        const circle = state.scenarios.flatMap(scenario => scenario.circles).find(candidate => candidate.viewerIsMember)!
-        expect(circle).toBeDefined()
-        expect((await actor.request.put(`/api/matching/sessions/${session.id}/confirmation`, { data: { circleKey: circle.circleKey, expectedStateVersion: state.session.stateVersion } })).ok()).toBe(true)
+        await confirmOwnCircle(actor.request)
       }
 
       await page.reload()


### PR DESCRIPTION
- ui-states:153 — registry-актёры закрепляли круги с expectedStateVersion,
  взятым до PUT; в CI (быстрый prod-сервер) версия устаревала → 409 →
  .ok()=false. Обёрнуто в expect.poll: свежий stateVersion перед каждой
  попыткой + ретрай на конфликте. Проверено локально на e2e-ветке.
- matching-satisfaction:393 (#453) — тест не логинил пользователя перед
  join, POST /join отдавал 401. Добавлен loginAsUser (как в соседних
  проходящих тестах). Красный с #453, т.к. E2E не в merge-gate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
