### PR TITLE
fix: show one calendar block marker

### DIFF
--- a/components/nd/CalendarClient.test.tsx
+++ b/components/nd/CalendarClient.test.tsx
@@ -125,4 +125,10 @@ describe('CalendarClient', () => {
     expect(screen.getByText('Чем больше участников свободны, тем темнее клетка')).toBeInTheDocument()
     expect(screen.queryByText(/1 →/)).not.toBeInTheDocument()
   })
+
+  it('shows one personal marker for a continuous availability block', () => {
+    const { container } = render(<CalendarClient initialState={makeState([{ startsAt: '2026-08-11T11:00:00.000Z', endsAt: '2026-08-11T12:30:00.000Z' }])} />)
+
+    expect(container.querySelectorAll('[data-mine-marker="true"]')).toHaveLength(1)
+  })
 })

--- a/components/nd/CalendarGrid.tsx
+++ b/components/nd/CalendarGrid.tsx
@@ -111,6 +111,9 @@ export default function CalendarGrid({
             const candidate = overlap.candidateStarts.has(key)
             const covered = overlap.candidateCovered.has(key)
             const mine = viewerFreeKeys.has(key)
+            const previousKey = slotKey(addSlots(new Date(key), -1))
+            const previousVisible = halfHour > slotRange[0]
+            const mineStart = mine && (!previousVisible || !viewerFreeKeys.has(previousKey))
             const freeCount = focusRef
               ? cell?.freeRefs.includes(focusRef) ? 1 : 0
               : cell?.freeRefs.length ?? 0
@@ -147,9 +150,10 @@ export default function CalendarGrid({
                   padding: 0,
                 }}
               >
-                {mine && (
+                {mineStart && (
                   <span
                     aria-hidden="true"
+                    data-mine-marker="true"
                     style={{
                       position: 'absolute',
                       left: 0,


### PR DESCRIPTION
## Summary
- render the personal corner marker only on the first visible cell of a continuous availability block
- keep the full block filled while avoiding repeated half-hour markers
- add a CalendarClient regression test for a 90-minute block

## Tests
- npm run lint
- npm run typecheck
- npm test -- components/nd/CalendarClient.test.tsx --runInBand
- npm run build
- npm test -- --runInBand