### PR TITLE
fix: боттом-шит книги меряется в svh — не открывается выше экрана на iOS

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1157,7 +1157,14 @@ body {
   .nd-mx-sheet {
     max-width: 100% !important;
     width: 100% !important;
+    /* svh, а не vh: на iOS `vh` считается от «большого» вьюпорта (адресная строка
+       спрятана), поэтому при показанной адресной строке шит открывался выше экрана
+       и его верх с крестиком уезжал за кадр (виден только после ручного скролла,
+       когда iOS пересчитывает вьюпорт). `svh` = высота при показанном UI браузера —
+       худший случай, так что шит всегда помещается сразу. `vh` оставлен фолбэком
+       для браузеров без поддержки svh. */
     max-height: 92vh !important;
+    max-height: 92svh !important;
     border-radius: var(--radius-card) var(--radius-card) 0 0 !important;
     padding-bottom: env(safe-area-inset-bottom) !important;
     animation: nd-mx-sheet-in 0.24s ease-out;

--- a/e2e/ui-states.spec.ts
+++ b/e2e/ui-states.spec.ts
@@ -460,6 +460,14 @@ test.describe('Matching restored board shell', () => {
 
       const closeButton = dialog.getByRole('button', { name: 'Закрыть' })
 
+      // Крестик виден СРАЗУ на открытии, без единого скролла: шит меряется в svh,
+      // поэтому не открывается выше вьюпорта (иначе верх с крестиком уезжал за кадр
+      // и появлялся только после ручной прокрутки — репорт пользователя).
+      const openBox = await closeButton.boundingBox()
+      expect(openBox, 'close button has geometry on open').not.toBeNull()
+      expect(openBox!.y, 'close button top edge on-screen on open').toBeGreaterThanOrEqual(0)
+      expect(openBox!.y + openBox!.height, 'close button bottom edge on-screen on open').toBeLessThanOrEqual(viewport.height + 1)
+
       // Скроллится только внутренний .nd-mx-sheet-scroll (сам диалог — overflow:hidden,
       // крестик прибит к нему). Прокручиваем тело вниз до упора: на длинном описании
       // это уводило крестик, пока он жил внутри прокрутки.


### PR DESCRIPTION
Настоящая причина «крестик пропал»: на iOS `vh` считается от «большого»
вьюпорта (со спрятанной адресной строкой). При показанной адресной строке
шит с max-height:92vh оказывался выше видимой области, и его верх с
крестиком уезжал за кадр — крестик появлялся только после ручного скролла,
когда iOS пересчитывал вьюпорт (репорт + два скрина пользователя).

Перевёл max-height шита на 92svh (svh = высота при показанном UI браузера,
худший случай) — шит всегда помещается в экран сразу, крестик виден без
скролла. `vh` оставлен строкой выше как фолбэк для старых браузеров.
Проект уже использует svh (globals.css:521), паттерн знакомый.

E2E: в ui-states.spec.ts добавлена проверка, что крестик в пределах вьюпорта
СРАЗУ на открытии, до единого скролла.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
