### PR TITLE
fix: age-gate в /api/test/cleanup-users против межпрогонной интерференции E2E

### DIFF
--- a/app/api/test/cleanup-users/route.test.ts
+++ b/app/api/test/cleanup-users/route.test.ts
@@ -59,7 +59,11 @@ describe('DELETE /api/test/cleanup-users', () => {
 
     expect(res.status).toBe(200)
     expect(db.execute).toHaveBeenCalled()
-    expect(JSON.stringify((db.execute as jest.Mock).mock.calls[0][0])).toContain('matching_sessions')
+    const sqlText = JSON.stringify((db.execute as jest.Mock).mock.calls[0][0])
+    expect(sqlText).toContain('matching_sessions')
+    // Age-gate: общая e2e-ветка, параллельный прогон не должен терять живых
+    // пользователей. Каждый удаляющий CTE обязан фильтровать по created_at.
+    expect(sqlText.match(/interval '2 hours'/g)?.length ?? 0).toBeGreaterThanOrEqual(5)
     await expect(res.json()).resolves.toEqual({
       ok: true,
       deleted: { users: 2, identities: 2, feedback: 1, notifications: 0, matchingSessions: 3 },

--- a/app/api/test/cleanup-users/route.ts
+++ b/app/api/test/cleanup-users/route.ts
@@ -1,5 +1,13 @@
 // Test-only endpoint: removes E2E users that may be left behind by failed tests.
 // Only works when NEXTAUTH_TEST_MODE=true — never enabled in production.
+//
+// ВАЖНО: удаляются только хвосты старше STALE_INTERVAL. Ветка `e2e` общая:
+// nightly в CI и локальные focused-прогоны могут идти одновременно, и без
+// age-gate global setup/teardown одного прогона сносил живых пользователей
+// другого прямо между /api/test/session и /api/test/signup (nightly run
+// 29497802469: юзер прожил 0.9 секунды → FK violation в signup_books).
+// Свежий мусор упавшего прогона доживает до следующего sweep'а — это
+// осознанная цена: id/email уникальны per-test, коллизий не бывает.
 
 import { NextResponse } from 'next/server'
 import { sql } from 'drizzle-orm'
@@ -41,16 +49,18 @@ export async function DELETE() {
     WITH target_users AS (
       SELECT u."id", u."contact_email"
       FROM "user" u
-      WHERE u."contact_email" ILIKE '%@test.invalid'
-        OR u."name" ILIKE 'E2E %'
+      WHERE (u."contact_email" ILIKE '%@test.invalid'
+        OR u."name" ILIKE 'E2E %')
+        AND u."created_at" < now() - interval '2 hours'
 
       UNION
 
       SELECT ui."user_id" AS "id", u."contact_email"
       FROM "user_identities" ui
       JOIN "user" u ON u."id" = ui."user_id"
-      WHERE ui."email" ILIKE '%@test.invalid'
-        OR ui."provider_account_id" ILIKE '%@test.invalid'
+      WHERE (ui."email" ILIKE '%@test.invalid'
+        OR ui."provider_account_id" ILIKE '%@test.invalid')
+        AND u."created_at" < now() - interval '2 hours'
     ),
     target_emails AS (
       SELECT "contact_email" AS "email"
@@ -60,8 +70,9 @@ export async function DELETE() {
     target_matching_sessions AS (
       SELECT "id"
       FROM "matching_sessions"
-      WHERE "name" ILIKE 'E2E Matching %'
-        OR "name" ILIKE 'E2E Admin Satisfaction %'
+      WHERE ("name" ILIKE 'E2E Matching %'
+        OR "name" ILIKE 'E2E Admin Satisfaction %')
+        AND "created_at" < now() - interval '2 hours'
     ),
     deleted_matching_book_assignments AS (
       DELETE FROM "matching_book_assignments"
@@ -81,14 +92,15 @@ export async function DELETE() {
     deleted_feedback AS (
       DELETE FROM "feedback"
       WHERE "user_id" IN (SELECT "id" FROM target_users)
-        OR "email" ILIKE '%@test.invalid'
-        OR "message" ILIKE 'E2E %'
+        OR (("email" ILIKE '%@test.invalid' OR "message" ILIKE 'E2E %')
+          AND "created_at" < now() - interval '2 hours')
       RETURNING "id"
     ),
     deleted_notifications AS (
       DELETE FROM "notification_queue"
       WHERE "user_email" IN (SELECT "email" FROM target_emails)
-        OR "user_email" ILIKE '%@test.invalid'
+        OR ("user_email" ILIKE '%@test.invalid'
+          AND "created_at" < now() - interval '2 hours')
       RETURNING "id"
     ),
     deleted_identities AS (

--- a/docs/features/testing.md
+++ b/docs/features/testing.md
@@ -122,7 +122,7 @@ Playwright запускается с `workers: 1`: matching-тесты испо�
 
 Каждый E2E-тест создаёт нужные ему книги через `createTestBook` фикстуру (см. `e2e/fixtures.ts`). Id'шники имеют префикс `__e2e_book_<testId>_<index>__`, фикстура удаляет книгу в teardown (FK signup_books/book_priorities → cascade). Глобального seed-каталога больше нет — каждая спека работает только со своими данными.
 
-Global setup/teardown удаляет E2E users и E2E matching sessions через `/api/test/cleanup-users`; per-test login fixtures не удаляют пользователей, чтобы не ломать session cookies и FK во время suite.
+Global setup/teardown удаляет E2E users и E2E matching sessions через `/api/test/cleanup-users`; per-test login fixtures не удаляют пользователей, чтобы не ломать session cookies и FK во время suite. Cleanup сносит **только хвосты старше 2 часов**: ветка `e2e` общая для CI nightly и локальных focused-прогонов, и без age-gate setup/teardown одного прогона удалял живых пользователей другого посреди теста (источник флака book-summaries в nightly 29497802469). Свежий мусор упавшего прогона доживает до следующего sweep'а — это нормально, id/email уникальны per-test.
 
 Для matching используются две составные fixture:
 

--- a/docs/wiki/Quality-CI-Allure-and-Codecov.md
+++ b/docs/wiki/Quality-CI-Allure-and-Codecov.md
@@ -80,7 +80,7 @@ E2E **никогда не пишут в продакшен Neon**. Изоляц�
 
 Любая мутация — через фикстуру в `e2e/fixtures.ts` (`loginAsUser`, `loginAsAdmin`, `createIntroSection`, `createTestBook`, `createMatchingSession`). Книги, intro-секции и matching-сессии удаляются fixture teardown. E2E users не удаляются внутри отдельных тестов: они живут до global cleanup, чтобы session cookies других шагов не получали FK-разрыв к таблице `user`.
 
-Global setup/teardown вызывает `/api/test/cleanup-users`: он удаляет E2E users, identities, feedback/notifications и E2E matching sessions (`E2E Matching %`, `E2E Admin Satisfaction %`). Тесты не редактируют существующие записи; вместо этого создают свою сущность, проверяют, fixture/global cleanup удаляет.
+Global setup/teardown вызывает `/api/test/cleanup-users`: он удаляет E2E users, identities, feedback/notifications и E2E matching sessions (`E2E Matching %`, `E2E Admin Satisfaction %`) — но только записи **старше 2 часов**. Ветка `e2e` общая для CI nightly и локальных прогонов; age-gate не даёт одному прогону удалить живых пользователей другого посреди теста. Тесты не редактируют существующие записи; вместо этого создают свою сущность, проверяют, fixture/global cleanup удаляет.
 
 Когда нужна новая сущность — добавь фикстуру, не пиши inline-cleanup в теле теста.
 

--- a/e2e/book-summaries.spec.ts
+++ b/e2e/book-summaries.spec.ts
@@ -316,11 +316,16 @@ test.describe('Саммари книг', () => {
     loginAsAdmin: (args: { name: string }) => Promise<unknown>,
   ) {
     const user = await loginAsUser({ name: opts.userName })
-    await page.request.post('/api/test/signup', {
+    // Каждый шаг проверяем явно с телом ответа: молчаливый провал здесь
+    // раньше всплывал как непонятный TypeError на draft.summary.id.
+    const signupRes = await page.request.post('/api/test/signup', {
       data: { userId: user.userId, name: user.name, email: user.email, contacts: '@e2e', selectedBookIds: [opts.bookId] },
     })
-    await page.request.patch(`/api/signup-books/${encodeURIComponent(opts.bookId)}/status`, { data: { status: 'read' } })
+    expect(signupRes.ok(), `POST /api/test/signup failed: ${signupRes.status()} ${await signupRes.text().catch(() => '')}`).toBe(true)
+    const statusRes = await page.request.patch(`/api/signup-books/${encodeURIComponent(opts.bookId)}/status`, { data: { status: 'read' } })
+    expect(statusRes.ok(), `PATCH status failed: ${statusRes.status()} ${await statusRes.text().catch(() => '')}`).toBe(true)
     const draftRes = await page.request.post(`/api/summaries/by-book/${encodeURIComponent(opts.bookId)}`)
+    expect(draftRes.ok(), `POST /api/summaries/by-book failed: ${draftRes.status()} ${await draftRes.text().catch(() => '')}`).toBe(true)
     const draft = (await draftRes.json()) as { summary: { id: string } }
 
     await page.goto(`/summaries/${draft.summary.id}/edit`)


### PR DESCRIPTION
Nightly 29497802469: bulk cleanup параллельного локального прогона удалял
только что созданных пользователей CI-прогона (юзер прожил 0.9 с между
/api/test/session и /api/test/signup → FK violation, draft.summary undefined).
Теперь cleanup сносит только хвосты старше 2 часов; publishSummary в
book-summaries.spec.ts проверяет ok() каждого шага и логирует тело ошибки.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
