### PR TITLE
fix: drop redundant hard-switch note on matching book cards

### DIFF
--- a/components/nd/MatchingBookCard.test.tsx
+++ b/components/nd/MatchingBookCard.test.tsx
@@ -71,11 +71,11 @@ describe('MatchingBookCard', () => {
     expect(screen.getByText('Без круга: Евгений')).toBeInTheDocument()
   })
 
-  it('explains that a new hard choice replaces the previous one', () => {
+  it('keeps the hard action available without pre-warning about the replaced choice', () => {
     render(<MatchingBookCard book={book} {...baseProps} viewerHardBookId="b2" />)
     expect(screen.getByRole('button', { name: 'Записаться' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Готов:а читать · 1' })).toBeDisabled()
-    expect(screen.getByText(/новый окончательный выбор заменит предыдущий/i)).toBeInTheDocument()
+    expect(screen.queryByText(/новый окончательный выбор заменит предыдущий/i)).not.toBeInTheDocument()
   })
 
   it('emits a hard command from the initiating button', () => {

--- a/components/nd/MatchingBookCard.tsx
+++ b/components/nd/MatchingBookCard.tsx
@@ -155,9 +155,6 @@ export default function MatchingBookCard({
                   : `${conditionalHere ? '✓ ' : ''}Готов:а читать${conditionalCount > 0 ? ` · ${conditionalCount}` : ''}`}
               </button>
             )}
-            {hasHardElsewhere && book.allowedActions.hard && (
-              <span className="nd-mb-action-note">Вы уже записаны на другую книгу. Новый окончательный выбор заменит предыдущий.</span>
-            )}
             {formed && book.allowedActions.hard && <span>Книга уже собрана, но можно присоединиться</span>}
           </>
         )}


### PR DESCRIPTION
Клик по «Записаться» при существующей записи и так открывает блок
подтверждения смены книги, статичная подсказка его дублировала.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
