### PR TITLE
Add coverage for calendar admin preview

### DIFF
--- a/components/nd/CalendarClient.test.tsx
+++ b/components/nd/CalendarClient.test.tsx
@@ -222,4 +222,27 @@ describe('CalendarClient', () => {
     expect(assign).toHaveBeenCalledWith('/calendar/dolg-pervye-5000-let-istorii?as=user-vova')
     Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
   })
+
+  it('uses participant clicks for preview on touch devices', () => {
+    ;(window.matchMedia as jest.Mock).mockImplementation((query: string) => ({
+      matches: !query.includes('hover: hover'),
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }))
+    const originalLocation = window.location
+    const assign = jest.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, assign },
+    })
+    const { container } = render(<CalendarClient initialState={makeAdminState()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Vova/i }))
+
+    expect(screen.getByText('Нажмите на имя, чтобы увидеть только его время')).toBeInTheDocument()
+    expect(container.querySelectorAll('[data-mine-marker="true"]')).toHaveLength(0)
+    expect(assign).not.toHaveBeenCalled()
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+  })
 })

--- a/lib/calendar/public-state.test.ts
+++ b/lib/calendar/public-state.test.ts
@@ -1,0 +1,89 @@
+import { fetchCalendarPublicState } from './public-state'
+import { resolveScheduleBySlug } from './schedule-db'
+
+jest.mock('./schedule-db', () => ({
+  resolveScheduleBySlug: jest.fn(),
+}))
+
+jest.mock('@/lib/audit/with-audit-context', () => ({
+  withAuditContext: jest.fn(),
+}))
+
+jest.mock('@/lib/db', () => ({ db: {} }))
+
+const mockResolveScheduleBySlug = resolveScheduleBySlug as jest.MockedFunction<typeof resolveScheduleBySlug>
+
+type QueryChain = {
+  from: jest.Mock<QueryChain>
+  where: jest.Mock<QueryChain>
+  leftJoin: jest.Mock<QueryChain>
+  innerJoin: jest.Mock<QueryChain>
+  then: (resolve: (rows: unknown[]) => unknown) => Promise<unknown>
+}
+
+function emptyQuery(): QueryChain {
+  const chain: QueryChain = {
+    from: jest.fn(() => chain),
+    where: jest.fn(() => chain),
+    leftJoin: jest.fn(() => chain),
+    innerJoin: jest.fn(() => chain),
+    then: (resolve: (rows: unknown[]) => unknown) => Promise.resolve([]).then(resolve),
+  }
+  return chain
+}
+
+const fakeDb = {
+  select: jest.fn(() => emptyQuery()),
+} as never
+
+function mockSchedule() {
+  mockResolveScheduleBySlug.mockResolvedValue({
+    id: 'schedule-1',
+    sessionId: 'session-1',
+    bookId: 'book-1',
+    position: 1,
+    slug: 'book-circle-1',
+    durationMinutes: 60,
+    bookTitle: 'Книга',
+    bookAuthor: 'Автор',
+    circleId: 'circle-1',
+    members: [
+      {
+        userId: 'user-1',
+        ref: 'ref-1',
+        displayName: 'Анна',
+        timezone: 'Europe/Belgrade',
+        timezoneConfirmed: true,
+      },
+    ],
+  })
+}
+
+describe('fetchCalendarPublicState participant admin ids', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSchedule()
+  })
+
+  it('includes participant user ids for admins', async () => {
+    const state = await fetchCalendarPublicState({
+      slug: 'book-circle-1',
+      viewerUserId: 'admin-1',
+      isAdmin: true,
+      now: new Date('2026-08-09T10:00:00.000Z'),
+    }, fakeDb)
+
+    expect(state.participants[0].adminUserId).toBe('user-1')
+  })
+
+  it('does not expose participant user ids to non-admin viewers', async () => {
+    const state = await fetchCalendarPublicState({
+      slug: 'book-circle-1',
+      viewerUserId: 'user-1',
+      isAdmin: false,
+      now: new Date('2026-08-09T10:00:00.000Z'),
+    }, fakeDb)
+
+    expect(state.participants[0]).not.toHaveProperty('adminUserId')
+  })
+})


### PR DESCRIPTION
## Summary
- add unit coverage for touch-device participant preview behavior
- add unit coverage that calendar participant user ids are exposed only in admin state

## Verification
- npm run lint
- npm run typecheck
- npm test -- components/nd/CalendarClient.test.tsx lib/calendar/public-state.test.ts --runInBand
- npm test -- --runInBand

E2E: не нужен — follow-up добавляет только unit-тесты, продуктовый E2E уже прошёл в PR #545.
Wiki: не нужна — документация обновлена в PR #545, здесь только тесты.