### PR TITLE
fix: stop calendar autosave loop

### DIFF
--- a/components/nd/CalendarClient.test.tsx
+++ b/components/nd/CalendarClient.test.tsx
@@ -1,0 +1,76 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import CalendarClient from './CalendarClient'
+import type { CalendarPublicState } from '@/lib/calendar/public-state'
+
+function response(body: unknown, ok = true): Response {
+  return { ok, json: () => Promise.resolve(body) } as Response
+}
+
+function makeState(intervals: CalendarPublicState['participants'][number]['intervals'] = []): CalendarPublicState {
+  return {
+    slug: 'dolg-pervye-5000-let-istorii',
+    book: { title: 'Долг: первые 5000 лет истории', author: 'Дэвид Гребер' },
+    position: 1,
+    circleExists: true,
+    durationMinutes: 90,
+    window: { start: '2026-08-09T00:00:00.000Z', end: '2026-09-06T00:00:00.000Z' },
+    now: '2026-08-09T09:00:00.000Z',
+    participants: [{
+      ref: 'viewer',
+      displayName: 'Евгений Кошкин',
+      timezone: 'Europe/Belgrade',
+      timezoneConfirmed: true,
+      marked: intervals.length > 0,
+      intervals,
+      busy: [],
+    }],
+    meetings: [],
+    viewer: {
+      ref: 'viewer',
+      canEdit: true,
+      isAdmin: false,
+      actingAsRef: 'viewer',
+      timezone: 'Europe/Belgrade',
+      timezoneConfirmed: true,
+    },
+    migrationRequired: false,
+  }
+}
+
+describe('CalendarClient', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('does not autosave again after applying the server state returned by reload', async () => {
+    const slot = '2026-08-11T11:00:00.000Z'
+    const savedIntervals = [{ startsAt: slot, endsAt: '2026-08-11T11:30:00.000Z' }]
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/calendar/availability')) return Promise.resolve(response({ ok: true, intervals: savedIntervals }))
+      return Promise.resolve(response(makeState(savedIntervals)))
+    })
+
+    render(<CalendarClient initialState={makeState()} />)
+
+    const cell = screen.getByRole('button', { name: '11 авг. 11:00' })
+    fireEvent.pointerDown(cell, { pointerType: 'mouse' })
+    fireEvent.pointerUp(cell)
+    fireEvent.click(screen.getByRole('button', { name: 'Отметить: я свободен' }))
+
+    await act(async () => { await jest.advanceTimersByTimeAsync(400) })
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2))
+
+    await act(async () => { await jest.advanceTimersByTimeAsync(400) })
+
+    const availabilitySaves = (global.fetch as jest.Mock).mock.calls.filter(([url, init]) => (
+      String(url).includes('/api/calendar/availability') && init?.method === 'PUT'
+    ))
+    expect(availabilitySaves).toHaveLength(1)
+  })
+})

--- a/components/nd/CalendarClient.tsx
+++ b/components/nd/CalendarClient.tsx
@@ -36,7 +36,12 @@ export default function CalendarClient({
   }, [asQuery, state.slug])
 
   useEffect(() => {
-    setViewerIntervals(actingParticipant(state)?.intervals.map(parseInterval) ?? [])
+    const next = actingParticipant(state)?.intervals.map(parseInterval) ?? []
+    setViewerIntervals((current) => {
+      if (intervalsEqual(current, next)) return current
+      skipSave.current = true
+      return next
+    })
   }, [state])
 
   useEffect(() => {
@@ -254,6 +259,14 @@ function actingParticipant(state: CalendarPublicState) {
 
 function parseInterval(interval: { startsAt: string; endsAt: string }): Interval {
   return { startsAt: new Date(interval.startsAt), endsAt: new Date(interval.endsAt) }
+}
+
+function intervalsEqual(left: Interval[], right: Interval[]) {
+  if (left.length !== right.length) return false
+  return left.every((interval, index) => (
+    interval.startsAt.getTime() === right[index].startsAt.getTime()
+    && interval.endsAt.getTime() === right[index].endsAt.getTime()
+  ))
 }
 
 function buildDayStarts(windowStart: Date) {


### PR DESCRIPTION
## Что исправлено
- Остановлен цикл autosave календаря: серверная синхронизация интервалов больше не воспринимается как новая пользовательская правка.
- Добавлен компонентный regression-тест: после reload состояния должен быть только один PUT /api/calendar/availability.

## Проверки
- npm test -- components/nd/CalendarClient.test.tsx --runInBand
- npm test -- --runTestsByPath components/nd/CalendarClient.test.tsx app/api/calendar/availability/route.test.ts 'app/api/calendar/[slug]/route.test.ts' lib/calendar/__tests__/availability-intervals.test.ts --runInBand
- npm run lint
- npm run typecheck
- PLAYWRIGHT_PORT=3100 npm run test:e2e:focused -- e2e/circle-calendar.spec.ts --grep "участники отмечают общий слот"
- CI=true npm test -- --runInBand
- npm run build