### PR TITLE
feat: обогатить тултип сценария matching

### DIFF
--- a/components/nd/MatchingScenarios.test.tsx
+++ b/components/nd/MatchingScenarios.test.tsx
@@ -90,9 +90,10 @@ describe('MatchingScenarios', () => {
     render(<MatchingScenarios {...base} scenarios={[scenario]} />)
     // metrics + left-out live in the tooltip on «Сценарий N», not inline
     const tip = screen.getByRole('tooltip')
-    expect(tip).toHaveTextContent('средний ранг 1.5')
     expect(tip).toHaveTextContent('охват 2 из 3')
     expect(tip).toHaveTextContent('за бортом: Вера')
+    expect(tip).toHaveTextContent('круги: «Первая книга» 2 чел. (ранг 1.5)')
+    expect(tip).toHaveTextContent('средний ранг 1.5 (справочно)')
     // content still present
     expect(screen.getByAltText('Обложка: Первая книга')).toBeVisible()
     expect(screen.getByText('Автор один')).toBeVisible()
@@ -104,6 +105,18 @@ describe('MatchingScenarios', () => {
     expect(screen.queryByLabelText('Анна: не подтвердил')).toBeNull()
     expect(screen.queryByText('○')).toBeNull()
     expect(screen.queryByText(/лучший|оптимальный/i)).toBeNull()
+  })
+
+  it('shows full-coverage wording in the tooltip and no left-out line when nobody is left out', () => {
+    const scenario = makeScenario('s1', [{ key: 'k1', bookId: 'book-1', memberRefs: ['r1', 'r2'] }])
+    scenario.score = { coveredCount: 3, totalCount: 3, avgRank: 2, worstRank: 2 }
+    scenario.circles[0].avgRank = 2
+    render(<MatchingScenarios {...base} scenarios={[scenario]} />)
+    const tip = screen.getByRole('tooltip')
+    expect(tip).toHaveTextContent('полный охват (3 из 3)')
+    expect(tip).not.toHaveTextContent('за бортом')
+    expect(tip).toHaveTextContent('круги: «Первая книга» 2 чел. (ранг 2)')
+    expect(tip).toHaveTextContent('средний ранг 2 (справочно)')
   })
 
   it('opens the shared book popup from title and cover', () => {

--- a/components/nd/MatchingScenarios.tsx
+++ b/components/nd/MatchingScenarios.tsx
@@ -20,16 +20,28 @@ interface Props {
 
 function popupChips(circle: PublicScenarioCircle): BookParticipant[] { return circle.members.map(member => ({ ref: member.ref, bookId: circle.bookId, displayName: member.displayName, rank: member.rank, personalStatus: null })) }
 function formatRank(value: number | null) { return value === null ? '—' : Number.isInteger(value) ? String(value) : value.toFixed(1) }
-function circleWord(n: number) { const m10 = n % 10; const m100 = n % 100; return m10 === 1 && m100 !== 11 ? 'круг' : m10 >= 2 && m10 <= 4 && (m100 < 12 || m100 > 14) ? 'круга' : 'кругов' }
-// Why this scenario is ranked where it is — metrics + who is left out (data already
-// computed server-side; surfaced in a tooltip on the «Сценарий N» label).
-function scenarioTip(scenario: PublicScenario): string {
+const TITLE_MAX = 22
+function truncateTitle(title: string): string {
+  return title.length > TITLE_MAX ? `${title.slice(0, TITLE_MAX).trimEnd()}…` : title
+}
+
+// Почему сценарий стоит на своём месте: сортировка идёт круг-к-кругу (сильнейший
+// круг первым), а не по среднему рангу. Тултип ведёт охватом и разбивкой по кругам
+// (размер + средний ранг внутри круга — это и есть ключ сортировки), а общий
+// средний ранг помечен справочным, т.к. это лишь финальный тай-брейкер.
+function scenarioTip(scenario: PublicScenario, booksById: Record<string, ScenarioBookMeta>): string {
+  const { coveredCount, totalCount } = scenario.score
   const parts = [
-    `средний ранг ${formatRank(scenario.score.avgRank)}`,
-    `${scenario.circles.length} ${circleWord(scenario.circles.length)}`,
-    `охват ${scenario.score.coveredCount} из ${scenario.score.totalCount}`,
+    coveredCount >= totalCount
+      ? `полный охват (${coveredCount} из ${totalCount})`
+      : `охват ${coveredCount} из ${totalCount}`,
   ]
   if (scenario.leftOut.length > 0) parts.push(`за бортом: ${scenario.leftOut.map(p => p.displayName).join(', ')}`)
+  const circles = scenario.circles
+    .map(circle => `«${truncateTitle(booksById[circle.bookId]?.title ?? 'Книга')}» ${circle.memberCount} чел. (ранг ${formatRank(circle.avgRank)})`)
+    .join(' · ')
+  parts.push(`круги: ${circles}`)
+  parts.push(`средний ранг ${formatRank(scenario.score.avgRank)} (справочно)`)
   return parts.join(' · ')
 }
 
@@ -66,7 +78,7 @@ export default function MatchingScenarios({ sessionId, stateVersion, scenarios, 
           <h3 style={{ margin: 0 }}>
             <span className="nd-scenario-label" tabIndex={0}>
               <span className="nd-scenario-label-text">Сценарий {index + 1}</span>
-              <span className="nd-scenario-tip" role="tooltip">{scenarioTip(scenario)}</span>
+              <span className="nd-scenario-tip" role="tooltip">{scenarioTip(scenario, booksById)}</span>
             </span>
           </h3>
         </header>


### PR DESCRIPTION
Тултип на «Сценарий N» вёл средним рангом, который читается как ключ
сортировки, хотя это лишь финальный тай-брейкер. Реальный критерий —
охват + сила кругов (сравнение круг-к-кругу, сильнейший первым).

Теперь тултип ведёт охватом (полный/неполный + кто за бортом), даёт
разбивку по кругам (название книги, число участников, средний ранг
круга — это и есть ключ сортировки), а общий средний ранг вынесен в
конец с пометкой «(справочно)». Длинные названия усекаются.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
