### PR TITLE
test: участник видит удаление круга по исчезновению блока

### DIFF
--- a/e2e/matching-admin.spec.ts
+++ b/e2e/matching-admin.spec.ts
@@ -74,7 +74,10 @@ test('администратор меняет круги, назначения �
   })
   await participantAPage.goto('/matching')
   await participantAPage.reload()
-  await expect(participantAPage.getByTestId(`matching-book-card-${books[0].id}`)).toContainText('Без круга')
+  // Участнику список «Без круга: …» не показывают — это админская диагностика; у него исчезает
+  // сам блок круга. Ниже, после пересоздания и размещения, тот же регион проверяется на возврат.
+  await expect(participantAPage.getByTestId(`matching-book-card-${books[0].id}`)
+    .getByRole('region', { name: 'Круг 1' })).toHaveCount(0)
 
   await adminAction(admin.request, session.id, participantA.userId, {
     action: 'createCircle', bookId: books[0].id,


### PR DESCRIPTION
Шаг «админ удалил круг → участник перезагружает страницу» ждал подпись
«Без круга», но PR #534 намеренно спрятал диагностику состава от участников:
рассадить людей по кругам он всё равно не может, для него это тревога без
средства исправления. Компонент и его unit-тест тогда поправили, а эту
проверку в matching-admin.spec.ts пропустили — E2E не входят в merge-gate,
и поломка доехала до ночного прогона.

Участнику после удаления круга исчезает сам блок круга — проверяем это.
Ниже по тесту тот же регион уже проверяется на возврат после пересоздания
и размещения, получается честная пара «пропало → вернулось».

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
