### PR TITLE
test: add circle calendar e2e

### DIFF
--- a/components/nd/CalendarGrid.tsx
+++ b/components/nd/CalendarGrid.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useRef, useState } from 'react'
+import { Fragment, useMemo, useRef, useState } from 'react'
 import type { OverlapResult } from '@/lib/calendar/overlap'
 import { addSlots, SLOT_MINUTES, slotKey } from '@/lib/calendar/slots'
 
@@ -108,7 +108,7 @@ export default function CalendarGrid({
         </div>
       ))}
       {slots.map((halfHour) => (
-        <>
+        <Fragment key={`slot-${halfHour}`}>
           <div key={`time-${halfHour}`} style={{ height: 'var(--calendar-cell-h, 22px)', color: 'var(--text-muted)', fontFamily: 'var(--nd-mono)', fontSize: '0.63rem', textAlign: 'right', paddingRight: 8, transform: 'translateY(-0.4em)' }}>
             {halfHour % 2 === 0 ? formatSlot(addSlots(columns.find((c) => !c.hiddenGap)?.day ?? new Date(), halfHour)) : ''}
           </div>
@@ -193,7 +193,7 @@ export default function CalendarGrid({
               </button>
             )
           })}
-        </>
+        </Fragment>
       ))}
     </div>
   )

--- a/e2e/circle-calendar.spec.ts
+++ b/e2e/circle-calendar.spec.ts
@@ -1,0 +1,118 @@
+import type { APIRequestContext, Page } from '@playwright/test'
+import { epic, feature } from 'allure-js-commons'
+import { test, expect } from './fixtures'
+
+test.describe.configure({ timeout: 120_000 })
+
+type BookModeState = {
+  session: { stateVersion: number }
+  bookMode: null | {
+    viewerAssignmentBookIds: string[]
+    books: Array<{
+      bookId: string
+      formedAt: string | null
+      circles: Array<{ position: number; memberRefs: string[] }>
+    }>
+  }
+}
+
+async function state(request: APIRequestContext, sessionId: string): Promise<BookModeState> {
+  const response = await request.get(`/api/matching/state?session=${sessionId}`)
+  expect(response.ok(), await response.text()).toBe(true)
+  return response.json() as Promise<BookModeState>
+}
+
+async function bookAction(
+  request: APIRequestContext,
+  sessionId: string,
+  action: 'setConditional' | 'setHard',
+  bookId: string,
+) {
+  const current = await state(request, sessionId)
+  const response = await request.post(`/api/matching/sessions/${sessionId}/book-actions`, {
+    data: { action, bookId, expectedStateVersion: current.session.stateVersion },
+  })
+  expect(response.ok(), await response.text()).toBe(true)
+}
+
+async function firstFutureCell(page: Page) {
+  const key = await page.getByTestId('calendar-cell').evaluateAll((cells) => {
+    const tomorrow = Date.now() + 24 * 60 * 60 * 1000
+    const match = cells
+      .map((cell) => cell.getAttribute('data-cell'))
+      .filter((value): value is string => Boolean(value))
+      .find((value) => new Date(value).getTime() > tomorrow)
+    if (!match) throw new Error('future calendar cell not found')
+    return match
+  })
+  return {
+    key,
+    locator: page.locator(`[data-testid="calendar-cell"][data-cell="${key}"]`),
+  }
+}
+
+async function markSlot(request: APIRequestContext, key: string) {
+  const startsAt = new Date(key)
+  const endsAt = new Date(startsAt.getTime() + 60 * 60 * 1000)
+  const response = await request.put('/api/calendar/availability', {
+    data: { intervals: [{ startsAt: startsAt.toISOString(), endsAt: endsAt.toISOString() }] },
+  })
+  expect(response.ok(), await response.text()).toBe(true)
+}
+
+test.beforeEach(async () => {
+  await epic('Календарь круга')
+  await feature('Согласование времени')
+})
+
+test('участники отмечают общий слот и назначают встречу после reload', { tag: '@matching-golden' }, async ({
+  matchingBooksFixture,
+  openMatchingPage,
+  dbExec,
+}) => {
+  const { session, books, participantA, getParticipantB, getParticipantC } = matchingBooksFixture
+  const [participantB, participantC] = await Promise.all([getParticipantB(), getParticipantC()])
+  const targetBook = books[0]
+
+  try {
+    await bookAction(participantA.request, session.id, 'setHard', targetBook.id)
+    await bookAction(participantB.request, session.id, 'setHard', targetBook.id)
+    await bookAction(participantC.request, session.id, 'setConditional', targetBook.id)
+
+    const formed = await state(participantA.request, session.id)
+    const formedBook = formed.bookMode?.books.find((book) => book.bookId === targetBook.id)
+    expect(formedBook?.formedAt).not.toBeNull()
+    expect(formedBook?.circles[0].position).toBe(1)
+
+    const participantAPage = await openMatchingPage(participantA)
+    await participantAPage.goto('/matching')
+    const card = participantAPage.getByTestId(`matching-book-card-${targetBook.id}`)
+    const calendarLink = card.getByRole('link', { name: 'Согласовать время' })
+    await expect(calendarLink).toBeVisible()
+    await calendarLink.click()
+    await expect(participantAPage.getByTestId('calendar-grid')).toBeVisible()
+    const calendarUrl = participantAPage.url()
+    const slug = new URL(calendarUrl).pathname.split('/').pop()
+    expect(slug).toBeTruthy()
+
+    const { key } = await firstFutureCell(participantAPage)
+    await markSlot(participantA.request, key)
+    await markSlot(participantB.request, key)
+
+    await participantAPage.reload()
+    await expect(participantAPage.locator(`[data-testid="calendar-cell"][data-cell="${key}"]`)).toBeVisible()
+
+    const scheduleResponse = await participantA.request.post(`/api/calendar/${slug}/meetings`, {
+      data: { startsAt: key },
+    })
+    expect(scheduleResponse.ok(), await scheduleResponse.text()).toBe(true)
+
+    await participantAPage.reload()
+    await expect(participantAPage.getByRole('heading', { name: targetBook.title })).toBeVisible()
+    await expect(participantAPage.getByText(`60 минут · ${targetBook.title}`)).toBeVisible()
+  } finally {
+    await dbExec('delete from circle_meetings where schedule_id in (select id from circle_schedules where book_id = $1)', [targetBook.id])
+    await dbExec('delete from user_availability where user_id = any($1::text[])', [[participantA.userId, participantB.userId]])
+    await dbExec('delete from circle_schedules where book_id = $1', [targetBook.id])
+  }
+})


### PR DESCRIPTION
## Что сделано
- Добавлен focused E2E для календаря круга: формирование круга, открытие календаря из matching, сохранение общего слота двумя участниками через серверные API, назначение встречи и проверка после reload.
- Исправлен React warning в CalendarGrid: список слотов теперь рендерится через Fragment с key.

## Проверки
- npm run lint
- npm run typecheck
- CI=true npm test -- --runInBand
- npm run build
- PLAYWRIGHT_PORT=3100 npm run test:e2e:focused -- e2e/circle-calendar.spec.ts --grep "участники отмечают общий слот"

## Примечания
- Перед focused E2E локально пришлось синхронизировать e2e-БД с новой схемой; первая попытка упала на DNS, повторная дошла до известного drift по matching index, но нужные calendar/user поля применились и focused E2E прошёл.