### PR TITLE
fix: clarify desktop matching split button

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-desktop-split-divider.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-desktop-split-divider.md
@@ -1,0 +1,27 @@
+---
+title: 'Добавить разделитель desktop split-кнопке Matching'
+type: 'bugfix'
+created: '2026-07-16'
+status: 'done'
+---
+
+# Добавить разделитель desktop split-кнопке Matching
+
+<frozen-after-approval reason="direct user request">
+
+## Intent
+
+На desktop визуально разделить основное действие «Записаться» и стрелку раскрытия авто-записи так же ясно, как на mobile. Не менять тексты, размеры, меню или бизнес-логику.
+
+## Acceptance
+
+- Given desktop Matching с доступной авто-записью, when отображается split-кнопка, then перед стрелкой видна вертикальная линия из существующего дизайн-токена.
+- Given mobile Matching, then существующая геометрия и поведение split-кнопки не меняются.
+
+</frozen-after-approval>
+
+## Tasks
+
+- [x] `app/globals.css` — задать desktop-only цвет левой границы caret.
+- [x] `e2e/matching-layout.spec.ts` — дополнить существующий desktop/mobile golden проверкой desktop-разделителя.
+- [x] Прогнать lint, typecheck и focused layout E2E.

--- a/app/globals.css
+++ b/app/globals.css
@@ -231,6 +231,10 @@
 .nd-mb-modal-participants li.is-assigned .nd-mb-modal-participant span:last-child { color: var(--success); font-weight: 700; }
 .nd-mb-rank-tip { position: absolute; z-index: 4; top: calc(100% + 0.35rem); left: 0; width: max-content; max-width: min(260px, calc(100vw - 2rem)); padding: 0.45rem 0.6rem; border: 1px solid var(--hair); border-radius: var(--radius-control); background: var(--bg-input); box-shadow: var(--shadow-pop); color: var(--text-body); font-size: 0.72rem; line-height: 1.35; }
 
+@media (min-width: 541px) {
+  .nd-mb-btn.is-hard.nd-mb-split-caret { border-left-color: var(--accent-line); }
+}
+
 .nd-mx-board-cap:has(.nd-mx-workspace.is-document) { height: auto !important; min-height: 0 !important; }
 
 @media (prefers-reduced-motion: reduce) {

--- a/e2e/matching-layout.spec.ts
+++ b/e2e/matching-layout.spec.ts
@@ -1211,6 +1211,26 @@ test.describe('Matching record button auto-enroll menu', () => {
       const barBox = await card.locator('.nd-mb-split-bar').boundingBox()
       expect(menuBox).not.toBeNull()
       expect(barBox).not.toBeNull()
+      if (viewport.width > 540) {
+        await caret.hover()
+        const dividerColors = await caret.evaluate((element) => {
+          const probe = document.createElement('span')
+          probe.style.color = 'var(--accent-line)'
+          document.body.appendChild(probe)
+          const expected = getComputedStyle(probe).color
+          probe.remove()
+          const style = getComputedStyle(element)
+          return {
+            actual: style.borderLeftColor,
+            expected,
+            width: style.borderLeftWidth,
+            borderStyle: style.borderLeftStyle,
+          }
+        })
+        expect(dividerColors.actual, 'desktop caret uses the visible split divider token').toBe(dividerColors.expected)
+        expect(dividerColors.width).toBe('1px')
+        expect(dividerColors.borderStyle).toBe('solid')
+      }
       expect(menuBox!.x, `${viewport.width}px: menu left edge on-screen`).toBeGreaterThanOrEqual(0)
       expect(menuBox!.x + menuBox!.width, `${viewport.width}px: menu right edge on-screen`).toBeLessThanOrEqual(viewport.width + 1)
       expect(menuBox!.y + menuBox!.height, `${viewport.width}px: menu bottom edge on-screen`).toBeLessThanOrEqual(viewport.height + 1)


### PR DESCRIPTION
## Summary
- add a visible desktop-only divider before the Matching split-button caret
- preserve the divider during hover without changing mobile styling or behavior
- extend the existing desktop/mobile layout golden with color, width and border-style assertions

## Verification
- npm run lint
- npm run typecheck
- npm run test:e2e:focused -- e2e/matching-layout.spec.ts --grep "caret dropdown opens fully on-screen"