### PR TITLE
perf(admin): виджеты AdminFooter опрашивают только при активной вкладке

### DIFF
--- a/components/nd/AdminStatusBar.tsx
+++ b/components/nd/AdminStatusBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback } from 'react'
+import { useVisibleInterval } from './use-visible-interval'
 
 interface CiStatus {
   status: string
@@ -85,11 +86,13 @@ export default function AdminStatusBar({ refreshSignal = 0 }: AdminStatusBarProp
     }
   }, [])
 
+  // Опрос только при активной вкладке (не крутить Vercel-функции из фоновой вкладки).
+  useVisibleInterval(fetchStatus, 60_000)
+
+  // Ручной рефреш по кнопке в AdminFooter.
   useEffect(() => {
-    fetchStatus()
-    const id = setInterval(fetchStatus, 60_000)
-    return () => clearInterval(id)
-  }, [fetchStatus, refreshSignal])
+    if (refreshSignal > 0) fetchStatus()
+  }, [refreshSignal, fetchStatus])
 
   if (loading) {
     return <div style={BASE_STYLE}><span style={{ color: 'var(--text-muted)' }}>загрузка статусов…</span></div>

--- a/components/nd/AllureWidget.tsx
+++ b/components/nd/AllureWidget.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback } from 'react'
+import { useVisibleInterval } from './use-visible-interval'
 
 interface AllureSummary {
   statistic: {
@@ -74,11 +75,14 @@ export default function AllureWidget({ refreshSignal = 0 }: AllureWidgetProps) {
     }
   }, [])
 
+  // Опрос только при активной вкладке (единообразие с остальными виджетами;
+  // источник внешний — GitHub Pages, но лишние фоновые таймеры ни к чему).
+  useVisibleInterval(fetchData, 60_000)
+
+  // Ручной рефреш по кнопке в AdminFooter.
   useEffect(() => {
-    fetchData()
-    const id = setInterval(fetchData, 60_000)
-    return () => clearInterval(id)
-  }, [fetchData, refreshSignal])
+    if (refreshSignal > 0) fetchData()
+  }, [refreshSignal, fetchData])
 
   if (error) return null
   if (!data) return null

--- a/components/nd/DigestStatusWidget.test.tsx
+++ b/components/nd/DigestStatusWidget.test.tsx
@@ -12,6 +12,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.useRealTimers()
+  setTabVisibility('visible')
 })
 
 function respondWith(data: object) {
@@ -19,6 +20,12 @@ function respondWith(data: object) {
     ok: true,
     json: async () => data,
   })
+}
+
+function setTabVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => state === 'hidden' })
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state })
+  document.dispatchEvent(new Event('visibilitychange'))
 }
 
 describe('DigestStatusWidget', () => {
@@ -59,6 +66,22 @@ describe('DigestStatusWidget', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1)
     await act(async () => { jest.advanceTimersByTime(60_000) })
     expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('не опрашивает, пока вкладка скрыта, и делает запрос при возврате', async () => {
+    setTabVisibility('hidden')
+    respondWith({ status: 'empty' })
+    render(<DigestStatusWidget />)
+    await act(async () => {})
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    // даже спустя два интервала — ни одного запроса из фоновой вкладки
+    await act(async () => { jest.advanceTimersByTime(120_000) })
+    expect(mockFetch).not.toHaveBeenCalled()
+
+    // возврат на вкладку → немедленный догоняющий запрос
+    await act(async () => { setTabVisibility('visible') })
+    expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 
   it('остаётся невидимым при ошибке fetch (non-ok ответ)', async () => {

--- a/components/nd/DigestStatusWidget.tsx
+++ b/components/nd/DigestStatusWidget.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback } from 'react'
+import { useVisibleInterval } from './use-visible-interval'
 
 type DigestStatusData =
   | { status: 'empty' }
@@ -36,11 +37,15 @@ export default function DigestStatusWidget({ refreshSignal = 0 }: DigestStatusWi
     }
   }, [])
 
+  // Опрос только при активной вкладке: этот виджет читает БД (`notificationQueue`),
+  // а фоновая /admin-вкладка раз в 60с не давала Neon-compute заснуть (scale-to-zero
+  // = 5 мин) и жгла CU-часы. Хук ставит опрос на паузу, пока вкладка скрыта.
+  useVisibleInterval(fetchStatus, 60_000)
+
+  // Ручной рефреш по кнопке в AdminFooter.
   useEffect(() => {
-    fetchStatus()
-    const id = setInterval(fetchStatus, 60_000)
-    return () => clearInterval(id)
-  }, [fetchStatus, refreshSignal])
+    if (refreshSignal > 0) fetchStatus()
+  }, [refreshSignal, fetchStatus])
 
   if (!data) return null
 

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -9,7 +9,7 @@
 - **Cron trigger** — GitHub Actions `digest.yml` вызывает `GET /api/cron/digest` с заголовком `Authorization: Bearer $CRON_SECRET` раз в сутки в **03:00 UTC**. Время намеренно совмещено с Vercel-кроном `telegram-preauth-cleanup` (тоже `0 3 * * *`): оба бьют в production-ветку Neon, поэтому compute просыпается один раз и обслуживает оба джоба. ⚠️ **Не учащать без нужды:** прежний `*/10` будил Neon-compute ~50% суток вхолостую (каждый вызов делает write даже на пустой очереди) и выжигал ~90 CU-час/мес — это вызвало паузу БД на Free-плане (июнь 2026). Сам digest всё равно дебаунсит отправку (cooling 30 мин / forced-flush 2 ч), так что частить смысла нет.
 - **Обработка** — `/api/cron/digest` атомарно захватывает строки с `sentAt IS NULL` и `processingAt IS NULL`, выдерживает debounce, отправляет один digest на `ADMIN_EMAIL` через Resend и заполняет `sentAt`
 - **Email** — HTML-шаблон в `lib/email-templates/`; содержит список новых участников и их контакты
-- **DigestStatusWidget** — компонент только для админов, показывает размер очереди и время последней отправки
+- **DigestStatusWidget** — компонент только для админов, показывает размер очереди и время последней отправки. Опрашивает `/api/admin/digest-status` раз в 60с через `useVisibleInterval` — **только пока вкладка активна**. ⚠️ Это важно для расходов: endpoint читает `notificationQueue` в Neon, а раньше на голом `setInterval` фоновая `/admin`-вкладка держала Neon-compute бодрым 24/7 (scale-to-zero = 5 мин) и выжигала CU-часы (июль 2026, упёрлись в spend-лимит Launch). Пауза на скрытой вкладке даёт БД заснуть. Тем же хуком поправлены `AdminStatusBar` и `AllureWidget`.
 
 ## Ключевые файлы
 - `lib/db/schema.ts` — таблица `notificationQueue`


### PR DESCRIPTION
DigestStatusWidget/AdminStatusBar/AllureWidget пинговали каждые 60с на голом
setInterval без паузы на скрытой вкладке. У DigestStatusWidget endpoint
(/api/admin/digest-status) читает notificationQueue в Neon — фоновая /admin-вкладка
держала Neon-compute бодрым 24/7 (scale-to-zero = 5 мин) и выжигала ~5 CU-час/день,
из-за чего упёрлись в spend-лимит Launch (июль 2026). AdminStatusBar бьёт в Vercel-
функции, AllureWidget — во внешнюю статику; переведены тем же хуком для единообразия.

Все три переведены на useVisibleInterval (тот же паттерн, что в матчинге): опрос
только при видимой вкладке + догоняющий запрос при возврате. Ручной рефреш по кнопке
AdminFooter сохранён отдельным эффектом.

Аудит подтвердил: других постоянных пуллеров без паузы в проекте нет.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
