### PR TITLE
fix: compact mobile matching cards

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-fix-matching-mobile-review.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-fix-matching-mobile-review.md
@@ -1,0 +1,82 @@
+---
+title: 'Исправить мобильную геометрию книжного Matching'
+type: 'bugfix'
+created: '2026-07-16'
+status: 'done'
+baseline_commit: 'fd9d478c01c1dd9efd543c8de41957a3fff10b17'
+context:
+  - 'docs/features/matching.md'
+  - 'docs/features/testing.md'
+  - '/Users/ekoshkin/Downloads/REVIEW-FIXES.md'
+---
+
+# Исправить мобильную геометрию книжного Matching
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** На ширине 360–393px универсальные правила `min-height: 44px` и `flex: 1 1 100%` применились к информационным метрикам, заголовку и вторичным кнопкам. Карточки стали рыхлыми, каретка split-кнопки заняла половину строки, ghost-действие выглядит главным, а bottom sheet оставляет длинному названию слишком узкую колонку. В каталоге также видна опечатка «Доктирна шока».
+
+**Approach:** Сузить mobile CSS-селекторы до действительно интерактивных контролов, сохранить 44px для основных CTA и каретки, вернуть контенту естественную высоту и освободить ширину заголовка в sheet. Исправить название идемпотентной data-миграцией, не переписывая историческую `0021`.
+
+## Boundaries & Constraints
+
+**Always:** Использовать только существующие токены; сохранить 56×80 у карточки и 96×144 в sheet; сохранить focus trap, drag-to-close, rank tooltip и доступные 44px у primary CTA; проверять 360 и 393px через `boundingBox()`.
+
+**Ask First:** Изменение текстов, бизнес-правил записи, состава карточки, desktop-геометрии или размеров обложек.
+
+**Never:** Уменьшать primary CTA ниже 44px; возвращать 44px информационным chips/metrics; править историческую миграцию `0021`; применять тесты к production DB.
+
+## I/O & Edge-Case Matrix
+
+| Состояние | Ожидаемое поведение |
+|---|---|
+| Split CTA | `Записаться` занимает остаток строки; каретка — узкая зона около 44px |
+| Метрики переносятся | Строки имеют естественную высоту без 44px пустот |
+| Hard до формирования | `Отменить` остаётся компактным вторичным действием слева |
+| Длинное название в sheet | Колонка заголовка использует доступную ширину, крестик не перекрывает текст |
+| Много участников | Chips переносятся по строкам и имеют высоту около 34px |
+| Каталог | Книга `9b351ca1-…` называется «Доктрина шока» во всех применённых окружениях |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `app/globals.css` — mobile specificity, естественная высота контента, геометрия sheet.
+- `e2e/matching-layout.spec.ts` — существующий mobile golden с геометрическими регрессиями.
+- `drizzle/0054_fix_shock_doctrine_title.sql` и тест — идемпотентная data correction.
+- `_bmad-output/implementation-artifacts/tech-spec-refine-matching-book-cards.md` — исправить устаревший статус `ready-for-dev` на `done`.
+
+## Tasks & Acceptance
+
+- [x] Удалить mobile `inline-flex/min-height` у `.nd-mb-title` и `.nd-mb-metric`, сохранив естественный перенос и доступность входа в детали через обложку/заголовок.
+- [x] Селектором достаточной специфичности закрепить растущий `.nd-mb-split-main`, фиксированную `.nd-mb-split-caret` и компактную `.is-ghost`.
+- [x] Сделать participant chips компактными (`34px`) и расширить колонку длинного названия sheet, не меняя обложку 96×144.
+- [x] Добавить `boundingBox()`-проверки ширины split-частей, плотности карточки, ghost-кнопки, sheet-заголовка и chips в существующий golden.
+- [x] Добавить и проверить идемпотентную коррекцию названия; применить её отдельно к e2e и production Neon через существующий migration runner после проверки URL без вывода секрета.
+- [x] Прогнать `lint`, `typecheck`, Jest, focused layout E2E и build.
+- [ ] Создать PR, дождаться auto-merge и проверить production UI.
+
+**Acceptance Criteria:**
+
+- Given viewport 360–393px, when карточка содержит несколько метрик, then между ними нет искусственных строк высотой 44px и горизонтального overflow.
+- Given split CTA, then каретка не растягивается и остаётся примерно 44px, а main занимает существенно большую часть строки.
+- Given hard selection, then ghost-action не шире своего содержимого, но сохраняет доступную высоту 44px.
+- Given mobile detail sheet, then cover остаётся 96×144, title не резервирует лишние 2.5rem справа, participant chips имеют компактную высоту и всё остаётся внутри viewport.
+- Given миграция применена повторно, then она безопасно оставляет корректное название без побочных изменений.
+
+## Design Notes
+
+**Visual thesis:** компактная редакторская карточка; обложка и название задают ритм, агрегаты читаются как плотная метаинформация, визуальный вес остаётся у одного primary CTA.
+
+**Content plan:** название и автор → компактная строка агрегатов → действие; в sheet — обложка и читаемый заголовок → участники → описание.
+
+**Interaction thesis:** split воспринимается одной кнопкой с узкой зоной раскрытия; вторичные действия отступают; sheet сохраняет drag/close/focus-модель без новых жестов.
+
+## Verification
+
+- `npm run lint && npm run typecheck && npm test`
+- `npm run test:e2e:focused -- e2e/matching-layout.spec.ts --grep "393px keeps cards"`
+- `npm run build`
+- Read-only production check: title and mobile layout after deploy.

--- a/_bmad-output/implementation-artifacts/tech-spec-refine-matching-book-cards.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-refine-matching-book-cards.md
@@ -2,7 +2,7 @@
 title: 'Уточнить карточки и детали книг в Matching'
 type: 'feature'
 created: '2026-07-15'
-status: 'ready-for-dev'
+status: 'done'
 context:
   - 'docs/features/matching.md'
   - 'docs/features/testing.md'

--- a/app/globals.css
+++ b/app/globals.css
@@ -249,19 +249,18 @@
   .nd-mb-title { font-size: 1.04rem; }
   .nd-mb-author { font-size: 0.78rem; }
   .nd-mb-metrics { gap: 0.22rem 0.7rem; }
-  .nd-mb-title,
-  .nd-mb-metric { display: inline-flex; align-items: center; min-height: 44px; }
   .nd-mb-split-opt { min-height: 44px; align-items: center; }
   .nd-mb-circles { grid-template-columns: minmax(0, 1fr); }
   .nd-mb-actions { align-items: stretch; }
   .nd-mb-actions .nd-mb-btn { flex: 1 1 100%; min-height: 44px; }
+  .nd-mb-actions .nd-mb-btn.is-ghost { flex: 0 0 auto; align-self: flex-start; }
   .nd-mb-actions .nd-mb-split { flex: 1 1 100%; }
   .nd-mb-split-bar { display: flex; }
-  .nd-mb-split-main { flex: 1 1 auto; }
-  .nd-mb-split-caret { flex: 0 0 auto; }
+  .nd-mb-actions .nd-mb-split-main { flex: 1 1 auto; }
+  .nd-mb-actions .nd-mb-split-caret { flex: 0 0 auto; }
   .nd-mb-selection { align-items: flex-start; }
   .nd-mb-selection .p-link { display: inline-flex; align-items: center; min-height: 44px; }
-  .nd-mb-modal-participant { min-height: 44px; }
+  .nd-mb-modal-participant { min-height: 34px; }
   .nd-mb-rank-tip { position: fixed; top: auto; right: 1rem; bottom: calc(1rem + env(safe-area-inset-bottom)); left: 1rem; width: auto; }
   .nd-mb-participant-tiers { align-items: flex-start; }
 }
@@ -1447,17 +1446,16 @@ body {
   /* §5 Book popup: cover + title/meta collapse into a row, like BookCardMobile. */
   .nd-mx-sheet-grid {
     grid-template-columns: 96px minmax(0,1fr) !important;
-    gap: 0.9rem !important;
+    gap: 1rem !important;
     padding: 0.35rem 1.1rem 0 !important;
   }
   .nd-mx-sheet-cover {
     width: 96px !important;
     height: 144px !important;
   }
-  .nd-mx-sheet-heading { padding-right: 2.5rem !important; }
   .nd-mx-sheet-heading { display: contents; }
-  .nd-mx-sheet-title { grid-column: 2; grid-row: 1; align-self: end; padding-right: 2.5rem; font-size: 1.3rem !important; }
-  .nd-mx-sheet-meta { grid-column: 2; grid-row: 2; align-self: start; padding-right: 2.5rem; font-size: 0.82rem !important; }
+  .nd-mx-sheet-title { grid-column: 2; grid-row: 1; align-self: end; font-size: 1.28rem !important; line-height: 1.18 !important; }
+  .nd-mx-sheet-meta { grid-column: 2; grid-row: 2; align-self: start; font-size: 0.82rem !important; }
   .nd-mx-sheet-cover { grid-column: 1; grid-row: 1 / span 2; }
   .nd-mx-sheet-participants,
   .nd-mx-sheet-tags { grid-column: 1 / -1; }

--- a/drizzle/0054_fix_shock_doctrine_title.sql
+++ b/drizzle/0054_fix_shock_doctrine_title.sql
@@ -1,0 +1,27 @@
+-- Исправляет опечатку из исторического импорта каталога 0021.
+-- Legacy-миграцию не переписываем: эта коррекция идемпотентно обновляет живые данные.
+-- scripts/apply-migration.mjs сам выполняет файл в одной транзакции.
+SET LOCAL app.audit_source = 'system';
+SET LOCAL app.audit_actor = '';
+SET LOCAL app.audit_label = '';
+SET LOCAL app.audit_reason = 'correct imported catalog title typo';
+
+UPDATE "books"
+SET
+  "title" = 'Доктрина шока',
+  "updated_at" = now()
+WHERE "id" = '9b351ca1-6513-43be-80d1-1547eb900984'
+  AND "title" = 'Доктирна шока';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM "books"
+    WHERE "id" = '9b351ca1-6513-43be-80d1-1547eb900984'
+      AND "title" = 'Доктрина шока'
+  ) THEN
+    RAISE EXCEPTION 'Shock Doctrine catalog title correction postcondition failed';
+  END IF;
+END
+$$;

--- a/drizzle/0054_fix_shock_doctrine_title.test.ts
+++ b/drizzle/0054_fix_shock_doctrine_title.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+describe('0054 fix Shock Doctrine title migration', () => {
+  const sql = readFileSync(join(process.cwd(), 'drizzle/0054_fix_shock_doctrine_title.sql'), 'utf8')
+
+  it('relies on the migration runner transaction and clears audit identity', () => {
+    expect(sql).not.toContain('BEGIN;')
+    expect(sql).not.toContain('COMMIT;')
+    expect(sql).toContain("SET LOCAL app.audit_source = 'system'")
+    expect(sql).toContain("SET LOCAL app.audit_actor = ''")
+    expect(sql).toContain("SET LOCAL app.audit_label = ''")
+  })
+
+  it('only corrects the known imported typo on the canonical book', () => {
+    expect(sql).toContain("\"id\" = '9b351ca1-6513-43be-80d1-1547eb900984'")
+    expect(sql).toContain("\"title\" = 'Доктирна шока'")
+    expect(sql).toContain("\"title\" = 'Доктрина шока'")
+    expect(sql).toContain('"updated_at" = now()')
+  })
+
+  it('fails instead of silently accepting a missing or unexpected catalog row', () => {
+    expect(sql).toContain('IF NOT EXISTS')
+    expect(sql).toContain("RAISE EXCEPTION 'Shock Doctrine catalog title correction postcondition failed'")
+  })
+})

--- a/e2e/matching-layout.spec.ts
+++ b/e2e/matching-layout.spec.ts
@@ -24,8 +24,23 @@ test.describe('Matching books: mobile layout and focus', () => {
     matchingBooksFixture,
     openMatchingPage,
   }) => {
-    const { session, books, participantA, admin, getParticipantB, getParticipantC } = matchingBooksFixture
+    const { session, books, participantA, admin, getParticipantB, getParticipantC, addParticipant } = matchingBooksFixture
     const [participantB, participantC] = await Promise.all([getParticipantB(), getParticipantC()])
+    await addParticipant('Галина Книги E2E')
+    const setBookAction = async (
+      participant: typeof participantA,
+      action: 'setHard' | 'setConditional',
+    ) => {
+      const currentResponse = await participant.request.get(`/api/matching/state?session=${session.id}`)
+      expect(currentResponse.ok(), await currentResponse.text()).toBe(true)
+      const current = await currentResponse.json() as { session: { stateVersion: number } }
+      const actionResponse = await participant.request.post(`/api/matching/sessions/${session.id}/book-actions`, {
+        data: { action, bookId: books[0].id, expectedStateVersion: current.session.stateVersion },
+      })
+      expect(actionResponse.ok(), await actionResponse.text()).toBe(true)
+    }
+    await setBookAction(participantB, 'setHard')
+    await setBookAction(participantC, 'setConditional')
     const participantAPage = await openMatchingPage(participantA)
     await participantAPage.setViewportSize({ width: 900, height: 844 })
     await participantAPage.goto('/matching')
@@ -55,6 +70,20 @@ test.describe('Matching books: mobile layout and focus', () => {
     const ctaBox = await cta.boundingBox()
     expect(ctaBox).not.toBeNull()
     expect(ctaBox!.x + ctaBox!.width).toBeLessThanOrEqual(394)
+    const splitCaret = card.getByRole('button', { name: 'Автоматическая запись, если соберётся круг' })
+    const splitCaretBox = await splitCaret.boundingBox()
+    expect(splitCaretBox).not.toBeNull()
+    expect(splitCaretBox!.width, 'split disclosure stays a narrow tap target').toBeLessThanOrEqual(52)
+    expect(ctaBox!.width, 'split primary action takes the remaining width').toBeGreaterThan(splitCaretBox!.width * 3)
+    const title = card.getByRole('button', { name: books[0].title, exact: true })
+    const titleBox = await title.boundingBox()
+    expect(titleBox).not.toBeNull()
+    expect(await title.evaluate((element) => getComputedStyle(element).minHeight), 'book title has no artificial tap-target height').toBe('0px')
+    const metricBoxes = await card.locator('.nd-mb-metric').evaluateAll((elements) => (
+      elements.map(element => element.getBoundingClientRect().height)
+    ))
+    expect(metricBoxes, 'hard, conditional and interest counters are all present').toHaveLength(3)
+    expect(Math.max(...metricBoxes), 'metadata counters do not become 44px controls').toBeLessThan(32)
     expect(await participantAPage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
 
     const trigger = cover
@@ -70,10 +99,20 @@ test.describe('Matching books: mobile layout and focus', () => {
     expect(sheetCoverBox).not.toBeNull()
     expect(sheetCoverBox!.width).toBeCloseTo(96, 0)
     expect(sheetCoverBox!.height).toBeCloseTo(144, 0)
+    const sheetTitle = dialog.locator('.nd-mx-sheet-title')
+    const sheetTitleBox = await sheetTitle.boundingBox()
+    expect(sheetTitleBox).not.toBeNull()
+    const sheetTitlePaddingRight = await sheetTitle.evaluate((element) => parseFloat(getComputedStyle(element).paddingRight))
+    expect(sheetTitleBox!.width - sheetTitlePaddingRight, 'sheet title receives the full second column').toBeGreaterThan(220)
     await expect(dialog.getByRole('button', { name: 'Закрыть' })).toBeFocused()
     await expect(dialog).toContainText(participantA.name)
     await expect(dialog).toContainText(participantB.name)
     await expect(dialog).toContainText(participantC.name)
+    const participantChipHeights = await dialog.locator('.nd-mb-modal-participant').evaluateAll((elements) => (
+      elements.map(element => element.getBoundingClientRect().height)
+    ))
+    expect(participantChipHeights.length).toBeGreaterThanOrEqual(3)
+    expect(Math.max(...participantChipHeights), 'participant chips stay compact').toBeLessThanOrEqual(36)
 
     const participantRank = dialog.getByRole('button', { name: new RegExp(participantB.name) })
     await participantRank.click()
@@ -109,18 +148,43 @@ test.describe('Matching books: mobile layout and focus', () => {
     expect(narrowCardBox!.x).toBeGreaterThanOrEqual(0)
     expect(narrowCardBox!.x + narrowCardBox!.width).toBeLessThanOrEqual(361)
     expect(await participantAPage.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
+    await trigger.click()
+    const narrowDialog = participantAPage.getByRole('dialog', { name: books[0].title })
+    const [narrowDialogBox, narrowSheetCoverBox, narrowSheetTitleBox] = await Promise.all([
+      narrowDialog.boundingBox(),
+      narrowDialog.locator('.nd-mx-sheet-cover').boundingBox(),
+      narrowDialog.locator('.nd-mx-sheet-title').boundingBox(),
+    ])
+    expect(narrowDialogBox).not.toBeNull()
+    expect(narrowDialogBox!.x + narrowDialogBox!.width).toBeLessThanOrEqual(361)
+    expect(narrowSheetCoverBox).not.toBeNull()
+    expect(narrowSheetCoverBox!.width).toBeCloseTo(96, 0)
+    expect(narrowSheetCoverBox!.height).toBeCloseTo(144, 0)
+    expect(narrowSheetTitleBox).not.toBeNull()
+    expect(narrowSheetTitleBox!.width, '360px sheet still gives the title a readable column').toBeGreaterThan(190)
+    const narrowChipHeights = await narrowDialog.locator('.nd-mb-modal-participant').evaluateAll((elements) => (
+      elements.map(element => element.getBoundingClientRect().height)
+    ))
+    expect(Math.max(...narrowChipHeights)).toBeLessThanOrEqual(36)
+    await narrowDialog.getByRole('button', { name: 'Закрыть' }).click()
 
     // Keep the compact participant/admin status regression in the same
     // mobile golden instead of spending a second browser-golden slot.
     const participantBPage = await openMatchingPage(participantB)
     const adminPage = await openMatchingPage(admin)
+    await participantBPage.setViewportSize({ width: 393, height: 852 })
     await participantBPage.goto('/matching')
     const participantBCard = participantBPage.getByTestId(`matching-book-card-${books[0].id}`)
-    const hardResponse = participantBPage.waitForResponse(response => (
-      response.request().method() === 'POST' && response.url().endsWith('/book-actions')
-    ))
-    await participantBCard.getByRole('button', { name: 'Записаться', exact: true }).click()
-    expect((await hardResponse).ok()).toBe(true)
+    await expect(participantBCard).toContainText('✓ Вы записаны')
+    const cancelHard = participantBCard.getByRole('button', { name: 'Отменить', exact: true })
+    const [participantBCardBox, cancelHardBox] = await Promise.all([
+      participantBCard.boundingBox(),
+      cancelHard.boundingBox(),
+    ])
+    expect(participantBCardBox).not.toBeNull()
+    expect(cancelHardBox).not.toBeNull()
+    expect(cancelHardBox!.height, 'secondary action remains a reachable tap target').toBeGreaterThanOrEqual(44)
+    expect(cancelHardBox!.width, 'secondary action does not imitate the primary full-width CTA').toBeLessThan(participantBCardBox!.width / 2)
     await participantAPage.reload()
     await expect(card.getByRole('button', { name: '1 уже записал:ась' })).toBeVisible()
     await expect(card.getByLabel('Определившиеся участники')).toHaveCount(0)


### PR DESCRIPTION
## Summary
- compact mobile Matching cards, metrics, split CTA and secondary actions
- improve book detail sheet width and participant chips at 360–393px
- correct the imported «Доктрина шока» title with an audited idempotent migration
- extend the existing mobile layout golden instead of adding another E2E flow

## Verification
- npm run lint
- npm run typecheck
- npm test -- --runInBand (213 suites, 1489 tests)
- npm run test:e2e:focused -- e2e/matching-layout.spec.ts --grep "393px keeps cards"
- npm run build
- migration applied and read back in e2e and production Neon